### PR TITLE
AnimatableNavigationController supports custom transition animations

### DIFF
--- a/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ view.configAnimatableProperties()
 iPhoneView.addSubview(view)
 
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = "Circle"
+view.maskType = MaskType.Circle.rawValue
 
 //: animationType: all supported predefined animations can be found in `enum AnimationType`
 view.animationType = "SqueezeInLeft"

--- a/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
@@ -24,10 +24,10 @@ view.configAnimatableProperties()
 iPhoneView.addSubview(view)
 
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = MaskType.Circle.rawValue
+view.maskType = String(MaskType.Circle)
 
 //: animationType: all supported predefined animations can be found in `enum AnimationType`
-view.animationType = "SqueezeInLeft"
+view.animationType = String(AnimationType.SqueezeInLeft)
 
 //: duration: used to specify the duration of animation. Default value is 0.7
 view.duration = 0.8

--- a/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ view.configAnimatableProperties()
 iPhoneView.addSubview(view)
 
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = "Circle"
+view.maskType = MaskType.Circle.rawValue
 
 //: Start another animation in completion closure
 view.squeezeInDown{ view.pop { view.shake{ view.squeeze{ view.wobble{ view.flipX { view.flash{ view.flipY { view.fadeOutDown() } } } } } } } }

--- a/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
@@ -24,16 +24,16 @@ view.configAnimatableProperties()
 iPhoneView.addSubview(view)
 
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = MaskType.Circle.rawValue
+view.maskType = String(MaskType.Circle)
 
 //: Start another animation in completion closure
 view.squeezeInDown{ view.pop { view.shake{ view.squeeze{ view.wobble{ view.flipX { view.flash{ view.flipY { view.fadeOutDown() } } } } } } } }
 
 //: To apply delay, we can specify the animationType and delay
-//view.animationType = "Pop"
+//view.animationType = String(AnimationType.Pop)
 //view.animate{
 //  view.delay = 0.3
-//  view.animationType = "Shake"
+//  view.animationType = String(AnimationType.Shake)
 //  view.animate()
 //}
 

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ iPhoneView.addSubview(view)
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
 view.borderWidth = 2
 view.borderColor = UIColor.purpleColor()
-view.maskType = MaskType.Circle.rawValue
+view.maskType = String(MaskType.Circle)
 
 // For moveTo or moveBy animation
 view.x = -100

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ iPhoneView.addSubview(view)
 view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
 view.borderWidth = 2
 view.borderColor = UIColor.purpleColor()
-view.maskType = "Circle"
+view.maskType = MaskType.Circle.rawValue
 
 // For moveTo or moveBy animation
 view.x = -100

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -5,9 +5,6 @@
 
 import UIKit
 
-public typealias AnimatableCompletion = () -> Void
-public typealias AnimatableExecution = () -> Void
-
 public protocol Animatable: class {
   
   /**
@@ -390,7 +387,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func fadeOutIn(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 1
       animation.toValue = 0
@@ -403,7 +400,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func fadeInOut(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 0
       animation.toValue = 1
@@ -436,7 +433,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func shake(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "position.x")
       animation.values = [0, 30 * self.force, -30 * self.force, 30 * self.force, 0]
       animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -450,7 +447,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func pop(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "transform.scale")
       animation.values = [0, 0.2 * self.force, -0.2 * self.force, 0.2 * self.force, 0]
       animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -464,7 +461,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func morph(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let morphX = CAKeyframeAnimation(keyPath: "transform.scale.x")
       morphX.values = [1, 1.3 * self.force, 0.7, 1.3 * self.force, 1]
       morphX.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -485,7 +482,7 @@ public extension Animatable where Self: UIView {
   }
 
   public func squeeze(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let squeezeX = CAKeyframeAnimation(keyPath: "transform.scale.x")
       squeezeX.values = [1, 1.5 * self.force, 0.5, 1.5 * self.force, 1]
       squeezeX.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -518,7 +515,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func flash(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 1
       animation.toValue = 0
@@ -531,7 +528,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func wobble(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let rotation = CAKeyframeAnimation(keyPath: "transform.rotation")
       rotation.values = [0, 0.3 * self.force, -0.3 * self.force, 0.3 * self.force, 0]
       rotation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -553,7 +550,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func swing(completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "transform.rotation")
       animation.values = [0, 0.3 * self.force, -0.3 * self.force, 0.3 * self.force, 0]
       animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
@@ -566,7 +563,7 @@ public extension Animatable where Self: UIView {
   }
 
   public func rotate(clockwise clockwise: Bool = true, completion: AnimatableCompletion? = nil) {
-    animateLayer({
+    CALayer.animate({
       let animation = CABasicAnimation(keyPath: "transform.rotation")
       animation.fromValue = clockwise ? 0 : ((360 * M_PI) / 180)
       animation.toValue = clockwise ? ((360 * M_PI) / 180) : 0
@@ -613,15 +610,6 @@ public extension Animatable where Self: UIView {
   }
   
   // MARK: - Private
-  private func animateLayer(animation: AnimatableExecution, completion: AnimatableCompletion? = nil) {
-    CATransaction.begin()
-    if let completion = completion {
-      CATransaction.setCompletionBlock { completion() }
-    }
-    animation()
-    CATransaction.commit()
-  }
-  
   private func animateInWithX(x: CGFloat, completion: AnimatableCompletion? = nil) {
     animateIn(x, 0, 1, 1, 1, completion)
   }

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -1,0 +1,10 @@
+//
+//  Created by Jake Lin on 2/20/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+class AnimatableNavigationController: UINavigationController {
+  
+}

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -5,6 +5,20 @@
 
 import UIKit
 
-class AnimatableNavigationController: UINavigationController {
+public class AnimatableNavigationController: UINavigationController {
+  class Navigator: NSObject, UINavigationControllerDelegate {
+    func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+      if operation == .Pop {
+        return FadeInAnimator()
+      }
+      return nil
+    }
+  }
   
+  let navigator = Navigator()
+  
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    delegate = navigator
+  }
 }

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -9,7 +9,9 @@ public class AnimatableNavigationController: UINavigationController {
   class Navigator: NSObject, UINavigationControllerDelegate {
     func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
       if operation == .Push {
-        return FadeInAnimator()
+        return CubeFromLeftAnimator()
+      } else if operation == .Pop {
+        return CubeFromRightAnimator()
       }
       return nil
     }

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -5,22 +5,30 @@
 
 import UIKit
 
-public class AnimatableNavigationController: UINavigationController {
-  class Navigator: NSObject, UINavigationControllerDelegate {
-    func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-      if operation == .Push {
-        return CubeFromLeftAnimator()
-      } else if operation == .Pop {
-        return CubeFromRightAnimator()
-      }
-      return nil
-    }
-  }
+public class AnimatableNavigationController: UINavigationController, TransitionAnimatable {
   
-  let navigator = Navigator()
-  
+  // MARK: - TransitionAnimatable
+  @IBInspectable public var transitionAnimationType: String?
+  @IBInspectable public var transitionDuration: Double = .NaN
+
   public override func viewDidLoad() {
     super.viewDidLoad()
+    configureNavigationControllerDelegate(transitionAnimationType, transitionDuration: transitionDuration)
+  }
+
+  // Must have a property to keep the reference alive because `UINavigationController.delegate` is `weak`
+  private var navigator: Navigator?
+
+  private func configureNavigationControllerDelegate(transitionAnimationType: String?, transitionDuration: Duration) {
+    guard let transitionAnimationType = transitionAnimationType else {
+      return
+    }
+    var duration = transitionDuration
+    // Set the default duration for transition
+    if transitionDuration.isNaN {
+      duration = 0.5
+    }
+    navigator = Navigator(transitionAnimationType: transitionAnimationType, transitionDuration: duration)
     delegate = navigator
   }
 }

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -8,7 +8,7 @@ import UIKit
 public class AnimatableNavigationController: UINavigationController {
   class Navigator: NSObject, UINavigationControllerDelegate {
     func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-      if operation == .Pop {
+      if operation == .Push {
         return FadeInAnimator()
       }
       return nil

--- a/IBAnimatable/AnimatedTransitioning.swift
+++ b/IBAnimatable/AnimatedTransitioning.swift
@@ -18,4 +18,9 @@ protocol AnimatedTransitioning: UIViewControllerAnimatedTransitioning {
    Transition duration
    */
   var transitionDuration: Duration { get set }
+
+  /**
+   Reverse animation type: used to specify the revers animation for pop or dismiss.
+   */
+  var reverseAnimationType: String? { get set }
 }

--- a/IBAnimatable/AnimatedTransitioning.swift
+++ b/IBAnimatable/AnimatedTransitioning.swift
@@ -4,8 +4,10 @@
 //
 
 import UIKit
