### PR TITLE
Present Segue

### DIFF
--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -28,7 +28,7 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
     var duration = transitionDuration
     // Set the default duration for transition
     if transitionDuration.isNaN {
-      duration = 0.35
+      duration = defaultTransitionDuration
     }
     navigator = Navigator(transitionAnimationType: animationType, transitionDuration: duration)
     delegate = navigator

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -62,7 +62,7 @@ import UIKit
     var duration = transitionDuration
     // Set the default duration for transition
     if transitionDuration.isNaN {
-      duration = 0.35 
+      duration = defaultTransitionDuration
     }
     presenter = Presenter(transitionAnimationType: animationType, transitionDuration: duration)
   }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -8,6 +8,10 @@ import UIKit
  Animator Factory
  */
 struct AnimatorFactory {
+  static func generateAnimator(transitionAnimationType: TransitionAnimationType) -> AnimatedTransitioning {
+    return generateAnimator(transitionAnimationType, transitionDuration: defaultTransitionDuration)
+  }
+
   static func generateAnimator(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) -> AnimatedTransitioning {
     switch transitionAnimationType {
     case .Fade:

--- a/IBAnimatable/Constants.swift
+++ b/IBAnimatable/Constants.swift
@@ -1,0 +1,9 @@
+//
+// Created by Jake Lin on 2/29/16.
+// Copyright (c) 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+// Default transition duration.
+let defaultTransitionDuration: Duration = 0.35

--- a/IBAnimatable/DismissSegue.swift
+++ b/IBAnimatable/DismissSegue.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 public class DismissSegue: UIStoryboardSegue {
-  override public func perform() {
-    sourceViewController.presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
+  public override func perform() {
+    sourceViewController.dismissViewControllerAnimated(true, completion: nil)
   }
 }

--- a/IBAnimatable/FadeAnimator.swift
+++ b/IBAnimatable/FadeAnimator.swift
@@ -8,7 +8,7 @@ import UIKit
 public class FadeAnimator: NSObject , AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   public var transitionAnimationType: TransitionAnimationType
-  public var transitionDuration: Duration = 0.35
+  public var transitionDuration: Duration = defaultTransitionDuration
   public var reverseAnimationType: TransitionAnimationType?
 
   // MARK: - private

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -10,9 +10,9 @@ import UIKit
  */
 public class Navigator: NSObject {
   var transitionAnimationType: TransitionAnimationType
-  var transitionDuration: Duration
+  var transitionDuration: Duration = defaultTransitionDuration
 
-  public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) {
+  public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration) {
     self.transitionAnimationType = transitionAnimationType
     self.transitionDuration = transitionDuration
     super.init()

--- a/IBAnimatable/PresentFadeInSegue.swift
+++ b/IBAnimatable/PresentFadeInSegue.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Jake Lin on 2/29/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentFadeInSegue: UIStoryboardSegue {
+  @IBInspectable var duration: Double = 0.5
+  
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.FadeIn)
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentFadeOutSegue.swift
+++ b/IBAnimatable/PresentFadeOutSegue.swift
@@ -1,0 +1,13 @@
+//
+//  Created by Jake Lin on 2/29/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentFadeOutSegue: UIStoryboardSegue {
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.FadeOut)
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentFadeSegue.swift
+++ b/IBAnimatable/PresentFadeSegue.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Jake Lin on 2/28/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+var fade: Presenter?
+public class PresentFadeSegue: UIStoryboardSegue {
+  public override func perform() {
+    fade = Presenter(transitionAnimationType: .Fade, transitionDuration: 0.35)
+    destinationViewController.transitioningDelegate = fade
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentFadeSegue.swift
+++ b/IBAnimatable/PresentFadeSegue.swift
@@ -8,7 +8,7 @@ import UIKit
 var fade: Presenter?
 public class PresentFadeSegue: UIStoryboardSegue {
   public override func perform() {
-    fade = Presenter(transitionAnimationType: .Fade, transitionDuration: 0.35)
+    fade = Presenter(transitionAnimationType: .Fade, transitionDuration: defaultTransitionDuration)
     destinationViewController.transitioningDelegate = fade
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }

--- a/IBAnimatable/PresentFadeSegue.swift
+++ b/IBAnimatable/PresentFadeSegue.swift
@@ -5,11 +5,9 @@
 
 import UIKit
 
-var fade: Presenter?
 public class PresentFadeSegue: UIStoryboardSegue {
   public override func perform() {
-    fade = Presenter(transitionAnimationType: .Fade, transitionDuration: defaultTransitionDuration)
-    destinationViewController.transitioningDelegate = fade
+      destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fade)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/Presenter.swift
+++ b/IBAnimatable/Presenter.swift
@@ -10,9 +10,9 @@ import UIKit
  */
 public class Presenter: NSObject {
   var transitionAnimationType: TransitionAnimationType
-  var transitionDuration: Duration
+  var transitionDuration: Duration = defaultTransitionDuration
 
-  public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) {
+  public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration) {
     self.transitionAnimationType = transitionAnimationType
     self.transitionDuration = transitionDuration
     super.init()

--- a/IBAnimatable/PresenterManager.swift
+++ b/IBAnimatable/PresenterManager.swift
@@ -1,0 +1,38 @@
+//
+//  Created by Jake Lin on 2/29/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Presenter Manager: Used to cache the Presenters for Present and Dismiss transitions
+ */
+struct PresenterManager {
+  // MARK: - Singleton Constructor
+  private init() {}
+  private struct Shared {
+    static let instance = PresenterManager()
+  }
+  internal static func sharedManager() -> PresenterManager {
+    return Shared.instance
+  }
+  
+  // MARK: - Private
+  private let cache = NSCache()
+  
+  // MARK: Inertnal Interface
+  func retrievePresenter(transitionAnimationType: TransitionAnimationType) -> Presenter {
+    // Get the cached presenter
+    let presenter = cache.objectForKey(transitionAnimationType.rawValue) as? Presenter
+    if let presenter = presenter {
+      return presenter
+    }
+    
+    // Create a new if cache doesn't exist
+    let newPresenter = Presenter(transitionAnimationType: transitionAnimationType)
+    cache.setObject(newPresenter, forKey: transitionAnimationType.rawValue)
+    return newPresenter
+  }
+  
+}

--- a/IBAnimatable/PresenterManager.swift
+++ b/IBAnimatable/PresenterManager.swift
@@ -8,7 +8,7 @@ import Foundation
 /**
  Presenter Manager: Used to cache the Presenters for Present and Dismiss transitions
  */
-struct PresenterManager {
+class PresenterManager {
   // MARK: - Singleton Constructor
   private init() {}
   private struct Shared {
@@ -19,20 +19,19 @@ struct PresenterManager {
   }
   
   // MARK: - Private
-  private let cache = NSCache()
+  private var cache = [TransitionAnimationType: Presenter]()
   
   // MARK: Inertnal Interface
   func retrievePresenter(transitionAnimationType: TransitionAnimationType) -> Presenter {
     // Get the cached presenter
-    let presenter = cache.objectForKey(transitionAnimationType.rawValue) as? Presenter
+    let presenter = cache[transitionAnimationType]
     if let presenter = presenter {
       return presenter
     }
     
     // Create a new if cache doesn't exist
     let newPresenter = Presenter(transitionAnimationType: transitionAnimationType)
-    cache.setObject(newPresenter, forKey: transitionAnimationType.rawValue)
+    cache[transitionAnimationType] = newPresenter
     return newPresenter
   }
-  
 }

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -10,7 +10,7 @@ import UIKit
 public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   public var transitionAnimationType: TransitionAnimationType
-  public var transitionDuration: Duration = 0.35
+  public var transitionDuration: Duration = defaultTransitionDuration
   public var reverseAnimationType: TransitionAnimationType?
   
   // MARK: - private

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -11,7 +11,7 @@ import UIKit
 public class SystemFlipAnimator: NSObject, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   public var transitionAnimationType: TransitionAnimationType
-  public var transitionDuration: Duration = 0.35
+  public var transitionDuration: Duration = defaultTransitionDuration
   public var reverseAnimationType: TransitionAnimationType?
   
   // MARK: - private

--- a/IBAnimatable/UIViewControllerExtension.swift
+++ b/IBAnimatable/UIViewControllerExtension.swift
@@ -11,6 +11,6 @@ public extension UIViewController {
   }
   
   @IBAction public func dismissCurrentViewController(sender: UIStoryboardSegue) {
-    sender.destinationViewController.dismissViewControllerAnimated(true, completion: nil)
+    sender.sourceViewController.dismissViewControllerAnimated(true, completion: nil)
   }
 }

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -110,6 +110,10 @@
 		AED1A11D1BFE983A001346FA /* ShadowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A1111BFE983A001346FA /* ShadowDesignable.swift */; };
 		AED1A11E1BFE983A001346FA /* PaddingDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A1121BFE983A001346FA /* PaddingDesignable.swift */; };
 		AED1A11F1BFE983A001346FA /* PlaceholderDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A1131BFE983A001346FA /* PlaceholderDesignable.swift */; };
+		AED5F6911C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED5F6901C83E9B60052E57B /* PresentFadeInSegue.swift */; };
+		AED5F6921C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED5F6901C83E9B60052E57B /* PresentFadeInSegue.swift */; };
+		AED5F6941C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED5F6931C83E9C20052E57B /* PresentFadeOutSegue.swift */; };
+		AED5F6951C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED5F6931C83E9C20052E57B /* PresentFadeOutSegue.swift */; };
 		AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED97B851C1710A900D2B0B8 /* BorderSide.swift */; };
 		AEDD8A311C7EDAE30033175A /* SystemFlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */; };
 		AEDD8A321C7EDAE30033175A /* SystemFlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */; };
