### PR TITLE
Make Framework iOS 8.x compatible

### DIFF
--- a/IBAnimatable.podspec
+++ b/IBAnimatable.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/JakeLin/IBAnimatable"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Jake Lin" => "JakeLinAu@gmail.com" }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '8.0'
   s.source       = { :git => "https://github.com/JakeLin/IBAnimatable.git", tag: "V#{s.version}" }
   s.source_files  = "IBAnimatable/*.swift"
 end

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -6,6 +6,7 @@
 import UIKit
 
 // FIXME: almost same as `AnimatableView`, Need to refactor to encasuplate.
+@available(iOS 9, *)
 @IBDesignable public class AnimatableStackView: UIStackView, CornerDesignable, FillDesignable, BorderDesignable, RotationDesignable, ShadowDesignable, BlurDesignable, TintDesignable, GradientDesignable, MaskDesignable, Animatable {
   
   // MARK: - CornerDesignable

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/IBAnimatableApp/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = JakeLin.IBAnimatable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -606,7 +606,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/IBAnimatableApp/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = JakeLin.IBAnimatable;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/IBAnimatableApp/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = JakeLin.IBAnimatable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -606,7 +606,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/IBAnimatableApp/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = JakeLin.IBAnimatable;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
iOS 8.x is still 15-20% of the users as of writing this.
Not every app developer can afford losing all this traffic.

The only thing that currently breaking compatibility is the use of UIStackView, then by marking AnimatableStackView `@available(iOS 9, *)` I was able to make the entire framework iOS 8.x compatible.