-
-protocol AnimatorProtocol: UIViewControllerAnimatedTransitioning {
+/**
+ AnimatedTransitioning is the protocol of all Animator subclasses
+ */
+protocol AnimatedTransitioning: UIViewControllerAnimatedTransitioning {
   
   /**
    String value of `TransitionAnimationType` enum

--- a/IBAnimatable/AnimatedTransitioning.swift
+++ b/IBAnimatable/AnimatedTransitioning.swift
@@ -30,7 +30,7 @@ public extension AnimatedTransitioning {
     return (transitionContext.viewForKey(UITransitionContextFromViewKey), transitionContext.viewForKey(UITransitionContextToViewKey), transitionContext.containerView())
   }
 
-  public func animateWithCATransition(transitionContext: UIViewControllerContextTransitioning, type: String, subtype: String?) {
+  public func animateWithCATransition(transitionContext: UIViewControllerContextTransitioning, type: CATransitionType, subtype: String?) {
     let (_, tempToView, tempContainerView) = retrieveViews(transitionContext)
     guard let toView = tempToView, containerView = tempContainerView else {
       transitionContext.completeTransition(true)
@@ -40,7 +40,7 @@ public extension AnimatedTransitioning {
     containerView.addSubview(toView)
     CALayer.animate({
       let transition = CATransition()
-      transition.type = type
+      transition.type = String(type)
       if let subtype = subtype {
         transition.subtype = subtype
       }

--- a/IBAnimatable/AnimatedTransitioning.swift
+++ b/IBAnimatable/AnimatedTransitioning.swift
@@ -7,7 +7,7 @@ import UIKit
 /**
  AnimatedTransitioning is the protocol of all Animator subclasses
  */
-protocol AnimatedTransitioning: UIViewControllerAnimatedTransitioning {
+public protocol AnimatedTransitioning: UIViewControllerAnimatedTransitioning {
   
   /**
    String value of `TransitionAnimationType` enum
@@ -23,4 +23,32 @@ protocol AnimatedTransitioning: UIViewControllerAnimatedTransitioning {
    Reverse animation type: used to specify the revers animation for pop or dismiss.
    */
   var reverseAnimationType: String? { get set }
+}
+
+public extension AnimatedTransitioning {
+  public func retrieveViews(transitionContext: UIViewControllerContextTransitioning) -> (UIView?, UIView?, UIView?) {
+    return (transitionContext.viewForKey(UITransitionContextFromViewKey), transitionContext.viewForKey(UITransitionContextToViewKey), transitionContext.containerView())
+  }
+
+  public func animateWithCATransition(transitionContext: UIViewControllerContextTransitioning, type: String, subtype: String?) {
+    let (_, tempToView, tempContainerView) = retrieveViews(transitionContext)
+    guard let toView = tempToView, containerView = tempContainerView else {
+      transitionContext.completeTransition(true)
+      return
+    }
+
+    containerView.addSubview(toView)
+    CALayer.animate({
+      let transition = CATransition()
+      transition.type = type
+      if let subtype = subtype {
+        transition.subtype = subtype
+      }
+      transition.duration = self.transitionDuration(transitionContext)
+
+      containerView.layer.addAnimation(transition, forKey: kCATransition)
+    }) {
+      transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }
+  }
 }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -1,0 +1,21 @@
+//
+//  Created by Jake Lin on 2/24/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+struct AnimatorFactory {
+  static func generateAnimator(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) -> AnimatorProtocol {
+    switch transitionAnimationType {
+    case .CubeFromLeft:
+      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+    case .CubeFromRight:
+      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+    case .CubeFromTop:
+      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+    case .CubeFromBottom:
+      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+    }
+  }
+}

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -4,9 +4,11 @@
 //
 
 import Foundation
-
+/**
+ Animator Factory
+ */
 struct AnimatorFactory {
-  static func generateAnimator(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) -> AnimatorProtocol {
+  static func generateAnimator(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) -> AnimatedTransitioning {
     switch transitionAnimationType {
     case .CubeFromLeft:
       return CubeFromLeftAnimator(transitionDuration: transitionDuration)

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -15,9 +15,9 @@ struct AnimatorFactory {
     case .CubeFromRight:
       return CubeFromRightAnimator(transitionDuration: transitionDuration)
     case .CubeFromTop:
-      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+      return CubeFromTopAnimator(transitionDuration: transitionDuration)
     case .CubeFromBottom:
-      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+      return CubeFromBottomAnimator(transitionDuration: transitionDuration)
     }
   }
 }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -11,7 +11,7 @@ struct AnimatorFactory {
     case .CubeFromLeft:
       return CubeFromLeftAnimator(transitionDuration: transitionDuration)
     case .CubeFromRight:
-      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+      return CubeFromRightAnimator(transitionDuration: transitionDuration)
     case .CubeFromTop:
       return CubeFromLeftAnimator(transitionDuration: transitionDuration)
     case .CubeFromBottom:

--- a/IBAnimatable/AnimatorProtocol.swift
+++ b/IBAnimatable/AnimatorProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  Created by Jake Lin on 2/24/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+protocol AnimatorProtocol: class {
+  
+  /**
+   String value of `TransitionAnimationType` enum
+   */
+  var transitionAnimationType: String { get set }
+  
+  /**
+   Transition duration
+   */
+  var transitionDuration: Duration { get set }
+}

--- a/IBAnimatable/AnimatorProtocol.swift
+++ b/IBAnimatable/AnimatorProtocol.swift
@@ -3,9 +3,9 @@
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
-protocol AnimatorProtocol: class {
+protocol AnimatorProtocol: UIViewControllerAnimatedTransitioning {
   
   /**
    String value of `TransitionAnimationType` enum

--- a/IBAnimatable/CALayerExtension.swift
+++ b/IBAnimatable/CALayerExtension.swift
@@ -1,0 +1,17 @@
+//
+//  Created by Jake Lin on 2/23/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public extension CALayer {
+  class func animate(animation: AnimatableExecution, completion: AnimatableCompletion? = nil) {
+    CATransaction.begin()
+    if let completion = completion {
+      CATransaction.setCompletionBlock { completion() }
+    }
+    animation()
+    CATransaction.commit()
+  }
+}

--- a/IBAnimatable/CATransitionType.swift
+++ b/IBAnimatable/CATransitionType.swift
@@ -1,0 +1,43 @@
+//
+// Created by Jake Lin on 2/24/16.
+// Copyright (c) 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+/**
+  CATransition Type: supported CATransition Type
+  refer to http://iphonedevwiki.net/index.php/CATransition
+*/
+public enum CATransitionType: String {
+  case fade
+  case moveIn
+  case push
+  case reveal
+  case flip
+  case alignedFlip
+  case oglFlip
+  case cube
+  case alignedCube
+  case pageCurl
+  case pageUnCurl
+  case rippleEffect
+  case suckEffect
+  case cameraIris
+  case cameraIrisHollowOpen
+  case cameraIrisHollowClose
+  case rotate
+  case spewEffect
+  case genieEffect
+  case unGenieEffect
+  case twist
+  case swirl
+  case charminUltra
+  case reflection
+  case zoomyIn
+  case zoomyOut
+  case mapCurl
+  case mapUnCurl
+  case oglApplicationSuspend
+  case cameraIrisHollow
+}

--- a/IBAnimatable/CubeFromBottomAnimator.swift
+++ b/IBAnimatable/CubeFromBottomAnimator.swift
@@ -1,0 +1,29 @@
+//
+//  Created by Jake Lin on 2/20/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Cube Animator, starts from top
+ */
+public class CubeFromBottomAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
+  // MARK: - AnimatorProtocol
+  public var transitionAnimationType = String(TransitionAnimationType.CubeFromBottom)
+  public var transitionDuration: Duration = .NaN
+  public var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromTop)
+
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    super.init()
+  }
+  
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return transitionDuration
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    animateWithCATransition(transitionContext, type: CATransitionType.cube, subtype: kCATransitionFromBottom)
+  }
+}

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -24,6 +24,6 @@ public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioni
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: "cube", subtype: kCATransitionFromLeft)
+    animateWithCATransition(transitionContext, type: CATransitionType.cube, subtype: kCATransitionFromLeft)
   }
 }

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -11,7 +11,8 @@ import UIKit
 public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   var transitionAnimationType = String(TransitionAnimationType.CubeFromLeft)
-  var transitionDuration = Duration.NaN
+  var transitionDuration: Duration = .NaN
+  var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromRight)
 
   init(transitionDuration: Duration) {
     self.transitionDuration = transitionDuration

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -5,7 +5,10 @@
 
 import UIKit
 
-public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatorProtocol {
+/**
+ Cube Animator, starts from left
+ */
+public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   var transitionAnimationType = String(TransitionAnimationType.CubeFromLeft)
   var transitionDuration = Duration.NaN

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -1,0 +1,35 @@
+//
+//  Created by Jake Lin on 2/20/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  let transitionDuration = 0.5
+  
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return transitionDuration
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    guard let _ = transitionContext.viewForKey(UITransitionContextFromViewKey),
+      toView = transitionContext.viewForKey(UITransitionContextToViewKey),
+      containerView = transitionContext.containerView() else {
+        transitionContext.completeTransition(true)
+        return
+    }
+    
+    containerView.addSubview(toView)
+    CALayer.animate({
+      let transition = CATransition()
+      transition.type = "cube"
+      transition.subtype = kCATransitionFromLeft
+      transition.duration = self.transitionDuration(transitionContext)
+      
+      containerView.layer.addAnimation(transition, forKey: kCATransition)
+      }) {
+        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }
+  }
+}

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -5,8 +5,15 @@
 
 import UIKit
 
-public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-  let transitionDuration = 0.5
+public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatorProtocol {
+  // MARK: - AnimatorProtocol
+  var transitionAnimationType = String(TransitionAnimationType.CubeFromLeft)
+  var transitionDuration = Duration.NaN
+
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    super.init()
+  }
   
   public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
     return transitionDuration

--- a/IBAnimatable/CubeFromLeftAnimator.swift
+++ b/IBAnimatable/CubeFromLeftAnimator.swift
@@ -10,9 +10,9 @@ import UIKit
  */
 public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
-  var transitionAnimationType = String(TransitionAnimationType.CubeFromLeft)
-  var transitionDuration: Duration = .NaN
-  var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromRight)
+  public var transitionAnimationType = String(TransitionAnimationType.CubeFromLeft)
+  public var transitionDuration: Duration = .NaN
+  public var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromRight)
 
   init(transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
@@ -24,23 +24,6 @@ public class CubeFromLeftAnimator: NSObject, UIViewControllerAnimatedTransitioni
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    guard let _ = transitionContext.viewForKey(UITransitionContextFromViewKey),
-      toView = transitionContext.viewForKey(UITransitionContextToViewKey),
-      containerView = transitionContext.containerView() else {
-        transitionContext.completeTransition(true)
-        return
-    }
-    
-    containerView.addSubview(toView)
-    CALayer.animate({
-      let transition = CATransition()
-      transition.type = "cube"
-      transition.subtype = kCATransitionFromLeft
-      transition.duration = self.transitionDuration(transitionContext)
-      
-      containerView.layer.addAnimation(transition, forKey: kCATransition)
-      }) {
-        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
-    }
+    animateWithCATransition(transitionContext, type: "cube", subtype: kCATransitionFromLeft)
   }
 }

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -5,9 +5,16 @@
 
 import UIKit
 
-public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-  let transitionDuration = 0.5
-  
+public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatorProtocol {
+  // MARK: - AnimatorProtocol
+  var transitionAnimationType = String(TransitionAnimationType.CubeFromRight)
+  var transitionDuration = Duration.NaN
+
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    super.init()
+  }
+
   public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
     return transitionDuration
   }

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -1,12 +1,12 @@
 //
-//  Created by Jake Lin on 2/20/16.
+//  Created by Jake Lin on 2/24/16.
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //
 
 import UIKit
 
-public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-  let transitionDuration = 3.0
+public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  let transitionDuration = 0.5
   
   public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
     return transitionDuration
@@ -23,8 +23,8 @@ public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     containerView.addSubview(toView)
     CALayer.animate({
       let transition = CATransition()
-      transition.type = "flip" // kCATransitionReveal
-      transition.subtype = kCATransitionFromTop
+      transition.type = "cube"
+      transition.subtype = kCATransitionFromRight
       transition.duration = self.transitionDuration(transitionContext)
       
       containerView.layer.addAnimation(transition, forKey: kCATransition)
@@ -32,4 +32,5 @@ public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
     }
   }
+
 }

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -5,7 +5,10 @@
 
 import UIKit
 
-public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatorProtocol {
+/**
+ Cube Animator, starts from right
+ */
+public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   var transitionAnimationType = String(TransitionAnimationType.CubeFromRight)
   var transitionDuration = Duration.NaN

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -11,7 +11,8 @@ import UIKit
 public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   var transitionAnimationType = String(TransitionAnimationType.CubeFromRight)
-  var transitionDuration = Duration.NaN
+  var transitionDuration: Duration = .NaN
+  var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromLeft)
 
   init(transitionDuration: Duration) {
     self.transitionDuration = transitionDuration

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -10,9 +10,9 @@ import UIKit
  */
 public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
-  var transitionAnimationType = String(TransitionAnimationType.CubeFromRight)
-  var transitionDuration: Duration = .NaN
-  var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromLeft)
+  public var transitionAnimationType = String(TransitionAnimationType.CubeFromRight)
+  public var transitionDuration: Duration = .NaN
+  public var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromLeft)
 
   init(transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
@@ -24,24 +24,6 @@ public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransition
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    guard let _ = transitionContext.viewForKey(UITransitionContextFromViewKey),
-      toView = transitionContext.viewForKey(UITransitionContextToViewKey),
-      containerView = transitionContext.containerView() else {
-        transitionContext.completeTransition(true)
-        return
-    }
-    
-    containerView.addSubview(toView)
-    CALayer.animate({
-      let transition = CATransition()
-      transition.type = "cube"
-      transition.subtype = kCATransitionFromRight
-      transition.duration = self.transitionDuration(transitionContext)
-      
-      containerView.layer.addAnimation(transition, forKey: kCATransition)
-      }) {
-        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
-    }
+    animateWithCATransition(transitionContext, type: "cube", subtype: kCATransitionFromRight)
   }