@@ -207,6 +211,8 @@
 		AED1A1111BFE983A001346FA /* ShadowDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShadowDesignable.swift; path = IBAnimatable/ShadowDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AED1A1121BFE983A001346FA /* PaddingDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PaddingDesignable.swift; path = IBAnimatable/PaddingDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AED1A1131BFE983A001346FA /* PlaceholderDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PlaceholderDesignable.swift; path = IBAnimatable/PlaceholderDesignable.swift; sourceTree = SOURCE_ROOT; };
+		AED5F6901C83E9B60052E57B /* PresentFadeInSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFadeInSegue.swift; sourceTree = "<group>"; };
+		AED5F6931C83E9C20052E57B /* PresentFadeOutSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFadeOutSegue.swift; sourceTree = "<group>"; };
 		AED97B851C1710A900D2B0B8 /* BorderSide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderSide.swift; sourceTree = "<group>"; };
 		AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemFlipAnimator.swift; sourceTree = "<group>"; };
 		AEE552A61C815AC5009CF623 /* FadeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeAnimator.swift; sourceTree = "<group>"; };
@@ -261,6 +267,8 @@
 			children = (
 				AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */,
 				AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */,
+				AED5F6901C83E9B60052E57B /* PresentFadeInSegue.swift */,
+				AED5F6931C83E9C20052E57B /* PresentFadeOutSegue.swift */,
 			);
 			name = segue;
 			sourceTree = "<group>";
