### PR TITLE
Wave shape

### DIFF
--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@IBDesignable public class AnimatableLabel: UILabel, Animatable {
+@IBDesignable public class AnimatableLabel: UILabel, Animatable, RotationDesignable {
   
   // MARK: - Animatable
   @IBInspectable public var animationType: String?
@@ -16,6 +16,13 @@ import UIKit
   @IBInspectable public var velocity: CGFloat = CGFloat.NaN
   @IBInspectable public var force: CGFloat = CGFloat.NaN
   @IBInspectable public var repeatCount: Float = Float.NaN
+  
+  // MARK: - RotationDesignable
+  @IBInspectable public var rotate: CGFloat = CGFloat.NaN {
+    didSet {
+      configRotate()
+    }
+  }
   
   // MARK: - Lifecycle
   public override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -48,9 +48,7 @@ public extension MaskDesignable where Self: UIView {
       .forEach { $0.removeFromSuperlayer() }
     
     let path = starPath(sides)
-    let borderPath = starPath(sides, borderWidth: layer.borderWidth).bezierPathByReversingPath()
     drawPath(path)
-    drawBorderPath(borderPath, path: path)
   }
   
   public func maskWave(waveUp: Bool = true, waveWidth: CGFloat = 40.0, waveOffset: CGFloat = 0.0) {

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -21,21 +21,24 @@ public extension MaskDesignable where Self: UIView {
         maskCircle()
       case .Star:
         maskStar()
+      case .Wave:
+        maskWave()
       }
       return
     }
     
     // Mask Star with parameter
+    // Mask Wave with parameter
   }
-    
-  // MARK: - Private
-  private func maskCircle() {
+  
+  // MARK: - Mask
+  
+  public func maskCircle() {
     layer.cornerRadius = ceil(min(bounds.width, bounds.height))/2
   }
   
   // See https://www.weheartswift.com/bezier-paths-gesture-recognizers/
-  
-  func maskStar(sides: Int = 5) {
+  public func maskStar(sides: Int = 5) {
     // FIXME: Do not mask the shadow.
     
     assert(sides >= 2, "Stars must has at least 2 sides.")
@@ -45,21 +48,32 @@ public extension MaskDesignable where Self: UIView {
       .forEach { $0.removeFromSuperlayer() }
     
     let path = starPath(sides)
-    
+    let borderPath = starPath(sides, borderWidth: layer.borderWidth).bezierPathByReversingPath()
+    drawPath(path)
+    drawBorderPath(borderPath, path: path)
+  }
+  
+  public func maskWave(waveUp: Bool = true, waveWidth: CGFloat = 40.0, waveOffset: CGFloat = 0.0) {
+    let wavePath = maskWaveBezierPath(waveUp, waveWidth: waveWidth, waveOffset: waveOffset)
+    drawPath(wavePath)
+  }
+  
+  // MARK: Private
+  
+  func drawPath(path: UIBezierPath) {
     let maskLayer = CAShapeLayer()
     maskLayer.frame = CGRect(origin: CGPoint.zero, size: bounds.size)
     maskLayer.path = path.CGPath
     layer.mask = maskLayer
-    
+  }
+  
+  func drawBorderPath(borderPath: UIBezierPath, path: UIBezierPath) {
     // FIXME: borderWidth is always set after mask, so the following code will never be excuted.
-    
     if layer.borderWidth == 0 {
       return
     }
     
     // NOTE: Lex: In order to draw the original border, we need to add a new sublayer.
-    
-    let borderPath = starPath(sides, borderWidth: layer.borderWidth).bezierPathByReversingPath()
     borderPath.appendPath(path)
     
     let borderMaskLayer = CAShapeLayer()
@@ -84,6 +98,8 @@ public extension MaskDesignable where Self: UIView {
   private func pointFrom(angle: CGFloat, radius: CGFloat, offset: CGPoint) -> CGPoint {
     return CGPoint(x: radius * cos(angle) + offset.x, y: radius * sin(angle) + offset.y)
   }
+  
+  // MARK: Star
   
   private func starPath(points: Int, borderWidth: CGFloat = 0) -> UIBezierPath {
     let path = UIBezierPath()
@@ -115,6 +131,38 @@ public extension MaskDesignable where Self: UIView {
     path.closePath()
     
     
+    return path
+  }
+  
+  // MARK: MaskWave
+  
+  private func maskWaveBezierPath(waveUp: Bool, waveWidth: CGFloat, waveOffset: CGFloat) -> UIBezierPath {
+    let originY = waveUp ? bounds.maxY : bounds.minY
+    let halfWidth = waveWidth / 2.0
+    let halfHeight = bounds.height / 2.0
+    let quarterWidth = waveWidth / 4.0
+    
+    var up = waveUp
+    var startX = bounds.minX - quarterWidth - (waveOffset % waveWidth)
+    var endX = startX + halfWidth
+    
+    let path = UIBezierPath()
+    path.moveToPoint(CGPoint(x: startX, y: originY))
+    path.addLineToPoint(CGPoint(x: startX, y: bounds.midY))
+    
+    repeat {
+      path.addQuadCurveToPoint(
+        CGPoint(x: endX, y: bounds.midY),
+        controlPoint: CGPoint(
+          x: startX + quarterWidth,
+          y: up ? bounds.maxY + halfHeight : bounds.minY - halfHeight)
+      )
+      startX = endX
+      endX += halfWidth
+      up = !up
+    } while startX < bounds.maxX
+    
+    path.addLineToPoint(CGPoint(x: path.currentPoint.x, y: originY))    
     return path
   }
   

--- a/IBAnimatable/MaskType.swift
+++ b/IBAnimatable/MaskType.swift
@@ -8,4 +8,5 @@ import Foundation
 public enum MaskType: String {
   case Circle
   case Star
+  case Wave
 }

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The easiest way to use `IBAnimatable` is to drag and drop UIKit elements and con
 #### `MaskDesignable`
 | Property name | Data type | Remark |
 | ------------- |:-------------:| ----- |
-| maskType | Optional&lt;String> | maks type, eg. `Circle`, `Star`, `Star10`. |
+| maskType | Optional&lt;String> | maks type, eg. `Circle`, `Star`, `Star10`, `Wave`. |
 
 #### `PaddingDesignable`
 It is used in `AnimatableTextField` to add padding on either or both sides.


### PR DESCRIPTION
Not sure if you are interested in this kind of mask, but here it is: MaskWave
Examples of output: two waves (one up / one down) with different width / offset

<img width="337" alt="screen shot 2016-02-05 at 20 40 09" src="https://cloud.githubusercontent.com/assets/1402212/12857140/d34b6f34-cc48-11e5-98e9-77f677b0fdcd.png">
<img width="336" alt="screen shot 2016-02-05 at 20 41 06" src="https://cloud.githubusercontent.com/assets/1402212/12857141/d379546c-cc48-11e5-8801-ef06d0ec2078.png">

In order to add this mask, I did some refactor in the `MaskDesignable`
- Put public all the maskStuff -> until we can pass parameters from the xib, we can at least make the mask more configurable in code
- Divide some codes in order to reuse it for the different shape (drawPath() / drawBorderPath())

Missing:
- Designable properties to manage the direction (up / down), width, and the offset of the wave. I didn't know if you have any thought how to handle this? If so, I will be happy to update the PR.
- Update README? Roadmap? Not sure I updated everything necessary