-
 }

--- a/IBAnimatable/CubeFromRightAnimator.swift
+++ b/IBAnimatable/CubeFromRightAnimator.swift
@@ -24,6 +24,6 @@ public class CubeFromRightAnimator: NSObject, UIViewControllerAnimatedTransition
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: "cube", subtype: kCATransitionFromRight)
+    animateWithCATransition(transitionContext, type: CATransitionType.cube, subtype: kCATransitionFromRight)
   }
 }

--- a/IBAnimatable/CubeFromTopAnimator.swift
+++ b/IBAnimatable/CubeFromTopAnimator.swift
@@ -1,0 +1,29 @@
+//
+//  Created by Jake Lin on 2/20/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Cube Animator, starts from top
+ */
+public class CubeFromTopAnimator: NSObject, UIViewControllerAnimatedTransitioning, AnimatedTransitioning {
+  // MARK: - AnimatorProtocol
+  public var transitionAnimationType = String(TransitionAnimationType.CubeFromTop)
+  public var transitionDuration: Duration = .NaN
+  public var reverseAnimationType: String? = String(TransitionAnimationType.CubeFromBottom)
+
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    super.init()
+  }
+  
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return transitionDuration
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    animateWithCATransition(transitionContext, type: CATransitionType.cube, subtype: kCATransitionFromTop)
+  }
+}

--- a/IBAnimatable/FadeInAnimator.swift
+++ b/IBAnimatable/FadeInAnimator.swift
@@ -1,0 +1,23 @@
+//
+//  Created by Jake Lin on 2/20/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return 0.25
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+//    guard let fromViewController = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey),
+//      toViewController = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey),
+//      containerView = transitionContext.containerView() else {
+//        transitionContext.completeTransition(true)
+//        return
+//    }
+    
+    
+  }
+}

--- a/IBAnimatable/FadeInAnimator.swift
+++ b/IBAnimatable/FadeInAnimator.swift
@@ -6,20 +6,30 @@
 import UIKit
 
 public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  let transitionDuration = 3.0
+  
   public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
-    return 0.25
+    return transitionDuration
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    guard let fromView = transitionContext.viewForKey(UITransitionContextFromViewKey),
+    guard let _ = transitionContext.viewForKey(UITransitionContextFromViewKey),
       toView = transitionContext.viewForKey(UITransitionContextToViewKey),
-      _ = transitionContext.containerView() else {
+      containerView = transitionContext.containerView() else {
         transitionContext.completeTransition(true)
         return
     }
-
-    UIView.transitionFromView(fromView, toView: toView, duration: transitionDuration(transitionContext), options: .TransitionFlipFromLeft) { (completed) -> Void in
-      transitionContext.completeTransition(completed)
+    
+    containerView.addSubview(toView)
+    CALayer.animate({
+      let transition = CATransition()
+      transition.type = "flip" // kCATransitionReveal
+      transition.subtype = kCATransitionFromTop
+      transition.duration = self.transitionDuration(transitionContext)
+      
+      containerView.layer.addAnimation(transition, forKey: kCATransition)
+      }) {
+        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
     }
   }
 }

--- a/IBAnimatable/FadeInAnimator.swift
+++ b/IBAnimatable/FadeInAnimator.swift
@@ -11,13 +11,15 @@ public class FadeInAnimator: NSObject, UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-//    guard let fromViewController = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey),
-//      toViewController = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey),
-//      containerView = transitionContext.containerView() else {
-//        transitionContext.completeTransition(true)
-//        return
-//    }
-    
-    
+    guard let fromView = transitionContext.viewForKey(UITransitionContextFromViewKey),
+      toView = transitionContext.viewForKey(UITransitionContextToViewKey),
+      _ = transitionContext.containerView() else {
+        transitionContext.completeTransition(true)
+        return
+    }
+
+    UIView.transitionFromView(fromView, toView: toView, duration: transitionDuration(transitionContext), options: .TransitionFlipFromLeft) { (completed) -> Void in
+      transitionContext.completeTransition(completed)
+    }
   }
 }

--- a/IBAnimatable/GradientType.swift
+++ b/IBAnimatable/GradientType.swift
@@ -1,7 +1,4 @@
 //
-//  GradientType.swift
-//  IBAnimatableApp
-//
 //  Created by Tom Baranes on 09/02/16.
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -5,6 +5,9 @@
 
 import UIKit
 
+/**
+ Custom navigator for `UINavigationController`
+ */
 public class Navigator: NSObject, UINavigationControllerDelegate {
   var transitionAnimationType: String?
   var transitionDuration: Duration

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -22,10 +22,14 @@ public class Navigator: NSObject, UINavigationControllerDelegate {
       return nil
     }
 
+    let animator = AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
     if operation == .Push {
-      return AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
+      return animator
     } else if operation == .Pop {
-      return AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
+      // Use the reverse animation
+      if let reverseAnimationType = animator.reverseAnimationType, reverseTransitionAnimationType = TransitionAnimationType(rawValue: reverseAnimationType) {
+        return AnimatorFactory.generateAnimator(reverseTransitionAnimationType, transitionDuration: transitionDuration)
+      }
     }
     return nil
   }

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -1,0 +1,25 @@
+//
+// Created by Jake Lin on 2/24/16.
+// Copyright (c) 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class Navigator: NSObject, UINavigationControllerDelegate {
+  var transitionAnimationType: String?
+  var transitionDuration: Duration
+
+  public init(transitionAnimationType: String?, transitionDuration: Duration) {
+    self.transitionAnimationType = transitionAnimationType
+    self.transitionDuration = transitionDuration
+  }
+
+  public func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    if operation == .Push {
+      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+    } else if operation == .Pop {
+      return CubeFromRightAnimator(transitionDuration: transitionDuration)
+    }
+    return nil
+  }
+}

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -15,10 +15,14 @@ public class Navigator: NSObject, UINavigationControllerDelegate {
   }
 
   public func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    guard let unwrappedTransitionAnimationType = transitionAnimationType, transitionAnimationType = TransitionAnimationType(rawValue: unwrappedTransitionAnimationType) else {
+      return nil
+    }
+
     if operation == .Push {
-      return CubeFromLeftAnimator(transitionDuration: transitionDuration)
+      return AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
     } else if operation == .Pop {
-      return CubeFromRightAnimator(transitionDuration: transitionDuration)
+      return AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
     }
     return nil
   }

--- a/IBAnimatable/TransitionAnimatable.swift
+++ b/IBAnimatable/TransitionAnimatable.swift
@@ -5,10 +5,14 @@
 
 import UIKit
 
-protocol TransitionAnimatable: class {
-  
+public protocol TransitionAnimatable: class {
   /**
    String value of `TransitionAnimationType` enum
    */
   var transitionAnimationType: String? { get set }
+  
+  /**
+   Transition duration: default value should be `Double.NaN`. Need to use `Double` instead of `NSTimeInterval` because IB doesn't support `NSTimeInterval`
+   */
+  var transitionDuration: Double { get set }
 }

--- a/IBAnimatable/TransitionAnimatable.swift
+++ b/IBAnimatable/TransitionAnimatable.swift
@@ -1,0 +1,14 @@
+//
+//  Created by Jake Lin on 2/24/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+protocol TransitionAnimatable: class {
+  
+  /**
+   String value of `TransitionAnimationType` enum
+   */
+  var transitionAnimationType: String? { get set }
+}

--- a/IBAnimatable/TransitionAnimatableType.swift
+++ b/IBAnimatable/TransitionAnimatableType.swift
@@ -1,0 +1,16 @@
+//
+//  Created by Jake Lin on 2/24/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Predefined Transition Animation Type
+ */
+public enum TransitionAnimationType: String {
+  case cubeFromLeft
+  case cubeFromRight
+  case cubeFromTop
+  case cubeFromBottom
+}

--- a/IBAnimatable/TransitionAnimatableType.swift
+++ b/IBAnimatable/TransitionAnimatableType.swift
@@ -9,8 +9,8 @@ import Foundation
  Predefined Transition Animation Type
  */
 public enum TransitionAnimationType: String {
-  case cubeFromLeft
-  case cubeFromRight
-  case cubeFromTop
-  case cubeFromBottom
+  case CubeFromLeft
+  case CubeFromRight
+  case CubeFromTop
+  case CubeFromBottom
 }

--- a/IBAnimatable/Typealias.swift
+++ b/IBAnimatable/Typealias.swift
@@ -1,0 +1,9 @@
+//
+//  Typealias.swift
+//  IBAnimatableApp
+//
+//  Created by Jake Lin on 2/23/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation

--- a/IBAnimatable/Typealias.swift
+++ b/IBAnimatable/Typealias.swift
@@ -1,9 +1,9 @@
 //
-//  Typealias.swift
-//  IBAnimatableApp
-//
 //  Created by Jake Lin on 2/23/16.
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //
 
 import Foundation
+
+public typealias AnimatableCompletion = () -> Void
+public typealias AnimatableExecution = () -> Void

--- a/IBAnimatable/Typealias.swift
+++ b/IBAnimatable/Typealias.swift
@@ -7,3 +7,4 @@ import Foundation
 
 public typealias AnimatableCompletion = () -> Void
 public typealias AnimatableExecution = () -> Void
+public typealias Duration = NSTimeInterval

--- a/IBAnimatable/UIViewControllerExtension.swift
+++ b/IBAnimatable/UIViewControllerExtension.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+// MARK: - UIStoryboardSegue
 public extension UIViewController {
   @IBAction public func unwindToViewController(sender: UIStoryboardSegue) {
   }

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AE154B081C7880520093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
 		AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
 		AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
+		AE154B101C788A560093C05B /* Transitions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE154B0E1C788A560093C05B /* Transitions.storyboard */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
 		AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787B1C1D97F500300246 /* MaskDesignable.swift */; };
 		AE18787E1C1D980D00300246 /* MaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787D1C1D980D00300246 /* MaskType.swift */; };
@@ -132,6 +133,7 @@
 		AE0FADAE1C203F9A00B5289B /* AnimatableTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableTableView.swift; sourceTree = "<group>"; };
 		AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableNavigationController.swift; sourceTree = "<group>"; };
 		AE154B071C7880520093C05B /* FadeInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeInAnimator.swift; sourceTree = "<group>"; };
+		AE154B0F1C788A560093C05B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Transitions.storyboard; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
 		AE18787D1C1D980D00300246 /* MaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskType.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				AED1A0FB1BFE9820001346FA /* Assets.xcassets */,
 				AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */,
 				AED1A0FF1BFE9820001346FA /* Main.storyboard */,
+				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
 			);
 			path = IBAnimatableApp;
@@ -464,6 +467,7 @@
 				AED1A1061BFE9820001346FA /* Main.storyboard in Resources */,
 				AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */,
 				AED1A1051BFE9820001346FA /* LaunchScreen.storyboard in Resources */,