@@ -560,6 +568,7 @@
 			files = (
 				AE6B017C1C2A445100950BB2 /* AnimatableButton.swift in Sources */,
 				AEE552B11C839EB7009CF623 /* PresenterManager.swift in Sources */,
+				AED5F6921C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */,
 				AE6B01721C2A444900950BB2 /* RotationDesignable.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
@@ -603,6 +612,7 @@
 				AE6B01881C2A445800950BB2 /* UIViewControllerExtension.swift in Sources */,
 				AE6B01771C2A444900950BB2 /* TintDesignable.swift in Sources */,
 				AE154B8F1C7D89CB0093C05B /* Presenter.swift in Sources */,
+				AED5F6951C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
 				AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
 				AE6B01641C2A444000950BB2 /* BorderSide.swift in Sources */,
@@ -647,6 +657,7 @@
 				AE154B2C1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
 				AED1A1171BFE983A001346FA /* AnimatableImageView.swift in Sources */,
 				AE3C54471C217F7F00829B10 /* BarButtonItemDesignable.swift in Sources */,
+				AED5F6911C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */,
 				AE0B0FEA1C25372200E36B78 /* TableViewCellDesignable.swift in Sources */,
 				AE18787E1C1D980D00300246 /* MaskType.swift in Sources */,
 				AED1A1191BFE983A001346FA /* AnimatableTextView.swift in Sources */,
@@ -679,6 +690,7 @@
 				AE154B841C7D1A740093C05B /* AnimatedTransitioning.swift in Sources */,
 				AED1A1151BFE983A001346FA /* AnimatableButton.swift in Sources */,
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
+				AED5F6941C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,
 				AEE552B01C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AEE552A71C815AC5009CF623 /* FadeAnimator.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		AEE552AB1C816233009CF623 /* TransitionFadeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552A91C816233009CF623 /* TransitionFadeType.swift */; };
 		AEE552AD1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
 		AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
