### PR TITLE
Fix potential crash while using DesignableGradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ TBD
 TBD
 
 #### Bugfixes
-TBD
+
+- Fix potential crash when using `GradientDesignable`
 
 ### [1.2](https://github.com/JakeLin/IBAnimatable/releases/tag/1.2)
 

--- a/IBAnimatable/GradientDesignable.swift
+++ b/IBAnimatable/GradientDesignable.swift
@@ -368,7 +368,7 @@ private class GradientView: UIView {
   init(frame: CGRect, layer: CAGradientLayer) {
     super.init(frame: frame)
     tag = viewTag
-    layer.insertSublayer(layer, atIndex: 0)
+    self.layer.insertSublayer(layer, atIndex: 0)
     autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
   }
   


### PR DESCRIPTION
I got a crash in my project just after updated the pod. When I read the code, it makes sense that there an error. The weird part is that I retest the gradient on IBAnimatable's simulator, and it's working perfectly.

So I don't really know why is it working in the sample project (simulator cache? Xcode derived data? ...), but here a fix to be sure that won't happen to anyone else.