+				AE154B101C788A560093C05B /* Transitions.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -578,6 +582,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
+		AE154B0E1C788A560093C05B /* Transitions.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AE154B0F1C788A560093C05B /* Base */,
+			);
+			name = Transitions.storyboard;
+			sourceTree = "<group>";
+		};
 		AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		AE0B0FEC1C26397700E36B78 /* AnimatableCheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B0FEB1C26397700E36B78 /* AnimatableCheckBox.swift */; };
 		AE0B0FEE1C263A1900E36B78 /* CheckBoxDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B0FED1C263A1900E36B78 /* CheckBoxDesignable.swift */; };
 		AE0B0FF01C26655000E36B78 /* AnimatableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0B0FEF1C26655000E36B78 /* AnimatableLabel.swift */; };
-		AE0FAD3B1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift */; };
+		AE0FAD3B1C1ECA4200B5289B /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */; };
 		AE0FAD3D1C1ED1EC00B5289B /* DismissSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */; };
 		AE0FAD411C1ED41D00B5289B /* DesignableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD401C1ED41D00B5289B /* DesignableViewController.swift */; };
 		AE0FAD431C1ED52800B5289B /* ViewControllerDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */; };
@@ -32,6 +32,10 @@
 		AE154B7F1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */; };
 		AE154B811C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
 		AE154B821C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
+		AE154B841C7D1A740093C05B /* AnimatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */; };
+		AE154B851C7D1A740093C05B /* AnimatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */; };
+		AE154B8B1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */; };
+		AE154B8C1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
 		AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787B1C1D97F500300246 /* MaskDesignable.swift */; };
 		AE18787E1C1D980D00300246 /* MaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787D1C1D980D00300246 /* MaskType.swift */; };
@@ -80,7 +84,7 @@
 		AE6B01841C2A445100950BB2 /* AnimatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A10D1BFE983A001346FA /* AnimatableTextView.swift */; };
 		AE6B01861C2A445100950BB2 /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
 		AE6B01871C2A445400950BB2 /* DesignableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD401C1ED41D00B5289B /* DesignableViewController.swift */; };
-		AE6B01881C2A445800950BB2 /* UIViewController+UnwindSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift */; };
+		AE6B01881C2A445800950BB2 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */; };
 		AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */; };
 		AE74D6D71C166FB100718E0E /* SideImageDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE74D6D61C166FB100718E0E /* SideImageDesignable.swift */; };
 		AE81DAEE1C10F14C000AEB20 /* GradientDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE81DAED1C10F14C000AEB20 /* GradientDesignable.swift */; };
@@ -107,7 +111,9 @@
 		AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED97B851C1710A900D2B0B8 /* BorderSide.swift */; };
 		AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */; };
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
+		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */; };
+		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
@@ -135,7 +141,7 @@
 		AE0B0FEB1C26397700E36B78 /* AnimatableCheckBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableCheckBox.swift; sourceTree = "<group>"; };
 		AE0B0FED1C263A1900E36B78 /* CheckBoxDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckBoxDesignable.swift; sourceTree = "<group>"; };
 		AE0B0FEF1C26655000E36B78 /* AnimatableLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableLabel.swift; sourceTree = "<group>"; };
-		AE0FAD3A1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+UnwindSegue.swift"; sourceTree = "<group>"; };
+		AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
 		AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DismissSegue.swift; sourceTree = "<group>"; };
 		AE0FAD401C1ED41D00B5289B /* DesignableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableViewController.swift; sourceTree = "<group>"; };
 		AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerDesignable.swift; sourceTree = "<group>"; };
@@ -149,6 +155,8 @@
 		AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatable.swift; sourceTree = "<group>"; };
 		AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatableType.swift; sourceTree = "<group>"; };
 		AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromRightAnimator.swift; sourceTree = "<group>"; };
+		AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatorProtocol.swift; sourceTree = "<group>"; };
+		AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatorFactory.swift; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
 		AE18787D1C1D980D00300246 /* MaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskType.swift; sourceTree = "<group>"; };
@@ -186,6 +194,7 @@
 		AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarDesginable.swift; sourceTree = "<group>"; };
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
+		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
 		E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatColorsTypeScript.swift; path = Scripts/FlatColorsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -216,7 +225,7 @@
 		AE0FAD391C1ECA2900B5289B /* extension */ = {
 			isa = PBXGroup;
 			children = (
-				AE0FAD3A1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift */,
+				AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */,
 				E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */,
 				AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */,
 			);
@@ -245,6 +254,8 @@
 			children = (
 				AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */,
 				AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */,
+				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
+				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
 			);
 			name = animator;
 			sourceTree = "<group>";
@@ -255,6 +266,15 @@
 				AE154B271C7BB52E0093C05B /* Typealias.swift */,
 			);
 			name = typealias;
+			sourceTree = "<group>";
+		};
+		AE154B861C7D1AA10093C05B /* TransitionAnimatable */ = {
+			isa = PBXGroup;
+			children = (
+				AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */,
+				AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */,
+			);
+			name = TransitionAnimatable;
 			sourceTree = "<group>";
 		};
 		AE6C66F61BFBF93500134A35 = {
@@ -312,6 +332,7 @@
 			children = (
 				AED1A1241BFEA328001346FA /* Animatable */,
 				AED1A1231BFEA319001346FA /* Designable */,
+				AE154B861C7D1AA10093C05B /* TransitionAnimatable */,
 			);
 			name = protocol;
 			sourceTree = "<group>";
@@ -380,7 +401,6 @@
 			isa = PBXGroup;
 			children = (
 				AED1A10A1BFE983A001346FA /* Animatable.swift */,
-				AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */,
 			);
 			name = Animatable;
 			sourceTree = "<group>";
@@ -516,6 +536,7 @@
 				AE6B01831C2A445100950BB2 /* AnimatableTextField.swift in Sources */,
 				AE6B01731C2A444900950BB2 /* ShadowDesignable.swift in Sources */,
 				AE6B01621C2A444000950BB2 /* AnimationType.swift in Sources */,
+				AE154B8C1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */,
 				AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE6B01871C2A445400950BB2 /* DesignableViewController.swift in Sources */,
 				E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */,
@@ -526,6 +547,7 @@
 				AE6B017A1C2A445100950BB2 /* AnimatableView.swift in Sources */,
 				AE6B01751C2A444900950BB2 /* StatusBarDesignable.swift in Sources */,
 				AE6B016A1C2A444900950BB2 /* CheckBoxDesignable.swift in Sources */,
+				AE154B851C7D1A740093C05B /* AnimatorProtocol.swift in Sources */,
 				AE6B017B1C2A445100950BB2 /* AnimatableBarButtonItem.swift in Sources */,
 				AE6B017D1C2A445100950BB2 /* AnimatableCheckBox.swift in Sources */,
 				AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
@@ -541,7 +563,7 @@
 				AE6B01841C2A445100950BB2 /* AnimatableTextView.swift in Sources */,
 				AE6B01791C2A444900950BB2 /* ViewControllerDesignable.swift in Sources */,
 				AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */,
-				AE6B01881C2A445800950BB2 /* UIViewController+UnwindSegue.swift in Sources */,
+				AE6B01881C2A445800950BB2 /* UIViewControllerExtension.swift in Sources */,
 				AE6B01771C2A444900950BB2 /* TintDesignable.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
 				AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
@@ -556,6 +578,7 @@
 				AE6B01741C2A444900950BB2 /* SideImageDesignable.swift in Sources */,
 				AE6B017E1C2A445100950BB2 /* AnimatableImageView.swift in Sources */,
 				AE6B01761C2A444900950BB2 /* TableViewCellDesignable.swift in Sources */,
+				CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -576,7 +599,7 @@
 				AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */,
 				AE0FAD411C1ED41D00B5289B /* DesignableViewController.swift in Sources */,
 				AE0FADAB1C20357C00B5289B /* StatusBarDesignable.swift in Sources */,
-				AE0FAD3B1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift in Sources */,
+				AE0FAD3B1C1ECA4200B5289B /* UIViewControllerExtension.swift in Sources */,
 				AED1A11B1BFE983A001346FA /* AnimationType.swift in Sources */,
 				AED1A11E1BFE983A001346FA /* PaddingDesignable.swift in Sources */,
 				AE154B2C1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
@@ -600,6 +623,7 @@
 				AE299BDC1C03BB670018CCDC /* TintDesignable.swift in Sources */,
 				AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */,
 				AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */,
+				AE154B8B1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */,
 				AE0FAD431C1ED52800B5289B /* ViewControllerDesignable.swift in Sources */,
 				AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */,
 				AE154B7B1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
@@ -609,11 +633,13 @@
 				AE0B0FEC1C26397700E36B78 /* AnimatableCheckBox.swift in Sources */,
 				AE0FAD3D1C1ED1EC00B5289B /* DismissSegue.swift in Sources */,
 				AE81DB4E1C11DF00000AEB20 /* BlurEffectStyle.swift in Sources */,
+				AE154B841C7D1A740093C05B /* AnimatorProtocol.swift in Sources */,
 				AED1A1151BFE983A001346FA /* AnimatableButton.swift in Sources */,
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,
 				CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */,
 				AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */,
+				CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
 		AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
 		AE154B101C788A560093C05B /* Transitions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE154B0E1C788A560093C05B /* Transitions.storyboard */; };
+		AE154B281C7BB52E0093C05B /* Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B271C7BB52E0093C05B /* Typealias.swift */; };
+		AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B271C7BB52E0093C05B /* Typealias.swift */; };
+		AE154B2C1C7BB5760093C05B /* CALayerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */; };
+		AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
 		AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787B1C1D97F500300246 /* MaskDesignable.swift */; };
 		AE18787E1C1D980D00300246 /* MaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787D1C1D980D00300246 /* MaskType.swift */; };
@@ -134,6 +138,8 @@
 		AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableNavigationController.swift; sourceTree = "<group>"; };
 		AE154B071C7880520093C05B /* FadeInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeInAnimator.swift; sourceTree = "<group>"; };
 		AE154B0F1C788A560093C05B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Transitions.storyboard; sourceTree = "<group>"; };
+		AE154B271C7BB52E0093C05B /* Typealias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Typealias.swift; sourceTree = "<group>"; };
+		AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CALayerExtension.swift; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
 		AE18787D1C1D980D00300246 /* MaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskType.swift; sourceTree = "<group>"; };
@@ -203,6 +209,7 @@
 			children = (
 				AE0FAD3A1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift */,
 				E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */,
+				AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */,
 			);
 			name = extension;
 			sourceTree = "<group>";
@@ -230,6 +237,14 @@
 				AE154B071C7880520093C05B /* FadeInAnimator.swift */,
 			);
 			name = animator;
+			sourceTree = "<group>";
+		};
+		AE154B2A1C7BB5370093C05B /* typealias */ = {
+			isa = PBXGroup;
+			children = (
+				AE154B271C7BB52E0093C05B /* Typealias.swift */,
+			);
+			name = typealias;
 			sourceTree = "<group>";
 		};
 		AE6C66F61BFBF93500134A35 = {
@@ -276,6 +291,7 @@
 				AE154B0B1C7880680093C05B /* animator */,
 				AE0FAD391C1ECA2900B5289B /* extension */,
 				AE0FAD3E1C1ED26A00B5289B /* segue */,
+				AE154B2A1C7BB5370093C05B /* typealias */,
 				E2E28E701C6A6E5E003F3852 /* scripts */,
 			);
 			path = IBAnimatable;