+		AEE552B01C839EB7009CF623 /* PresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* PresenterManager.swift */; };
+		AEE552B11C839EB7009CF623 /* PresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* PresenterManager.swift */; };
 		AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */; };
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
@@ -210,6 +212,7 @@
 		AEE552A61C815AC5009CF623 /* FadeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeAnimator.swift; sourceTree = "<group>"; };
 		AEE552A91C816233009CF623 /* TransitionFadeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionFadeType.swift; sourceTree = "<group>"; };
 		AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFadeSegue.swift; sourceTree = "<group>"; };
+		AEE552AF1C839EB7009CF623 /* PresenterManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresenterManager.swift; sourceTree = "<group>"; };
 		AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarDesginable.swift; sourceTree = "<group>"; };
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
@@ -277,6 +280,7 @@
 				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
 				AE154B8D1C7D89CB0093C05B /* Presenter.swift */,
 				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
+				AEE552AF1C839EB7009CF623 /* PresenterManager.swift */,
 				AEE552A61C815AC5009CF623 /* FadeAnimator.swift */,
 				33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */,
 				AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */,
@@ -555,6 +559,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE6B017C1C2A445100950BB2 /* AnimatableButton.swift in Sources */,
+				AEE552B11C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AE6B01721C2A444900950BB2 /* RotationDesignable.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
@@ -675,6 +680,7 @@
 				AED1A1151BFE983A001346FA /* AnimatableButton.swift in Sources */,
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,
+				AEE552B01C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AEE552A71C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */,
 				AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552A61C815AC5009CF623 /* FadeAnimator.swift */; };
 		AEE552AA1C816233009CF623 /* TransitionFadeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552A91C816233009CF623 /* TransitionFadeType.swift */; };
 		AEE552AB1C816233009CF623 /* TransitionFadeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552A91C816233009CF623 /* TransitionFadeType.swift */; };
+		AEE552AD1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
+		AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
 		AEEE200B1C18CFD200AD033B /* NavigationBarDesginable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */; };
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
@@ -205,6 +207,7 @@
 		AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemFlipAnimator.swift; sourceTree = "<group>"; };
 		AEE552A61C815AC5009CF623 /* FadeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeAnimator.swift; sourceTree = "<group>"; };
 		AEE552A91C816233009CF623 /* TransitionFadeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionFadeType.swift; sourceTree = "<group>"; };
+		AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFadeSegue.swift; sourceTree = "<group>"; };
 		AEEE200A1C18CFD200AD033B /* NavigationBarDesginable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarDesginable.swift; sourceTree = "<group>"; };
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
@@ -251,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */,
+				AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */,
 			);
 			name = segue;
 			sourceTree = "<group>";
@@ -573,6 +577,7 @@
 				33A8B9ED1C7E790800082529 /* SystemCubeAnimator.swift in Sources */,
 				AE6B017D1C2A445100950BB2 /* AnimatableCheckBox.swift in Sources */,
 				AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
+				AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */,
 				E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AEDD8A321C7EDAE30033175A /* SystemFlipAnimator.swift in Sources */,
 				AE6B01681C2A444900950BB2 /* BlurDesignable.swift in Sources */,
@@ -646,6 +651,7 @@
 				AED1A11C1BFE983A001346FA /* BorderDesignable.swift in Sources */,
 				AE3C54451C21439100829B10 /* AnimatableTableViewCell.swift in Sources */,
 				AE299BDC1C03BB670018CCDC /* TintDesignable.swift in Sources */,
+				AEE552AD1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */,
 				AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */,
 				AE18787A1C1A25C100300246 /* AnimatableStackView.swift in Sources */,
 				AEE552AA1C816233009CF623 /* TransitionFadeType.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -123,9 +123,11 @@
 		AEEE200D1C18D10C00AD033B /* DesignableNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
+		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */; };
 		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56E8FA0F35057290D67C4 /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
+		CAB56F164EE0CC8E0510FEC6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
@@ -213,6 +215,7 @@
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
 		CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemTransitionType.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
 		E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatColorsTypeScript.swift; path = Scripts/FlatColorsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -281,12 +284,13 @@
 			name = animator;
 			sourceTree = "<group>";
 		};
