### PR TITLE
Fixed gradient designable rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ TBD
 
 #### Bugfixes
 
-- Fixed `GradientDesignable` rotation. #86
+- Fixed `GradientDesignable` rotation. [#86](https://github.com/JakeLin/IBAnimatable/issues/86)
 
 ### [1.1](https://github.com/JakeLin/IBAnimatable/releases/tag/V1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ TBD
 TBD
 
 #### Bugfixes
-TBD
+
+- Fixed `GradientDesignable` rotation. #86
 
 ### [1.1](https://github.com/JakeLin/IBAnimatable/releases/tag/V1.1)
 

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -112,7 +112,7 @@ import UIKit
     super.layoutSubviews()
     autoRunAnimation()
   }
-
+  
   // MARK: - Private
   private func configInspectableProperties() {
     configAnimatableProperties()

--- a/IBAnimatable/GradientDesignable.swift
+++ b/IBAnimatable/GradientDesignable.swift
@@ -58,12 +58,14 @@ public extension GradientDesignable where Self: UIView {
       gradientLayer.startPoint = CGPoint(x: 0, y: 0)
       gradientLayer.endPoint = CGPoint(x: 1, y: 1)
     }
+    
+    let gradientView = GradientView(frame: self.bounds, layer: gradientLayer)
+    self.insertSubview(gradientView, atIndex: 0)
   }
   
   private func createGradientLayer() -> CAGradientLayer {
     let gradientLayer: CAGradientLayer = CAGradientLayer()
     gradientLayer.frame = self.bounds
-    self.layer.insertSublayer(gradientLayer, atIndex: 0)
     return gradientLayer
   }
   
@@ -353,4 +355,24 @@ public extension GradientDesignable where Self: UIView {
       return (UIColor(hexString: "#4B79A1"), UIColor(hexString: "#283E51"))
     }
   }
+}
+
+private class GradientView: UIView {
+
+  // MARK: - Life cycle
+  
+  init(frame: CGRect, layer: CAGradientLayer) {
+    super.init(frame: frame)
+    self.layer.insertSublayer(layer, atIndex: 0)
+    self.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override class func layerClass() -> AnyClass {
+    return CAGradientLayer.self
+  }
+  
 }


### PR DESCRIPTION
Should closed #86 

Here an implementation which seems a good compromise. I didn't find any way to handle this issue without a custom subview. So in order to keep everything easy to use, I ended up by created a private custom view only used in `GradientDesignable`.

This way, the layer handles well the rotation.. didn't find any bugs related to this implementation.