@@ -488,6 +504,7 @@
 				AE6B01831C2A445100950BB2 /* AnimatableTextField.swift in Sources */,
 				AE6B01731C2A444900950BB2 /* ShadowDesignable.swift in Sources */,
 				AE6B01621C2A444000950BB2 /* AnimationType.swift in Sources */,
+				AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE6B01871C2A445400950BB2 /* DesignableViewController.swift in Sources */,
 				E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE6B016D1C2A444900950BB2 /* GradientDesignable.swift in Sources */,
@@ -499,6 +516,7 @@
 				AE6B016A1C2A444900950BB2 /* CheckBoxDesignable.swift in Sources */,
 				AE6B017B1C2A445100950BB2 /* AnimatableBarButtonItem.swift in Sources */,
 				AE6B017D1C2A445100950BB2 /* AnimatableCheckBox.swift in Sources */,
+				AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
 				E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AE6B01681C2A444900950BB2 /* BlurDesignable.swift in Sources */,
 				AE6B01711C2A444900950BB2 /* PlaceholderDesignable.swift in Sources */,
@@ -534,6 +552,7 @@
 				AED1A11A1BFE983A001346FA /* AnimatableView.swift in Sources */,
 				E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */,
 				E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */,
+				AE154B281C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE81DAEE1C10F14C000AEB20 /* GradientDesignable.swift in Sources */,
 				AE299BDA1C0338C70018CCDC /* BlurDesignable.swift in Sources */,
 				AE81DB501C12E060000AEB20 /* RotationDesignable.swift in Sources */,
@@ -544,6 +563,7 @@
 				AE0FAD3B1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift in Sources */,
 				AED1A11B1BFE983A001346FA /* AnimationType.swift in Sources */,
 				AED1A11E1BFE983A001346FA /* PaddingDesignable.swift in Sources */,
+				AE154B2C1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
 				AED1A1171BFE983A001346FA /* AnimatableImageView.swift in Sources */,
 				AE3C54471C217F7F00829B10 /* BarButtonItemDesignable.swift in Sources */,
 				AE0B0FEA1C25372200E36B78 /* TableViewCellDesignable.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -32,8 +32,8 @@
 		AE154B7F1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */; };
 		AE154B811C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
 		AE154B821C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
-		AE154B841C7D1A740093C05B /* AnimatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */; };
-		AE154B851C7D1A740093C05B /* AnimatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */; };
+		AE154B841C7D1A740093C05B /* AnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatedTransitioning.swift */; };
+		AE154B851C7D1A740093C05B /* AnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B831C7D1A740093C05B /* AnimatedTransitioning.swift */; };
 		AE154B8B1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */; };
 		AE154B8C1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
@@ -155,7 +155,7 @@
 		AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatable.swift; sourceTree = "<group>"; };
 		AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatableType.swift; sourceTree = "<group>"; };
 		AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromRightAnimator.swift; sourceTree = "<group>"; };
-		AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatorProtocol.swift; sourceTree = "<group>"; };
+		AE154B831C7D1A740093C05B /* AnimatedTransitioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedTransitioning.swift; sourceTree = "<group>"; };
 		AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatorFactory.swift; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
@@ -272,7 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */,
-				AE154B831C7D1A740093C05B /* AnimatorProtocol.swift */,
+				AE154B831C7D1A740093C05B /* AnimatedTransitioning.swift */,
 			);
 			name = TransitionAnimatable;
 			sourceTree = "<group>";
@@ -547,7 +547,7 @@
 				AE6B017A1C2A445100950BB2 /* AnimatableView.swift in Sources */,
 				AE6B01751C2A444900950BB2 /* StatusBarDesignable.swift in Sources */,
 				AE6B016A1C2A444900950BB2 /* CheckBoxDesignable.swift in Sources */,
-				AE154B851C7D1A740093C05B /* AnimatorProtocol.swift in Sources */,
+				AE154B851C7D1A740093C05B /* AnimatedTransitioning.swift in Sources */,
 				AE6B017B1C2A445100950BB2 /* AnimatableBarButtonItem.swift in Sources */,
 				AE6B017D1C2A445100950BB2 /* AnimatableCheckBox.swift in Sources */,
 				AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
@@ -633,7 +633,7 @@
 				AE0B0FEC1C26397700E36B78 /* AnimatableCheckBox.swift in Sources */,
 				AE0FAD3D1C1ED1EC00B5289B /* DismissSegue.swift in Sources */,
 				AE81DB4E1C11DF00000AEB20 /* BlurEffectStyle.swift in Sources */,
-				AE154B841C7D1A740093C05B /* AnimatorProtocol.swift in Sources */,
+				AE154B841C7D1A740093C05B /* AnimatedTransitioning.swift in Sources */,
 				AED1A1151BFE983A001346FA /* AnimatableButton.swift in Sources */,
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		AE0FAD431C1ED52800B5289B /* ViewControllerDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */; };
 		AE0FADAB1C20357C00B5289B /* StatusBarDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FADAA1C20357C00B5289B /* StatusBarDesignable.swift */; };
 		AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FADAE1C203F9A00B5289B /* AnimatableTableView.swift */; };
+		AE154B061C787DDE0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
+		AE154B081C7880520093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
+		AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
+		AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
 		AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787B1C1D97F500300246 /* MaskDesignable.swift */; };
 		AE18787E1C1D980D00300246 /* MaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787D1C1D980D00300246 /* MaskType.swift */; };
@@ -126,6 +130,8 @@
 		AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerDesignable.swift; sourceTree = "<group>"; };
 		AE0FADAA1C20357C00B5289B /* StatusBarDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusBarDesignable.swift; sourceTree = "<group>"; };
 		AE0FADAE1C203F9A00B5289B /* AnimatableTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableTableView.swift; sourceTree = "<group>"; };
+		AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableNavigationController.swift; sourceTree = "<group>"; };
+		AE154B071C7880520093C05B /* FadeInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeInAnimator.swift; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
 		AE18787D1C1D980D00300246 /* MaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskType.swift; sourceTree = "<group>"; };
@@ -207,12 +213,21 @@
 			name = segue;
 			sourceTree = "<group>";
 		};
-		AE0FAD3F1C1ED2BD00B5289B /* viewController */ = {
+		AE0FAD3F1C1ED2BD00B5289B /* controller */ = {
 			isa = PBXGroup;
 			children = (
 				AE0FAD401C1ED41D00B5289B /* DesignableViewController.swift */,
+				AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */,
 			);
-			name = viewController;
+			name = controller;
+			sourceTree = "<group>";
+		};
+		AE154B0B1C7880680093C05B /* animator */ = {
+			isa = PBXGroup;
+			children = (
+				AE154B071C7880520093C05B /* FadeInAnimator.swift */,
+			);
+			name = animator;
 			sourceTree = "<group>";
 		};
 		AE6C66F61BFBF93500134A35 = {
@@ -254,7 +269,8 @@
 				AE6F18831BFD934A00CFDF4F /* enum */,
 				AE6F18741BFD49DE00CFDF4F /* protocol */,
 				AE6F18761BFD4A3200CFDF4F /* view */,
-				AE0FAD3F1C1ED2BD00B5289B /* viewController */,
+				AE0FAD3F1C1ED2BD00B5289B /* controller */,
+				AE154B0B1C7880680093C05B /* animator */,
 				AE0FAD391C1ECA2900B5289B /* extension */,
 				AE0FAD3E1C1ED26A00B5289B /* segue */,
 				E2E28E701C6A6E5E003F3852 /* scripts */,
@@ -471,6 +487,7 @@
 				AE6B01871C2A445400950BB2 /* DesignableViewController.swift in Sources */,
 				E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE6B016D1C2A444900950BB2 /* GradientDesignable.swift in Sources */,
+				AE154B061C787DDE0093C05B /* AnimatableNavigationController.swift in Sources */,
 				AE8964DB1C2CC0D100D3E9F0 /* RootWindowDesignable.swift in Sources */,
 				AE6B01651C2A444000950BB2 /* GradientStartPoint.swift in Sources */,
 				AE6B017A1C2A445100950BB2 /* AnimatableView.swift in Sources */,
@@ -492,6 +509,7 @@
 				AE6B01881C2A445800950BB2 /* UIViewController+UnwindSegue.swift in Sources */,
 				AE6B01771C2A444900950BB2 /* TintDesignable.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
+				AE154B081C7880520093C05B /* FadeInAnimator.swift in Sources */,
 				AE6B01641C2A444000950BB2 /* BorderSide.swift in Sources */,
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
@@ -516,6 +534,7 @@
 				AE299BDA1C0338C70018CCDC /* BlurDesignable.swift in Sources */,
 				AE81DB501C12E060000AEB20 /* RotationDesignable.swift in Sources */,
 				AE74D6D71C166FB100718E0E /* SideImageDesignable.swift in Sources */,
+				AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */,
 				AE0FAD411C1ED41D00B5289B /* DesignableViewController.swift in Sources */,
 				AE0FADAB1C20357C00B5289B /* StatusBarDesignable.swift in Sources */,
 				AE0FAD3B1C1ECA4200B5289B /* UIViewController+UnwindSegue.swift in Sources */,
@@ -530,6 +549,7 @@
 				E2E28E6E1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AED1A1161BFE983A001346FA /* Animatable.swift in Sources */,
 				AE8C53B01C0F1C0400A775AF /* GradientStartPoint.swift in Sources */,
+				AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */,
 				AE0B0FF01C26655000E36B78 /* AnimatableLabel.swift in Sources */,
 				AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */,
 				AED1A11D1BFE983A001346FA /* ShadowDesignable.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -18,14 +18,20 @@
 		AE0FADAB1C20357C00B5289B /* StatusBarDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FADAA1C20357C00B5289B /* StatusBarDesignable.swift */; };
 		AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FADAE1C203F9A00B5289B /* AnimatableTableView.swift */; };
 		AE154B061C787DDE0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
-		AE154B081C7880520093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
+		AE154B081C7880520093C05B /* CubeFromLeftAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */; };
 		AE154B091C78805A0093C05B /* AnimatableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */; };
-		AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* FadeInAnimator.swift */; };
+		AE154B0A1C78805C0093C05B /* CubeFromLeftAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */; };
 		AE154B101C788A560093C05B /* Transitions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE154B0E1C788A560093C05B /* Transitions.storyboard */; };
 		AE154B281C7BB52E0093C05B /* Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B271C7BB52E0093C05B /* Typealias.swift */; };
 		AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B271C7BB52E0093C05B /* Typealias.swift */; };
 		AE154B2C1C7BB5760093C05B /* CALayerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */; };
 		AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */; };
+		AE154B7B1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */; };
+		AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */; };
+		AE154B7E1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */; };
+		AE154B7F1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */; };
+		AE154B811C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
+		AE154B821C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */; };
 		AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1878791C1A25C100300246 /* AnimatableStackView.swift */; };
 		AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787B1C1D97F500300246 /* MaskDesignable.swift */; };
 		AE18787E1C1D980D00300246 /* MaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18787D1C1D980D00300246 /* MaskType.swift */; };