-		AE154B2A1C7BB5370093C05B /* typealias */ = {
+		AE154B2A1C7BB5370093C05B /* common */ = {
 			isa = PBXGroup;
 			children = (
 				AE154B271C7BB52E0093C05B /* Typealias.swift */,
+				CAB56A8BA4FB110D501DC1DC /* Constants.swift */,
 			);
-			name = typealias;
+			name = common;
 			sourceTree = "<group>";
 		};
 		AE154B861C7D1AA10093C05B /* TransitionAnimatable */ = {
@@ -342,7 +346,7 @@
 				AE154B0B1C7880680093C05B /* animator */,
 				AE0FAD391C1ECA2900B5289B /* extension */,
 				AE0FAD3E1C1ED26A00B5289B /* segue */,
-				AE154B2A1C7BB5370093C05B /* typealias */,
+				AE154B2A1C7BB5370093C05B /* common */,
 				E2E28E701C6A6E5E003F3852 /* scripts */,
 			);
 			path = IBAnimatable;
@@ -609,6 +613,7 @@
 				AE6B01761C2A444900950BB2 /* TableViewCellDesignable.swift in Sources */,
 				CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */,
 				CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */,
+				CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -676,6 +681,7 @@
 				33A8B9EF1C7E7A4C00082529 /* TransitionFromDirection.swift in Sources */,
 				CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */,
 				CAB56E8FA0F35057290D67C4 /* SystemTransitionType.swift in Sources */,
+				CAB56F164EE0CC8E0510FEC6 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -436,37 +436,52 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4lU-N7-UdB" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="40" y="304" width="295" height="60"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="0Gp-E2-vhb">
+                                <rect key="frame" x="40" y="259" width="295" height="150"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4lU-N7-UdB" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="295" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="Gu3-mh-kVd"/>
+                                        </constraints>
+                                        <state key="normal" title="Tap to dismiss">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="emc-Jl-Ob8" kind="unwind" unwindAction="unwindToViewController:" id="9Y9-p6-lA4"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="06m-hU-WYa" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="90" width="295" height="60"/>
+                                        <state key="normal" title="Tap to present another">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="J3N-gN-3lD" kind="custom" customClass="PresentFadeOutSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="pEU-RW-fT6"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="Gu3-mh-kVd"/>
+                                    <constraint firstItem="06m-hU-WYa" firstAttribute="height" secondItem="4lU-N7-UdB" secondAttribute="height" id="u0C-se-1HM"/>
                                 </constraints>
-                                <state key="normal" title="Tap to dismiss">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="emc-Jl-Ob8" kind="unwind" unwindAction="unwindToViewController:" id="9Y9-p6-lA4"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iRw-lc-RKk">
-                                <rect key="frame" x="158" y="389" width="46" height="30"/>
-                                <state key="normal" title="Button"/>
-                                <connections>
-                                    <segue destination="J3N-gN-3lD" kind="custom" customClass="PresentFadeInSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="cWZ-Ht-hKk"/>
-                                </connections>
-                            </button>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="4lU-N7-UdB" firstAttribute="centerY" secondItem="Ya9-02-nKR" secondAttribute="centerY" id="9FV-qJ-9QK"/>
-                            <constraint firstItem="4lU-N7-UdB" firstAttribute="centerX" secondItem="Ya9-02-nKR" secondAttribute="centerX" id="F22-2D-A01"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="4lU-N7-UdB" secondAttribute="trailing" constant="24" id="PVV-9q-gyy"/>
-                            <constraint firstItem="4lU-N7-UdB" firstAttribute="leading" secondItem="Ya9-02-nKR" secondAttribute="leadingMargin" constant="24" id="nPT-4A-Gs1"/>
+                            <constraint firstItem="0Gp-E2-vhb" firstAttribute="centerX" secondItem="Ya9-02-nKR" secondAttribute="centerX" id="JJG-AU-4gO"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="0Gp-E2-vhb" secondAttribute="trailing" constant="24" id="aKF-X8-ai6"/>
+                            <constraint firstItem="0Gp-E2-vhb" firstAttribute="centerY" secondItem="Ya9-02-nKR" secondAttribute="centerY" id="gh7-6I-bXi"/>
+                            <constraint firstItem="0Gp-E2-vhb" firstAttribute="leading" secondItem="Ya9-02-nKR" secondAttribute="leadingMargin" constant="24" id="yDl-7D-bYX"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="predefinedGradient" value="Candy"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -165,7 +165,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="9Qt-ed-0ZI" kind="presentation" customClass="PresentFadeSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="WyK-21-zHP"/>
+                                            <segue destination="9Qt-ed-0ZI" kind="custom" customClass="PresentFadeInSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="WyK-21-zHP"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -437,7 +437,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4lU-N7-UdB" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="40" y="303" width="295" height="60"/>
+                                <rect key="frame" x="40" y="304" width="295" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="Gu3-mh-kVd"/>
                                 </constraints>
@@ -450,7 +450,14 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="emc-Jl-Ob8" kind="unwind" unwindAction="unwindToViewController:" id="OXb-L3-H56"/>
+                                    <segue destination="emc-Jl-Ob8" kind="unwind" unwindAction="unwindToViewController:" id="9Y9-p6-lA4"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iRw-lc-RKk">
+                                <rect key="frame" x="158" y="389" width="46" height="30"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <segue destination="J3N-gN-3lD" kind="custom" customClass="PresentFadeInSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="cWZ-Ht-hKk"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -465,11 +472,12 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="predefinedGradient" value="Candy"/>
                         </userDefinedRuntimeAttributes>
                     </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L8b-q3-z0V" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="emc-Jl-Ob8" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="5411.5" y="-268.5"/>
+            <point key="canvasLocation" x="5400.5" y="-281.5"/>
         </scene>
         <!--Animatable Navigation Controller-->
         <scene sceneID="qOL-WV-HTi">
@@ -915,6 +923,54 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xig-Zd-fJP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2775.5" y="-281.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="bf7-Dg-a9m">
+            <objects>
+                <viewController id="J3N-gN-3lD" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="OjE-jf-D7p"/>
+                        <viewControllerLayoutGuide type="bottom" id="Dxn-mh-kw0"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="wii-JR-fVE" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M39-se-qo0" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
+                                <rect key="frame" x="40" y="304" width="295" height="60"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="kLq-6u-aZW"/>
+                                </constraints>
+                                <state key="normal" title="Tap to dismiss">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="nWz-fC-GLe" kind="unwind" unwindAction="unwindToViewController:" id="3Sw-tX-AL6"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="M39-se-qo0" firstAttribute="centerY" secondItem="wii-JR-fVE" secondAttribute="centerY" id="70p-b1-5UL"/>
+                            <constraint firstItem="M39-se-qo0" firstAttribute="leading" secondItem="wii-JR-fVE" secondAttribute="leadingMargin" constant="24" id="Bkq-ci-sZz"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="M39-se-qo0" secondAttribute="trailing" constant="24" id="Iq8-yT-O9i"/>
+                            <constraint firstItem="M39-se-qo0" firstAttribute="centerX" secondItem="wii-JR-fVE" secondAttribute="centerX" id="xCo-dq-N0O"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedGradient" value="Moss"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yqc-zm-1iX" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="nWz-fC-GLe" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="5846.5" y="-281.5"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -20,11 +20,11 @@
                                         <rect key="frame" x="0.0" y="64" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d16-xz-tg5" id="EOb-bR-emF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromLeft" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="No1-bE-wbP">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -40,11 +40,11 @@
                                         <rect key="frame" x="0.0" y="108" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nj5-cf-pNc" id="8Su-qC-Aml">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromRight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qgE-dG-LF9">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -60,11 +60,11 @@
                                         <rect key="frame" x="0.0" y="152" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qwH-na-sDL" id="jed-Wd-EXL">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromTop" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9ls-iI-4fp">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -80,11 +80,11 @@
                                         <rect key="frame" x="0.0" y="196" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zIp-1C-FRq" id="Iia-28-Snv">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromBottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xgd-rs-g1J">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -165,7 +165,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="9Qt-ed-0ZI" kind="presentation" id="WyK-21-zHP"/>
+                                            <segue destination="9Qt-ed-0ZI" kind="presentation" customClass="PresentFadeSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="WyK-21-zHP"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -195,9 +195,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Fade"/>
-                    </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iNw-ov-HSV" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="mGz-2k-KHz" userLabel="Exit" sceneMemberID="exit"/>
@@ -440,7 +437,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4lU-N7-UdB" userLabel="present" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="40" y="304" width="295" height="60"/>
+                                <rect key="frame" x="40" y="303" width="295" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="Gu3-mh-kVd"/>
                                 </constraints>


### PR DESCRIPTION
In this PR, we add `PresentFadeSegue`, `PresentFadeInSegue` and `PresentFadeOutSegue` to present viewController with Fade, FadeIn and FadeOut transition animations. Also update the transition.story to test these transitions. Now can we use segue to configure a custom present transition. Because Segue doesn't support IBInspectable, all segues have to use default duration 0.35. 

Will work Transition playground to demonstrate all supported transition animations.

Relate to #19 
