### PR TITLE
Add MaskType.Star.

### DIFF
--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -36,6 +36,7 @@ public extension BorderDesignable where Self: UIView {
     // if borderSide has been specified, only display one side
     if let unwrappedBorderSide = borderSide , side = BorderSide(rawValue: unwrappedBorderSide) {
       let border = CALayer()
+      border.name = "borderSideLayer"
       
       border.backgroundColor = unwrappedBorderColor.CGColor
       

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -18,6 +18,16 @@ public extension MaskDesignable where Self: UIView {
     switch(rawMaskType) {
     case .Circle:
       maskCircle()
+    case .Star:
+      maskStar()
+    case .Star4:
+      maskStar(4)
+    case .Star6:
+      maskStar(6)
+    case .Star8:
+      maskStar(8)
+    case .Star10:
+      maskStar(10)
     }
   }
   
@@ -25,4 +35,90 @@ public extension MaskDesignable where Self: UIView {
   private func maskCircle() {
     layer.cornerRadius = ceil(min(bounds.width, bounds.height))/2
   }
+  
+  // See https://www.weheartswift.com/bezier-paths-gesture-recognizers/
+  
+  func maskStar(sides: Int = 5) {
+    // FIXME: Do not mask the shadow.
+    
+    assert(sides >= 2, "Stars must has at least 2 sides.")
+    layer.mask?.removeFromSuperlayer()
+    layer.sublayers?
+      .filter  { $0.name == "borderSideLayer" || $0.name == "borderLayer" }
+      .forEach { $0.removeFromSuperlayer() }
+    
+    let path = starPath(sides)
+    
+    let maskLayer = CAShapeLayer()
+    maskLayer.frame = CGRect(origin: CGPointZero, size: bounds.size)
+    maskLayer.path = path.CGPath
+    layer.mask = maskLayer
+    
+    // FIXME: borderWidth is always set after mask, so the following code will never be excuted.
+    
+    if layer.borderWidth == 0 {
+      return
+    }
+    
+    // NOTE: Lex: In order to draw the original border, we need to add a new sublayer.
+    
+    let borderPath = starPath(sides, borderWidth: layer.borderWidth).bezierPathByReversingPath()
+    borderPath.appendPath(path)
+    
+    let borderMaskLayer = CAShapeLayer()
+    borderMaskLayer.path = borderPath.CGPath
+    
+    let borderLayer = CALayer()
+    borderLayer.name = "borderLayer"
+    borderLayer.bounds = layer.bounds
+    borderLayer.mask = borderMaskLayer
+    layer.addSublayer(borderLayer)
+    borderLayer.backgroundColor = layer.borderColor
+    
+    // NOTE: Lex: Dismiss the original border of layer.
+    layer.borderWidth = 0
+  }
+  
+  private func degree2radian(degree: CGFloat) -> CGFloat {
+    let radian = CGFloat(M_PI) * degree / 180
+    return radian
+  }
+  
+  private func pointFrom(angle: CGFloat, radius: CGFloat, offset: CGPoint) -> CGPoint {
+    return CGPointMake(radius * cos(angle) + offset.x, radius * sin(angle) + offset.y)
+  }
+  
+  private func starPath(points: Int, borderWidth: CGFloat = 0) -> UIBezierPath {
+    let path = UIBezierPath()
+    let radius = min(layer.bounds.size.width, layer.bounds.size.height) / 2 - borderWidth
+    let starCenter = CGPointMake(radius, radius)
+    let starExtrusion = radius / 2
+    
+    let angleIncrement = CGFloat(M_PI * 2.0 / Double(points))
+    var angle:CGFloat = -CGFloat(M_PI / 2.0)
+    
+    var firstPoint = true
+    
+    for _ in 1...points {
+      let point = pointFrom(angle, radius: radius, offset: center)
+      let nextPoint = pointFrom(angle + angleIncrement, radius: radius, offset: starCenter)
+      let midPoint = pointFrom(angle + angleIncrement / 2.0, radius: starExtrusion, offset: starCenter)
+      
+      if firstPoint {
+        firstPoint = false
+        path.moveToPoint(point)
+      }
+      
+      path.addLineToPoint(midPoint)
+      path.addLineToPoint(nextPoint)
+      
+      angle += angleIncrement
+    }
+    
+    path.closePath()
+    
+    
+    return path
+  }
+  
 }

--- a/IBAnimatable/MaskType.swift
+++ b/IBAnimatable/MaskType.swift
@@ -7,4 +7,9 @@ import Foundation
 
 public enum MaskType: String {
   case Circle
+  case Star
+  case Star4
+  case Star6
+  case Star8
+  case Star10
 }

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The easiest way to use `IBAnimatable` is to drag and drop UIKit elements and con
 #### `MaskDesignable`
 | Property name | Data type | Remark |
 | ------------- |:-------------:| ----- |
-| maskType | Optional&lt;String> | maks type, eg. `Circle`. |
+| maskType | Optional&lt;String> | maks type, eg. `Circle`, `Star`, `Star10`. |
 
 #### `PaddingDesignable`
 It is used in `AnimatableTextField` to add padding on either or both sides.


### PR DESCRIPTION
Add `.Star`, `.Star4`, `.Star6`, `.Star8`, `.Star10` to MaskType. We can mask views like this:
<img width="557" alt="screen shot 2016-01-17 at 11 51 31 pm" src="https://cloud.githubusercontent.com/assets/219689/12378354/be6c4b56-bd75-11e5-897b-688259dc8ed7.png">

Conclusion:
1. These stars are masked with CAShapeLayer which mask shadows as well. Thus we can't have shadows under star views. (Stars have no shadow in the real world neither. 🤓)
2. Border of star is not rendered properly. I already have a workaround in my Playground which is not suitable(maybe next PR) for IBAnimatable:
<img width="284" alt="screen shot 2016-01-18 at 12 03 04 am" src="https://cloud.githubusercontent.com/assets/219689/12378391/e0822854-bd76-11e5-8d87-4bf334b99dc2.png">