@@ -136,10 +142,13 @@
 		AE0FADAA1C20357C00B5289B /* StatusBarDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusBarDesignable.swift; sourceTree = "<group>"; };
 		AE0FADAE1C203F9A00B5289B /* AnimatableTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableTableView.swift; sourceTree = "<group>"; };
 		AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableNavigationController.swift; sourceTree = "<group>"; };
-		AE154B071C7880520093C05B /* FadeInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeInAnimator.swift; sourceTree = "<group>"; };
+		AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromLeftAnimator.swift; sourceTree = "<group>"; };
 		AE154B0F1C788A560093C05B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Transitions.storyboard; sourceTree = "<group>"; };
 		AE154B271C7BB52E0093C05B /* Typealias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Typealias.swift; sourceTree = "<group>"; };
 		AE154B2B1C7BB5760093C05B /* CALayerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CALayerExtension.swift; sourceTree = "<group>"; };
+		AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatable.swift; sourceTree = "<group>"; };
+		AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionAnimatableType.swift; sourceTree = "<group>"; };
+		AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromRightAnimator.swift; sourceTree = "<group>"; };
 		AE1878791C1A25C100300246 /* AnimatableStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableStackView.swift; sourceTree = "<group>"; };
 		AE18787B1C1D97F500300246 /* MaskDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskDesignable.swift; sourceTree = "<group>"; };
 		AE18787D1C1D980D00300246 /* MaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MaskType.swift; sourceTree = "<group>"; };
@@ -234,7 +243,8 @@
 		AE154B0B1C7880680093C05B /* animator */ = {
 			isa = PBXGroup;
 			children = (
-				AE154B071C7880520093C05B /* FadeInAnimator.swift */,
+				AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */,
+				AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */,
 			);
 			name = animator;
 			sourceTree = "<group>";
@@ -335,6 +345,7 @@
 				E2E28E6A1C6A6C30003F3852 /* GradientType.swift */,
 				E2472EA31C6F97F800A20E27 /* ColorType.swift */,
 				AE18787D1C1D980D00300246 /* MaskType.swift */,
+				AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */,
 			);
 			name = enum;
 			sourceTree = "<group>";
@@ -369,6 +380,7 @@
 			isa = PBXGroup;
 			children = (
 				AED1A10A1BFE983A001346FA /* Animatable.swift */,
+				AE154B7A1C7D04A40093C05B /* TransitionAnimatable.swift */,
 			);
 			name = Animatable;
 			sourceTree = "<group>";
@@ -522,6 +534,7 @@
 				AE6B01711C2A444900950BB2 /* PlaceholderDesignable.swift in Sources */,
 				AE6B01821C2A445100950BB2 /* AnimatableTableViewCell.swift in Sources */,
 				AE6B01691C2A444900950BB2 /* BorderDesignable.swift in Sources */,
+				AE154B821C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */,
 				E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */,
 				AE6B016C1C2A444900950BB2 /* FillDesignable.swift in Sources */,
 				AE6B01701C2A444900950BB2 /* PaddingDesignable.swift in Sources */,
@@ -531,12 +544,14 @@
 				AE6B01881C2A445800950BB2 /* UIViewController+UnwindSegue.swift in Sources */,
 				AE6B01771C2A444900950BB2 /* TintDesignable.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
-				AE154B081C7880520093C05B /* FadeInAnimator.swift in Sources */,
+				AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
+				AE154B081C7880520093C05B /* CubeFromLeftAnimator.swift in Sources */,
 				AE6B01641C2A444000950BB2 /* BorderSide.swift in Sources */,
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
 				AE6B016E1C2A444900950BB2 /* NavigationBarDesginable.swift in Sources */,
 				AE6B01861C2A445100950BB2 /* DesignableNavigationBar.swift in Sources */,
+				AE154B7F1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */,
 				AE6B016F1C2A444900950BB2 /* MaskDesignable.swift in Sources */,
 				AE6B01741C2A444900950BB2 /* SideImageDesignable.swift in Sources */,
 				AE6B017E1C2A445100950BB2 /* AnimatableImageView.swift in Sources */,
@@ -554,6 +569,7 @@
 				E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE154B281C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE81DAEE1C10F14C000AEB20 /* GradientDesignable.swift in Sources */,
+				AE154B7E1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */,
 				AE299BDA1C0338C70018CCDC /* BlurDesignable.swift in Sources */,
 				AE81DB501C12E060000AEB20 /* RotationDesignable.swift in Sources */,
 				AE74D6D71C166FB100718E0E /* SideImageDesignable.swift in Sources */,
@@ -572,8 +588,9 @@
 				AE8964DC1C2CC2E000D3E9F0 /* RootWindowDesignable.swift in Sources */,
 				E2E28E6E1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AED1A1161BFE983A001346FA /* Animatable.swift in Sources */,
+				AE154B811C7D08B30093C05B /* CubeFromRightAnimator.swift in Sources */,
 				AE8C53B01C0F1C0400A775AF /* GradientStartPoint.swift in Sources */,
-				AE154B0A1C78805C0093C05B /* FadeInAnimator.swift in Sources */,
+				AE154B0A1C78805C0093C05B /* CubeFromLeftAnimator.swift in Sources */,
 				AE0B0FF01C26655000E36B78 /* AnimatableLabel.swift in Sources */,
 				AE18787C1C1D97F500300246 /* MaskDesignable.swift in Sources */,
 				AED1A11D1BFE983A001346FA /* ShadowDesignable.swift in Sources */,
@@ -585,6 +602,7 @@
 				AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */,
 				AE0FAD431C1ED52800B5289B /* ViewControllerDesignable.swift in Sources */,
 				AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */,
+				AE154B7B1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
 				AE216FDD1C0DBC5D00BC6366 /* CornerDesignable.swift in Sources */,
 				AED1A11F1BFE983A001346FA /* PlaceholderDesignable.swift in Sources */,
 				AE3C54491C2180D500829B10 /* AnimatableBarButtonItem.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -112,8 +112,10 @@
 		AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */; };
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
+		CAB56443CD667F41413A560F /* CATransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* CATransitionType.swift */; };
 		CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */; };
 		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
+		CAB56E8FA0F35057290D67C4 /* CATransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* CATransitionType.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
@@ -194,6 +196,7 @@
 		AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarDesginable.swift; sourceTree = "<group>"; };
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
+		CAB56645FCD11BEC66200818 /* CATransitionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CATransitionType.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
@@ -367,6 +370,7 @@
 				E2472EA31C6F97F800A20E27 /* ColorType.swift */,
 				AE18787D1C1D980D00300246 /* MaskType.swift */,
 				AE154B7D1C7D061A0093C05B /* TransitionAnimatableType.swift */,
+				CAB56645FCD11BEC66200818 /* CATransitionType.swift */,
 			);
 			name = enum;
 			sourceTree = "<group>";
@@ -579,6 +583,7 @@
 				AE6B017E1C2A445100950BB2 /* AnimatableImageView.swift in Sources */,
 				AE6B01761C2A444900950BB2 /* TableViewCellDesignable.swift in Sources */,
 				CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */,
+				CAB56443CD667F41413A560F /* CATransitionType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -640,6 +645,7 @@
 				CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */,
 				AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */,
 				CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */,
+				CAB56E8FA0F35057290D67C4 /* CATransitionType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -111,9 +111,13 @@
 		AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED97B851C1710A900D2B0B8 /* BorderSide.swift */; };
 		AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */; };
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
+		CAB560F132D516C1D6DC6ADE /* CubeFromTopAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5682099C97D6B9AA87341 /* CubeFromTopAnimator.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56443CD667F41413A560F /* CATransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* CATransitionType.swift */; };
+		CAB565CD69E3F398329E926E /* CubeFromBottomAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB561BC1F7391FCD516BA65 /* CubeFromBottomAnimator.swift */; };
+		CAB5670EF177CDF085D2FDCB /* CubeFromBottomAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB561BC1F7391FCD516BA65 /* CubeFromBottomAnimator.swift */; };
 		CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */; };
+		CAB56B67A133B40140DCFD8E /* CubeFromTopAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5682099C97D6B9AA87341 /* CubeFromTopAnimator.swift */; };
 		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56E8FA0F35057290D67C4 /* CATransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* CATransitionType.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
@@ -195,8 +199,10 @@
 		AED97B851C1710A900D2B0B8 /* BorderSide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderSide.swift; sourceTree = "<group>"; };
 		AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarDesginable.swift; sourceTree = "<group>"; };
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
+		CAB561BC1F7391FCD516BA65 /* CubeFromBottomAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromBottomAnimator.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
 		CAB56645FCD11BEC66200818 /* CATransitionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CATransitionType.swift; sourceTree = "<group>"; };
+		CAB5682099C97D6B9AA87341 /* CubeFromTopAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CubeFromTopAnimator.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
@@ -255,10 +261,12 @@
 		AE154B0B1C7880680093C05B /* animator */ = {
 			isa = PBXGroup;
 			children = (
-				AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */,
-				AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */,
 				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
 				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
+				AE154B071C7880520093C05B /* CubeFromLeftAnimator.swift */,
+				AE154B801C7D08B30093C05B /* CubeFromRightAnimator.swift */,
+				CAB5682099C97D6B9AA87341 /* CubeFromTopAnimator.swift */,
+				CAB561BC1F7391FCD516BA65 /* CubeFromBottomAnimator.swift */,
 			);
 			name = animator;
 			sourceTree = "<group>";
@@ -584,6 +592,8 @@
 				AE6B01761C2A444900950BB2 /* TableViewCellDesignable.swift in Sources */,
 				CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */,
 				CAB56443CD667F41413A560F /* CATransitionType.swift in Sources */,
+				CAB56B67A133B40140DCFD8E /* CubeFromTopAnimator.swift in Sources */,
+				CAB565CD69E3F398329E926E /* CubeFromBottomAnimator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -646,6 +656,8 @@
 				AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */,
 				CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */,
 				CAB56E8FA0F35057290D67C4 /* CATransitionType.swift in Sources */,
+				CAB560F132D516C1D6DC6ADE /* CubeFromTopAnimator.swift in Sources */,
+				CAB5670EF177CDF085D2FDCB /* CubeFromBottomAnimator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBAnimatableApp/Base.lproj/Main.storyboard
+++ b/IBAnimatableApp/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -50,6 +50,9 @@
                                 <state key="normal" title="Forgot Password">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <segue destination="2i8-5x-idC" kind="show" id="pRb-pt-haD"/>
+                                </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wBb-ns-Bw1" customClass="AnimatableStackView" customModule="IBAnimatableApp" customModuleProvider="target">
                                 <rect key="frame" x="16" y="387" width="343" height="180"/>
@@ -4476,6 +4479,14 @@
                 <exit id="Lmb-XJ-KRv" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="5567.5" y="1234.5"/>
+        </scene>
+        <!--Transitions-->
+        <scene sceneID="IE3-a9-ajk">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Transitions" id="2i8-5x-idC" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JNa-0V-Cew" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3102.5" y="-255.5"/>
         </scene>
     </scenes>
     <resources>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -145,10 +145,10 @@
             </objects>
             <point key="canvasLocation" x="4451.5" y="-255.5"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Animatable Navigation Controller-->
         <scene sceneID="Ryf-4p-TtM">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="6OX-wo-iCM" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="6OX-wo-iCM" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="p1j-Ei-YPr">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -183,9 +183,6 @@
                     <nil name="viewControllers"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromLeft"/>
-                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
-                            <real key="value" value="3"/>
-                        </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -182,7 +182,7 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromLeft"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromTop"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -65,7 +65,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ShH-Bu-pJr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3102.5" y="-255.5"/>
+            <point key="canvasLocation" x="3205.5" y="-289.5"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="j4X-Oe-hEs">
@@ -79,12 +79,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kFy-ex-CKY" userLabel="Sign In" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="24" y="304" width="327" height="60"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kFy-ex-CKY" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="303" width="311" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="cES-w9-kDF"/>
                                 </constraints>
-                                <state key="normal" title="Tap to pop">
+                                <state key="normal" title="Tap to push">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -99,9 +99,9 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="kFy-ex-CKY" firstAttribute="leading" secondItem="OnE-aw-cD0" secondAttribute="leadingMargin" constant="8" id="Ox2-G5-mwd"/>
+                            <constraint firstItem="kFy-ex-CKY" firstAttribute="leading" secondItem="OnE-aw-cD0" secondAttribute="leadingMargin" constant="16" id="Ox2-G5-mwd"/>
                             <constraint firstItem="kFy-ex-CKY" firstAttribute="centerY" secondItem="OnE-aw-cD0" secondAttribute="centerY" id="efA-dj-Cqd"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="kFy-ex-CKY" secondAttribute="trailing" constant="8" id="gg1-8p-S2q"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="kFy-ex-CKY" secondAttribute="trailing" constant="16" id="gg1-8p-S2q"/>
                             <constraint firstItem="kFy-ex-CKY" firstAttribute="centerX" secondItem="OnE-aw-cD0" secondAttribute="centerX" id="npG-Gg-l7a"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
@@ -122,7 +122,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iNw-ov-HSV" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="mGz-2k-KHz" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="3998.5" y="-255.5"/>
+            <point key="canvasLocation" x="4074" y="-289"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="emT-DW-liW">
@@ -135,15 +135,41 @@
                     <view key="view" contentMode="scaleToFill" id="2wE-60-Psz" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nmd-hI-p2R" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="303.5" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="AFk-rh-3sU"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="Jr9-M0-K6n" kind="show" id="f4g-PY-43d"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="Nmd-hI-p2R" secondAttribute="trailing" constant="16" id="0xX-Z6-Lvy"/>
+                            <constraint firstItem="Nmd-hI-p2R" firstAttribute="centerY" secondItem="2wE-60-Psz" secondAttribute="centerY" id="N5j-CT-ZiW"/>
+                            <constraint firstItem="Nmd-hI-p2R" firstAttribute="centerX" secondItem="2wE-60-Psz" secondAttribute="centerX" id="fJg-LH-uHT"/>
+                            <constraint firstItem="Nmd-hI-p2R" firstAttribute="leading" secondItem="2wE-60-Psz" secondAttribute="leadingMargin" constant="16" id="wdh-vR-qjO"/>
+                        </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
                         </userDefinedRuntimeAttributes>
                     </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MwU-bg-SAk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4451.5" y="-255.5"/>
+            <point key="canvasLocation" x="4507.5" y="-289.5"/>
         </scene>
         <!--Animatable Navigation Controller-->
         <scene sceneID="Ryf-4p-TtM">
@@ -161,7 +187,57 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aut-7u-fEr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3548.5" y="-255.5"/>
+            <point key="canvasLocation" x="3638.5" y="-289.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="w9j-KN-ZrE">
+            <objects>
+                <viewController id="Jr9-M0-K6n" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="tdz-Jv-EtD"/>
+                        <viewControllerLayoutGuide type="bottom" id="GgG-Mi-ld8"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="LRM-UA-5Be" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kms-5b-dKQ" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="303.5" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="O0s-Uh-Y1N"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="jDB-Ur-y9F" kind="show" id="jmq-xh-2yp"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="Kms-5b-dKQ" firstAttribute="centerX" secondItem="LRM-UA-5Be" secondAttribute="centerX" id="KiJ-TS-CKA"/>
+                            <constraint firstItem="Kms-5b-dKQ" firstAttribute="leading" secondItem="LRM-UA-5Be" secondAttribute="leadingMargin" constant="16" id="gKn-ol-Dct"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Kms-5b-dKQ" secondAttribute="trailing" constant="16" id="qXh-0W-F7v"/>
+                            <constraint firstItem="Kms-5b-dKQ" firstAttribute="centerY" secondItem="LRM-UA-5Be" secondAttribute="centerY" id="yNn-wo-FFX"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatClouds"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5Td-V3-Teq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4938.5" y="-289.5"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="ftd-QI-Jx6"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -23,7 +23,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="FadeIn" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="No1-bE-wbP">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromLeft" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="No1-bE-wbP">
                                                     <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -36,21 +36,65 @@
                                             <segue destination="6OX-wo-iCM" kind="show" id="HOm-gh-tlN"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Z5Y-2f-RwJ">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="qgE-dG-LF9" style="IBUITableViewCellStyleDefault" id="nj5-cf-pNc">
                                         <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Z5Y-2f-RwJ" id="1vl-7U-Xwt">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nj5-cf-pNc" id="8Su-qC-Aml">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromRight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qgE-dG-LF9">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="pIx-bo-hWN" kind="show" id="lA5-u4-6F4"/>
+                                        </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="rjT-V2-Q32">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="9ls-iI-4fp" style="IBUITableViewCellStyleDefault" id="qwH-na-sDL">
                                         <rect key="frame" x="0.0" y="88" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rjT-V2-Q32" id="Z4F-vQ-Zyg">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qwH-na-sDL" id="jed-Wd-EXL">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromTop" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9ls-iI-4fp">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="7gB-lA-7u1" kind="show" id="QcN-dt-Net"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="Xgd-rs-g1J" style="IBUITableViewCellStyleDefault" id="zIp-1C-FRq">
+                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zIp-1C-FRq" id="Iia-28-Snv">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromBottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xgd-rs-g1J">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="U4T-2U-1G1" kind="show" id="QvV-qW-WoQ"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -182,7 +226,7 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromTop"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromLeft"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>
@@ -239,8 +283,545 @@
             </objects>
             <point key="canvasLocation" x="4938.5" y="-289.5"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="zkz-0D-pHw">
+            <objects>
+                <viewController id="wt3-fV-ipe" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="3Qf-56-Fn7"/>
+                        <viewControllerLayoutGuide type="bottom" id="21u-hQ-Oja"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="mIW-jy-9dw" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6uK-2O-45G" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="i6z-CI-E1w"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="XxR-ur-0cL" kind="show" id="0zV-vG-a8x">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="6uK-2O-45G" firstAttribute="leading" secondItem="mIW-jy-9dw" secondAttribute="leadingMargin" constant="16" id="3LN-he-OpD"/>
+                            <constraint firstItem="6uK-2O-45G" firstAttribute="centerX" secondItem="mIW-jy-9dw" secondAttribute="centerX" id="3P3-09-CIj"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="6uK-2O-45G" secondAttribute="trailing" constant="16" id="F62-bN-pcA"/>
+                            <constraint firstItem="6uK-2O-45G" firstAttribute="centerY" secondItem="mIW-jy-9dw" secondAttribute="centerY" id="TMQ-UC-IL8"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="ARa-tX-fGh">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="2QH-Y4-gBU">
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="8wB-pd-gpg" kind="unwind" unwindAction="dismissCurrentViewController:" id="gEA-sG-Pg3"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yFb-gB-tom" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="8wB-pd-gpg" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4073.5" y="456.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="RTy-q8-Qlx">
+            <objects>
+                <viewController id="XxR-ur-0cL" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="12o-aW-aIP"/>
+                        <viewControllerLayoutGuide type="bottom" id="gKO-AG-WEC"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="jdr-rX-mzb" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6VQ-5l-IB7" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="DOH-MQ-7Ll"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="7X1-vi-zAZ" kind="show" id="qIE-bw-FGH">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="centerY" secondItem="jdr-rX-mzb" secondAttribute="centerY" id="9Sa-K3-OfM"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="6VQ-5l-IB7" secondAttribute="trailing" constant="16" id="HJK-wF-peo"/>
+                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="centerX" secondItem="jdr-rX-mzb" secondAttribute="centerX" id="JaW-uJ-18s"/>
+                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="leading" secondItem="jdr-rX-mzb" secondAttribute="leadingMargin" constant="16" id="wvm-ui-WBO"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tN5-lJ-KuM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4507.5" y="455.5"/>
+        </scene>
+        <!--Animatable Navigation Controller-->
+        <scene sceneID="qOL-WV-HTi">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pIx-bo-hWN" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="100-lD-2V2">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromRight"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <segue destination="wt3-fV-ipe" kind="relationship" relationship="rootViewController" id="W6n-br-1tp"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="R4N-oZ-Bvn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3637.5" y="455.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="MOI-ky-v9m">
+            <objects>
+                <viewController id="7X1-vi-zAZ" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="WVl-jP-qo6"/>
+                        <viewControllerLayoutGuide type="bottom" id="2dC-Kz-fML"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="zgQ-d2-NZQ" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uo7-BE-L9r" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="kEv-XA-Qlo"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="XxR-ur-0cL" kind="show" id="eEs-IF-sK1">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="uo7-BE-L9r" firstAttribute="leading" secondItem="zgQ-d2-NZQ" secondAttribute="leadingMargin" constant="16" id="ESj-bZ-nmM"/>
+                            <constraint firstItem="uo7-BE-L9r" firstAttribute="centerY" secondItem="zgQ-d2-NZQ" secondAttribute="centerY" id="G28-au-4Qh"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="uo7-BE-L9r" secondAttribute="trailing" constant="16" id="S4w-P9-v5d"/>
+                            <constraint firstItem="uo7-BE-L9r" firstAttribute="centerX" secondItem="zgQ-d2-NZQ" secondAttribute="centerX" id="vEM-lw-dnU"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Wdp-9w-M8M" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4938.5" y="456.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="BSR-YF-MqV">
+            <objects>
+                <viewController id="lRF-8T-oRc" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Cc5-M9-i2T"/>
+                        <viewControllerLayoutGuide type="bottom" id="12s-eR-J7Y"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="6H9-y6-hdA" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="olh-AF-frb" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="clH-0e-Hx1"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="hjA-pQ-id2" kind="show" id="j7j-cv-Wcs">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="olh-AF-frb" firstAttribute="leading" secondItem="6H9-y6-hdA" secondAttribute="leadingMargin" constant="16" id="TYd-b4-e9a"/>
+                            <constraint firstItem="olh-AF-frb" firstAttribute="centerX" secondItem="6H9-y6-hdA" secondAttribute="centerX" id="e6S-Ka-Zwf"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="olh-AF-frb" secondAttribute="trailing" constant="16" id="g18-cF-Rzs"/>
+                            <constraint firstItem="olh-AF-frb" firstAttribute="centerY" secondItem="6H9-y6-hdA" secondAttribute="centerY" id="yHE-jy-lGJ"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="Qjb-Ri-BqK">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="dTc-Bw-f4o">
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="DNv-of-qHq" kind="unwind" unwindAction="dismissCurrentViewController:" id="qdK-j0-ioQ"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="EN1-U4-AJ6" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="DNv-of-qHq" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4073.5" y="1181.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="kme-nr-oXD">
+            <objects>
+                <viewController id="hjA-pQ-id2" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="OJ5-Mu-XYw"/>
+                        <viewControllerLayoutGuide type="bottom" id="vyQ-AX-fsR"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="pGJ-I2-Yme" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XC2-gV-KZd" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="Ymn-Qu-Yts"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="eTT-2F-Col" kind="show" id="llL-Dq-Cbg">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="XC2-gV-KZd" firstAttribute="centerX" secondItem="pGJ-I2-Yme" secondAttribute="centerX" id="6Vw-46-5mQ"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="XC2-gV-KZd" secondAttribute="trailing" constant="16" id="B03-fV-Fxt"/>
+                            <constraint firstItem="XC2-gV-KZd" firstAttribute="centerY" secondItem="pGJ-I2-Yme" secondAttribute="centerY" id="ipm-Ed-afP"/>
+                            <constraint firstItem="XC2-gV-KZd" firstAttribute="leading" secondItem="pGJ-I2-Yme" secondAttribute="leadingMargin" constant="16" id="xzD-gm-fAt"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6dE-6P-yqM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4507.5" y="1181.5"/>
+        </scene>
+        <!--Animatable Navigation Controller-->
+        <scene sceneID="qUz-Kk-AT5">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="7gB-lA-7u1" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="JpT-1e-ezZ">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromTop"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <segue destination="lRF-8T-oRc" kind="relationship" relationship="rootViewController" id="N5Q-Kf-pgc"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SrX-Ad-7Cs" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3638.5" y="1181.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="qDB-fZ-lGR">
+            <objects>
+                <viewController id="eTT-2F-Col" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="QGT-g6-LG4"/>
+                        <viewControllerLayoutGuide type="bottom" id="iwM-AV-JXx"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="dq2-OI-lEO" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-QL-RfN" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="UeV-QQ-5ad"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="hjA-pQ-id2" kind="show" id="eHd-rU-6Jd">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="Ezc-QL-RfN" secondAttribute="trailing" constant="16" id="KZu-TG-34Q"/>
+                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="centerY" secondItem="dq2-OI-lEO" secondAttribute="centerY" id="Kfa-dw-F9n"/>
+                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="centerX" secondItem="dq2-OI-lEO" secondAttribute="centerX" id="RmA-8k-Twv"/>
+                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="leading" secondItem="dq2-OI-lEO" secondAttribute="leadingMargin" constant="16" id="yjU-FJ-KxY"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="k4o-oE-Ynl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4938.5" y="1181.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="7cO-4l-3Gk">
+            <objects>
+                <viewController id="OOs-Ks-dfG" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="tE8-M7-Qtd"/>
+                        <viewControllerLayoutGuide type="bottom" id="Tah-on-p0P"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="T1u-4V-MrQ" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xsr-Of-sFh" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="vHk-Ll-xew"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="Ra6-Uz-2x2" kind="show" id="aTe-dj-ZDJ">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="centerY" secondItem="T1u-4V-MrQ" secondAttribute="centerY" id="8vk-8F-70d"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Xsr-Of-sFh" secondAttribute="trailing" constant="16" id="Wsu-7q-VFB"/>
+                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="centerX" secondItem="T1u-4V-MrQ" secondAttribute="centerX" id="lkl-Ni-m2G"/>
+                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="leading" secondItem="T1u-4V-MrQ" secondAttribute="leadingMargin" constant="16" id="nst-SC-via"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="8W3-Y5-383">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="jfV-nc-Bxa">
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="I6E-3F-98f" kind="unwind" unwindAction="dismissCurrentViewController:" id="GBV-bc-hgD"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="nQE-Wy-xYF" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="I6E-3F-98f" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4073.5" y="1926.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="R4R-1Q-thB">
+            <objects>
+                <viewController id="Ra6-Uz-2x2" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="bGe-Dd-xRH"/>
+                        <viewControllerLayoutGuide type="bottom" id="4RH-KN-alU"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="tYl-mR-A8l" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6lL-np-eaw" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="biw-fE-Qqn"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="uzv-bm-0GO" kind="show" id="W9e-AJ-whj">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="6lL-np-eaw" firstAttribute="centerX" secondItem="tYl-mR-A8l" secondAttribute="centerX" id="AmS-zZ-Rmj"/>
+                            <constraint firstItem="6lL-np-eaw" firstAttribute="leading" secondItem="tYl-mR-A8l" secondAttribute="leadingMargin" constant="16" id="P6v-pZ-5MM"/>
+                            <constraint firstItem="6lL-np-eaw" firstAttribute="centerY" secondItem="tYl-mR-A8l" secondAttribute="centerY" id="YuF-dR-zJn"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="6lL-np-eaw" secondAttribute="trailing" constant="16" id="rgk-Mc-LQB"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mGU-VZ-dXR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4507.5" y="1926.5"/>
+        </scene>
+        <!--Animatable Navigation Controller-->
+        <scene sceneID="o5b-xL-yU1">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="U4T-2U-1G1" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="a02-g7-W4t">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromBottom"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <segue destination="OOs-Ks-dfG" kind="relationship" relationship="rootViewController" id="PKr-78-Bfo"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4jP-rx-4Xn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3638.5" y="1926.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="iAS-4C-XWE">
+            <objects>
+                <viewController id="uzv-bm-0GO" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="gpH-cU-jnq"/>
+                        <viewControllerLayoutGuide type="bottom" id="tGh-Zj-fWs"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Q9K-Wx-ALF" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V3H-rC-JH2" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="Gew-aw-pQh"/>
+                                </constraints>
+                                <state key="normal" title="Tap to push">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="Ra6-Uz-2x2" kind="show" id="ZI6-kP-eKH">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="V3H-rC-JH2" firstAttribute="centerY" secondItem="Q9K-Wx-ALF" secondAttribute="centerY" id="1db-FP-77H"/>
+                            <constraint firstItem="V3H-rC-JH2" firstAttribute="leading" secondItem="Q9K-Wx-ALF" secondAttribute="leadingMargin" constant="16" id="2MY-ZM-P9o"/>
+                            <constraint firstItem="V3H-rC-JH2" firstAttribute="centerX" secondItem="Q9K-Wx-ALF" secondAttribute="centerX" id="R3d-sB-Pe0"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="V3H-rC-JH2" secondAttribute="trailing" constant="16" id="ZJO-nE-vOu"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2qt-PY-eRd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4938.5" y="1926.5"/>
+        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
+        <segue reference="j7j-cv-Wcs"/>
+        <segue reference="aTe-dj-ZDJ"/>
+        <segue reference="0zV-vG-a8x"/>
         <segue reference="jmq-xh-2yp"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -40,7 +40,7 @@
                                         <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Z5Y-2f-RwJ" id="1vl-7U-Xwt">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -48,7 +48,7 @@
                                         <rect key="frame" x="0.0" y="88" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rjT-V2-Q32" id="Z4F-vQ-Zyg">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -137,7 +137,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nmd-hI-p2R" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="303.5" width="311" height="60"/>
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="AFk-rh-3sU"/>
                                 </constraints>
@@ -181,6 +181,12 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromLeft"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="3"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>
                     </connections>
@@ -202,7 +208,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kms-5b-dKQ" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="303.5" width="311" height="60"/>
+                                <rect key="frame" x="32" y="304" width="311" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="O0s-Uh-Y1N"/>
                                 </constraints>
@@ -227,7 +233,7 @@
                             <constraint firstItem="Kms-5b-dKQ" firstAttribute="centerY" secondItem="LRM-UA-5Be" secondAttribute="centerY" id="yNn-wo-FFX"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatClouds"/>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
@@ -238,6 +244,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="ftd-QI-Jx6"/>
+        <segue reference="jmq-xh-2yp"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="oAB-Bz-TaE">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <scenes>
+        <!--Table View Controller-->
+        <scene sceneID="q1o-VY-0TT">
+            <objects>
+                <tableViewController id="oAB-Bz-TaE" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NP4-Ex-cLZ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="Brh-KC-NRg">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="No1-bE-wbP" style="IBUITableViewCellStyleDefault" id="d16-xz-tg5">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d16-xz-tg5" id="EOb-bR-emF">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="FadeIn" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="No1-bE-wbP">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="6OX-wo-iCM" kind="show" id="HOm-gh-tlN"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Z5Y-2f-RwJ">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Z5Y-2f-RwJ" id="1vl-7U-Xwt">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="rjT-V2-Q32">
+                                        <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rjT-V2-Q32" id="Z4F-vQ-Zyg">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="oAB-Bz-TaE" id="siJ-Yh-bzI"/>
+                            <outlet property="delegate" destination="oAB-Bz-TaE" id="Kgq-Zw-1ML"/>
+                        </connections>
+                    </tableView>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ShH-Bu-pJr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3102.5" y="-255.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="j4X-Oe-hEs">
+            <objects>
+                <viewController id="NTx-bf-G81" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="G7z-Tg-1Gv"/>
+                        <viewControllerLayoutGuide type="bottom" id="Kjd-MK-vGJ"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="OnE-aw-cD0" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kFy-ex-CKY" userLabel="Sign In" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="24" y="304" width="327" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="cES-w9-kDF"/>
+                                </constraints>
+                                <state key="normal" title="Tap to pop">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="jDB-Ur-y9F" kind="show" id="ftd-QI-Jx6"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="kFy-ex-CKY" firstAttribute="leading" secondItem="OnE-aw-cD0" secondAttribute="leadingMargin" constant="8" id="Ox2-G5-mwd"/>
+                            <constraint firstItem="kFy-ex-CKY" firstAttribute="centerY" secondItem="OnE-aw-cD0" secondAttribute="centerY" id="efA-dj-Cqd"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="kFy-ex-CKY" secondAttribute="trailing" constant="8" id="gg1-8p-S2q"/>
+                            <constraint firstItem="kFy-ex-CKY" firstAttribute="centerX" secondItem="OnE-aw-cD0" secondAttribute="centerX" id="npG-Gg-l7a"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="oeS-US-PEg">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="4AM-Wn-dMe">
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="mGz-2k-KHz" kind="unwind" unwindAction="dismissCurrentViewController:" id="hFN-Rv-Lnf"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iNw-ov-HSV" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="mGz-2k-KHz" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="3998.5" y="-255.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="emT-DW-liW">
+            <objects>
+                <viewController id="jDB-Ur-y9F" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="llV-0i-zPQ"/>
+                        <viewControllerLayoutGuide type="bottom" id="ztb-jM-jZh"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="2wE-60-Psz" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MwU-bg-SAk" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4451.5" y="-255.5"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Ryf-4p-TtM">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="6OX-wo-iCM" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="p1j-Ei-YPr">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aut-7u-fEr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3548.5" y="-255.5"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
There is the first PR to support custom transition animations. It has a flexible architecture to support more custom transitions.

`AnimatableNavigationController` is a subclass of `UINavigationController`, it has two IBInspectable properties:
`transitionAnimationType` for `TransitionAnimationType` and `transitionDuration` for duration

Currently, we have four custom animations: `CubeFromLeft`, `CubeFromRight`, `CubeFromTop` and `CubeFromBottom`. Will add a lot more animations soon.

To see those supported custom transition animations in the demo App. Tap on "Forgot Password" button in the login screen.

relate to https://github.com/JakeLin/IBAnimatable/issues/19
