### PR TITLE
Transition playground

### DIFF
--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -40,6 +40,7 @@ import UIKit
 
   public override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType(rawValue: transitionAnimationType) else {
+      super.prepareForSegue(segue, sender: sender)
       return
     }
     

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -39,6 +39,7 @@ import UIKit
   }
 
   public override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    // Configure custom transition animation
     guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType(rawValue: transitionAnimationType) else {
       super.prepareForSegue(segue, sender: sender)
       return

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -20,11 +20,6 @@ import UIKit
   @IBInspectable public var transitionDuration: Double = .NaN
 
   // MARK: - Lifecylce
-  public override func viewDidLoad() {
-    super.viewDidLoad()
-    configureTransitioningDelegate()
-  }
-
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
     confingHideNavigationBar()
@@ -44,26 +39,13 @@ import UIKit
   }
 
   public override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-    let toViewController = segue.destinationViewController
-    toViewController.transitioningDelegate = presenter
-
-    super.prepareForSegue(segue, sender: sender)
-  }
-
-  // MARK: - Private
-  // Must have a property to keep the reference alive because `UIViewController.transitioningDelegate` is `weak`
-  private var presenter: Presenter?
-
-  private func configureTransitioningDelegate() {
     guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType(rawValue: transitionAnimationType) else {
       return
     }
     
-    var duration = transitionDuration
-    // Set the default duration for transition
-    if transitionDuration.isNaN {
-      duration = defaultTransitionDuration
-    }
-    presenter = Presenter(transitionAnimationType: animationType, transitionDuration: duration)
+    let toViewController = segue.destinationViewController
+    toViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(animationType, transitionDuration: transitionDuration)
+
+    super.prepareForSegue(segue, sender: sender)
   }
 }

--- a/IBAnimatable/PresenterManager.swift
+++ b/IBAnimatable/PresenterManager.swift
@@ -22,15 +22,18 @@ class PresenterManager {
   private var cache = [TransitionAnimationType: Presenter]()
   
   // MARK: Inertnal Interface
-  func retrievePresenter(transitionAnimationType: TransitionAnimationType) -> Presenter {
+  func retrievePresenter(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration) -> Presenter {
     // Get the cached presenter
     let presenter = cache[transitionAnimationType]
     if let presenter = presenter {
+      // Update the duration every time to reuse the same one with the same type
+      presenter.transitionDuration = transitionDuration
       return presenter
     }
     
     // Create a new if cache doesn't exist
     let newPresenter = Presenter(transitionAnimationType: transitionAnimationType)
+    newPresenter.transitionDuration = transitionDuration
     cache[transitionAnimationType] = newPresenter
     return newPresenter
   }

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -29,15 +29,15 @@ public class SystemFlipAnimator: NSObject, AnimatedTransitioning {
       self.animationOption = .TransitionFlipFromLeft
     case .FromRight:
       self.transitionAnimationType = .SystemFlipFromRight
-      self.reverseAnimationType = .SystemFlipFromRight
+      self.reverseAnimationType = .SystemFlipFromLeft
       self.animationOption = .TransitionFlipFromRight
     case .FromTop:
       self.transitionAnimationType = .SystemFlipFromTop
-      self.reverseAnimationType = .SystemFlipFromRight
+      self.reverseAnimationType = .SystemFlipFromBottom
       self.animationOption = .TransitionFlipFromTop
     case .FromBottom:
       self.transitionAnimationType = .SystemFlipFromBottom
-      self.reverseAnimationType = .SystemFlipFromRight
+      self.reverseAnimationType = .SystemFlipFromTop
       self.animationOption = .TransitionFlipFromBottom
     }
     

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		AE81DB501C12E060000AEB20 /* RotationDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE81DB4F1C12E060000AEB20 /* RotationDesignable.swift */; };
 		AE8964DB1C2CC0D100D3E9F0 /* RootWindowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */; };
 		AE8964DC1C2CC2E000D3E9F0 /* RootWindowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */; };
+		AE8A4FFA1C856EEC00E9E368 /* TransitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8A4FF91C856EEC00E9E368 /* TransitionViewController.swift */; };
 		AE8C53B01C0F1C0400A775AF /* GradientStartPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */; };
 		AE8FBAA91C853C7A00EB8AEA /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8FBAA81C853C7A00EB8AEA /* Functions.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
@@ -197,6 +198,7 @@
 		AE81DB4D1C11DF00000AEB20 /* BlurEffectStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BlurEffectStyle.swift; path = IBAnimatable/BlurEffectStyle.swift; sourceTree = SOURCE_ROOT; };
 		AE81DB4F1C12E060000AEB20 /* RotationDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RotationDesignable.swift; path = IBAnimatable/RotationDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootWindowDesignable.swift; path = IBAnimatable/RootWindowDesignable.swift; sourceTree = SOURCE_ROOT; };
+		AE8A4FF91C856EEC00E9E368 /* TransitionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionViewController.swift; sourceTree = "<group>"; };
 		AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientStartPoint.swift; path = IBAnimatable/GradientStartPoint.swift; sourceTree = SOURCE_ROOT; };
 		AE8FBAA81C853C7A00EB8AEA /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
@@ -321,8 +323,9 @@
 		AE6C21071C842A1500DB6892 /* code */ = {
 			isa = PBXGroup;
 			children = (
-				AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */,
 				AE8FBAA81C853C7A00EB8AEA /* Functions.swift */,
+				AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */,
+				AE8A4FF91C856EEC00E9E368 /* TransitionViewController.swift */,
 			);
 			name = code;
 			sourceTree = "<group>";
@@ -655,6 +658,7 @@
 				E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */,
 				E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE154B281C7BB52E0093C05B /* Typealias.swift in Sources */,
+				AE8A4FFA1C856EEC00E9E368 /* TransitionViewController.swift in Sources */,
 				AE81DAEE1C10F14C000AEB20 /* GradientDesignable.swift in Sources */,
 				AE154B8E1C7D89CB0093C05B /* Presenter.swift in Sources */,
 				AE154B7E1C7D061A0093C05B /* TransitionAnimatableType.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		AE8964DB1C2CC0D100D3E9F0 /* RootWindowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */; };
 		AE8964DC1C2CC2E000D3E9F0 /* RootWindowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */; };
 		AE8C53B01C0F1C0400A775AF /* GradientStartPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */; };
+		AE8FBAA91C853C7A00EB8AEA /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8FBAA81C853C7A00EB8AEA /* Functions.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
 		AED1A1051BFE9820001346FA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */; };
@@ -197,6 +198,7 @@
 		AE81DB4F1C12E060000AEB20 /* RotationDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RotationDesignable.swift; path = IBAnimatable/RotationDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootWindowDesignable.swift; path = IBAnimatable/RootWindowDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientStartPoint.swift; path = IBAnimatable/GradientStartPoint.swift; sourceTree = SOURCE_ROOT; };
+		AE8FBAA81C853C7A00EB8AEA /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		AED1A0FE1BFE9820001346FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -316,12 +318,13 @@
 			name = TransitionAnimatable;
 			sourceTree = "<group>";
 		};
-		AE6C21071C842A1500DB6892 /* controller */ = {
+		AE6C21071C842A1500DB6892 /* code */ = {
 			isa = PBXGroup;
 			children = (
 				AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */,
+				AE8FBAA81C853C7A00EB8AEA /* Functions.swift */,
 			);
-			name = controller;
+			name = code;
 			sourceTree = "<group>";
 		};
 		AE6C66F61BFBF93500134A35 = {
@@ -354,7 +357,7 @@
 				AED1A0FF1BFE9820001346FA /* Main.storyboard */,
 				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
-				AE6C21071C842A1500DB6892 /* controller */,
+				AE6C21071C842A1500DB6892 /* code */,
 			);
 			path = IBAnimatableApp;
 			sourceTree = "<group>";
@@ -682,6 +685,7 @@
 				AED1A11D1BFE983A001346FA /* ShadowDesignable.swift in Sources */,
 				AED1A1181BFE983A001346FA /* AnimatableTextField.swift in Sources */,
 				AED1A11C1BFE983A001346FA /* BorderDesignable.swift in Sources */,
+				AE8FBAA91C853C7A00EB8AEA /* Functions.swift in Sources */,
 				AE3C54451C21439100829B10 /* AnimatableTableViewCell.swift in Sources */,
 				AE299BDC1C03BB670018CCDC /* TintDesignable.swift in Sources */,
 				AEE552AD1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		AE6B01871C2A445400950BB2 /* AnimatableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD401C1ED41D00B5289B /* AnimatableViewController.swift */; };
 		AE6B01881C2A445800950BB2 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */; };
 		AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */; };
+		AE6C21061C842A0F00DB6892 /* TransitionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */; };
 		AE74D6D71C166FB100718E0E /* SideImageDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE74D6D61C166FB100718E0E /* SideImageDesignable.swift */; };
 		AE81DAEE1C10F14C000AEB20 /* GradientDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE81DAED1C10F14C000AEB20 /* GradientDesignable.swift */; };
 		AE81DB4E1C11DF00000AEB20 /* BlurEffectStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE81DB4D1C11DF00000AEB20 /* BlurEffectStyle.swift */; };
@@ -188,6 +189,7 @@
 		AE3C54461C217F7F00829B10 /* BarButtonItemDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonItemDesignable.swift; sourceTree = "<group>"; };
 		AE3C54481C2180D500829B10 /* AnimatableBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableBarButtonItem.swift; sourceTree = "<group>"; };
 		AE6B01551C2A082300950BB2 /* IBAnimatable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IBAnimatable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionTableViewController.swift; sourceTree = "<group>"; };
 		AE6C66FF1BFBF93500134A35 /* IBAnimatableApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IBAnimatableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE74D6D61C166FB100718E0E /* SideImageDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideImageDesignable.swift; sourceTree = "<group>"; };
 		AE81DAED1C10F14C000AEB20 /* GradientDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientDesignable.swift; path = IBAnimatable/GradientDesignable.swift; sourceTree = SOURCE_ROOT; };
@@ -314,6 +316,14 @@
 			name = TransitionAnimatable;
 			sourceTree = "<group>";
 		};
+		AE6C21071C842A1500DB6892 /* controller */ = {
+			isa = PBXGroup;
+			children = (
+				AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */,
+			);
+			name = controller;
+			sourceTree = "<group>";
+		};
 		AE6C66F61BFBF93500134A35 = {
 			isa = PBXGroup;
 			children = (
@@ -344,6 +354,7 @@
 				AED1A0FF1BFE9820001346FA /* Main.storyboard */,
 				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
+				AE6C21071C842A1500DB6892 /* controller */,
 			);
 			path = IBAnimatableApp;
 			sourceTree = "<group>";
@@ -662,6 +673,7 @@
 				AE18787E1C1D980D00300246 /* MaskType.swift in Sources */,
 				AED1A1191BFE983A001346FA /* AnimatableTextView.swift in Sources */,
 				AE8964DC1C2CC2E000D3E9F0 /* RootWindowDesignable.swift in Sources */,
+				AE6C21061C842A0F00DB6892 /* TransitionTableViewController.swift in Sources */,
 				E2E28E6E1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AED1A1161BFE983A001346FA /* Animatable.swift in Sources */,
 				AE8C53B01C0F1C0400A775AF /* GradientStartPoint.swift in Sources */,

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -8,7 +8,7 @@
         <!--Transitions-->
         <scene sceneID="q1o-VY-0TT">
             <objects>
-                <tableViewController id="oAB-Bz-TaE" sceneMemberID="viewController">
+                <tableViewController id="oAB-Bz-TaE" customClass="TransitionTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NP4-Ex-cLZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -18,11 +18,11 @@
                                 <rect key="frame" x="0.0" y="92" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gTl-GY-SNY" id="qhN-8T-xDf">
-                                    <rect key="frame" x="0.0" y="0.0" width="342" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mDV-Ii-W8m">
-                                            <rect key="frame" x="15" y="0.0" width="325" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="325" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -197,9 +197,6 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="FadeOut"/>
-                    </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="NTx-bf-G81" kind="relationship" relationship="rootViewController" id="3Ez-j6-isk"/>
                     </connections>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -133,6 +133,9 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <connections>
+                        <outlet property="presentButton" destination="59W-58-R6i" id="k5T-Fs-g03"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iNw-ov-HSV" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="mGz-2k-KHz" userLabel="Exit" sceneMemberID="exit"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -9,96 +9,33 @@
         <scene sceneID="q1o-VY-0TT">
             <objects>
                 <tableViewController id="oAB-Bz-TaE" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NP4-Ex-cLZ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NP4-Ex-cLZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <sections>
-                            <tableViewSection id="Brh-KC-NRg">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="No1-bE-wbP" style="IBUITableViewCellStyleDefault" id="d16-xz-tg5">
-                                        <rect key="frame" x="0.0" y="64" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d16-xz-tg5" id="EOb-bR-emF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromLeft" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="No1-bE-wbP">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="6OX-wo-iCM" kind="showDetail" id="HOm-gh-tlN"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="qgE-dG-LF9" style="IBUITableViewCellStyleDefault" id="nj5-cf-pNc">
-                                        <rect key="frame" x="0.0" y="108" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nj5-cf-pNc" id="8Su-qC-Aml">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromRight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qgE-dG-LF9">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="pIx-bo-hWN" kind="show" id="lA5-u4-6F4"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="9ls-iI-4fp" style="IBUITableViewCellStyleDefault" id="qwH-na-sDL">
-                                        <rect key="frame" x="0.0" y="152" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qwH-na-sDL" id="jed-Wd-EXL">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromTop" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9ls-iI-4fp">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="7gB-lA-7u1" kind="show" id="QcN-dt-Net"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="Xgd-rs-g1J" style="IBUITableViewCellStyleDefault" id="zIp-1C-FRq">
-                                        <rect key="frame" x="0.0" y="196" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zIp-1C-FRq" id="Iia-28-Snv">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="CubeFromBottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xgd-rs-g1J">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="U4T-2U-1G1" kind="show" id="QvV-qW-WoQ"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                        </sections>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mDV-Ii-W8m" style="IBUITableViewCellStyleDefault" id="gTl-GY-SNY">
+                                <rect key="frame" x="0.0" y="92" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gTl-GY-SNY" id="qhN-8T-xDf">
+                                    <rect key="frame" x="0.0" y="0.0" width="342" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mDV-Ii-W8m">
+                                            <rect key="frame" x="15" y="0.0" width="325" height="43"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="6OX-wo-iCM" kind="show" id="JfO-bv-zah"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <sections/>
                         <connections>
                             <outlet property="dataSource" destination="oAB-Bz-TaE" id="siJ-Yh-bzI"/>
                             <outlet property="delegate" destination="oAB-Bz-TaE" id="Kgq-Zw-1ML"/>
@@ -195,11 +132,12 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iNw-ov-HSV" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="mGz-2k-KHz" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4073.5" y="-281.5"/>
+            <point key="canvasLocation" x="4094.5" y="-281.5"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="emT-DW-liW">
@@ -246,13 +184,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MwU-bg-SAk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4507.5" y="-281.5"/>
+            <point key="canvasLocation" x="4567.5" y="-667.5"/>
         </scene>
         <!--Animatable Navigation Controller-->
         <scene sceneID="Ryf-4p-TtM">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="6OX-wo-iCM" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="p1j-Ei-YPr">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -267,7 +206,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aut-7u-fEr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3638.5" y="-281.5"/>
+            <point key="canvasLocation" x="3648.5" y="-281.5"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="w9j-KN-ZrE">
@@ -314,115 +253,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5Td-V3-Teq" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4938.5" y="-281.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="zkz-0D-pHw">
-            <objects>
-                <viewController id="wt3-fV-ipe" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="3Qf-56-Fn7"/>
-                        <viewControllerLayoutGuide type="bottom" id="21u-hQ-Oja"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="mIW-jy-9dw" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6uK-2O-45G" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="i6z-CI-E1w"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="XxR-ur-0cL" kind="show" id="0zV-vG-a8x">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="6uK-2O-45G" firstAttribute="leading" secondItem="mIW-jy-9dw" secondAttribute="leadingMargin" constant="16" id="3LN-he-OpD"/>
-                            <constraint firstItem="6uK-2O-45G" firstAttribute="centerX" secondItem="mIW-jy-9dw" secondAttribute="centerX" id="3P3-09-CIj"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="6uK-2O-45G" secondAttribute="trailing" constant="16" id="F62-bN-pcA"/>
-                            <constraint firstItem="6uK-2O-45G" firstAttribute="centerY" secondItem="mIW-jy-9dw" secondAttribute="centerY" id="TMQ-UC-IL8"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <toolbarItems/>
-                    <navigationItem key="navigationItem" id="ARa-tX-fGh">
-                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="2QH-Y4-gBU">
-                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                            <connections>
-                                <segue destination="8wB-pd-gpg" kind="unwind" unwindAction="dismissCurrentViewController:" id="gEA-sG-Pg3"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="yFb-gB-tom" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="8wB-pd-gpg" userLabel="Exit" sceneMemberID="exit"/>
-            </objects>
-            <point key="canvasLocation" x="4073.5" y="467.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="RTy-q8-Qlx">
-            <objects>
-                <viewController id="XxR-ur-0cL" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="12o-aW-aIP"/>
-                        <viewControllerLayoutGuide type="bottom" id="gKO-AG-WEC"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="jdr-rX-mzb" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6VQ-5l-IB7" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="DOH-MQ-7Ll"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="7X1-vi-zAZ" kind="show" id="qIE-bw-FGH">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="centerY" secondItem="jdr-rX-mzb" secondAttribute="centerY" id="9Sa-K3-OfM"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="6VQ-5l-IB7" secondAttribute="trailing" constant="16" id="HJK-wF-peo"/>
-                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="centerX" secondItem="jdr-rX-mzb" secondAttribute="centerX" id="JaW-uJ-18s"/>
-                            <constraint firstItem="6VQ-5l-IB7" firstAttribute="leading" secondItem="jdr-rX-mzb" secondAttribute="leadingMargin" constant="16" id="wvm-ui-WBO"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="tN5-lJ-KuM" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4507.5" y="466.5"/>
+            <point key="canvasLocation" x="5034.5" y="-667.5"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="D7y-Bi-dz5">
@@ -492,433 +323,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L8b-q3-z0V" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="emc-Jl-Ob8" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="5400.5" y="-281.5"/>
-        </scene>
-        <!--Animatable Navigation Controller-->
-        <scene sceneID="qOL-WV-HTi">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pIx-bo-hWN" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="100-lD-2V2">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromRight"/>
-                    </userDefinedRuntimeAttributes>
-                    <connections>
-                        <segue destination="wt3-fV-ipe" kind="relationship" relationship="rootViewController" id="W6n-br-1tp"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="R4N-oZ-Bvn" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3637.5" y="466.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="MOI-ky-v9m">
-            <objects>
-                <viewController id="7X1-vi-zAZ" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="WVl-jP-qo6"/>
-                        <viewControllerLayoutGuide type="bottom" id="2dC-Kz-fML"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="zgQ-d2-NZQ" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uo7-BE-L9r" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="kEv-XA-Qlo"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="XxR-ur-0cL" kind="show" id="eEs-IF-sK1">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="uo7-BE-L9r" firstAttribute="leading" secondItem="zgQ-d2-NZQ" secondAttribute="leadingMargin" constant="16" id="ESj-bZ-nmM"/>
-                            <constraint firstItem="uo7-BE-L9r" firstAttribute="centerY" secondItem="zgQ-d2-NZQ" secondAttribute="centerY" id="G28-au-4Qh"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="uo7-BE-L9r" secondAttribute="trailing" constant="16" id="S4w-P9-v5d"/>
-                            <constraint firstItem="uo7-BE-L9r" firstAttribute="centerX" secondItem="zgQ-d2-NZQ" secondAttribute="centerX" id="vEM-lw-dnU"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Wdp-9w-M8M" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4938.5" y="467.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="BSR-YF-MqV">
-            <objects>
-                <viewController id="lRF-8T-oRc" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Cc5-M9-i2T"/>
-                        <viewControllerLayoutGuide type="bottom" id="12s-eR-J7Y"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="6H9-y6-hdA" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="olh-AF-frb" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="clH-0e-Hx1"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="hjA-pQ-id2" kind="show" id="j7j-cv-Wcs">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="olh-AF-frb" firstAttribute="leading" secondItem="6H9-y6-hdA" secondAttribute="leadingMargin" constant="16" id="TYd-b4-e9a"/>
-                            <constraint firstItem="olh-AF-frb" firstAttribute="centerX" secondItem="6H9-y6-hdA" secondAttribute="centerX" id="e6S-Ka-Zwf"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="olh-AF-frb" secondAttribute="trailing" constant="16" id="g18-cF-Rzs"/>
-                            <constraint firstItem="olh-AF-frb" firstAttribute="centerY" secondItem="6H9-y6-hdA" secondAttribute="centerY" id="yHE-jy-lGJ"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <toolbarItems/>
-                    <navigationItem key="navigationItem" id="Qjb-Ri-BqK">
-                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="dTc-Bw-f4o">
-                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                            <connections>
-                                <segue destination="DNv-of-qHq" kind="unwind" unwindAction="dismissCurrentViewController:" id="qdK-j0-ioQ"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="EN1-U4-AJ6" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="DNv-of-qHq" userLabel="Exit" sceneMemberID="exit"/>
-            </objects>
-            <point key="canvasLocation" x="4073.5" y="1181.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="kme-nr-oXD">
-            <objects>
-                <viewController id="hjA-pQ-id2" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="OJ5-Mu-XYw"/>
-                        <viewControllerLayoutGuide type="bottom" id="vyQ-AX-fsR"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="pGJ-I2-Yme" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XC2-gV-KZd" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="Ymn-Qu-Yts"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="eTT-2F-Col" kind="show" id="llL-Dq-Cbg">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="XC2-gV-KZd" firstAttribute="centerX" secondItem="pGJ-I2-Yme" secondAttribute="centerX" id="6Vw-46-5mQ"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="XC2-gV-KZd" secondAttribute="trailing" constant="16" id="B03-fV-Fxt"/>
-                            <constraint firstItem="XC2-gV-KZd" firstAttribute="centerY" secondItem="pGJ-I2-Yme" secondAttribute="centerY" id="ipm-Ed-afP"/>
-                            <constraint firstItem="XC2-gV-KZd" firstAttribute="leading" secondItem="pGJ-I2-Yme" secondAttribute="leadingMargin" constant="16" id="xzD-gm-fAt"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="6dE-6P-yqM" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4507.5" y="1181.5"/>
-        </scene>
-        <!--Animatable Navigation Controller-->
-        <scene sceneID="qUz-Kk-AT5">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="7gB-lA-7u1" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="JpT-1e-ezZ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromTop"/>
-                    </userDefinedRuntimeAttributes>
-                    <connections>
-                        <segue destination="lRF-8T-oRc" kind="relationship" relationship="rootViewController" id="N5Q-Kf-pgc"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="SrX-Ad-7Cs" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3638.5" y="1181.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="qDB-fZ-lGR">
-            <objects>
-                <viewController id="eTT-2F-Col" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="QGT-g6-LG4"/>
-                        <viewControllerLayoutGuide type="bottom" id="iwM-AV-JXx"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="dq2-OI-lEO" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezc-QL-RfN" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="UeV-QQ-5ad"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="hjA-pQ-id2" kind="show" id="eHd-rU-6Jd">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstAttribute="trailingMargin" secondItem="Ezc-QL-RfN" secondAttribute="trailing" constant="16" id="KZu-TG-34Q"/>
-                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="centerY" secondItem="dq2-OI-lEO" secondAttribute="centerY" id="Kfa-dw-F9n"/>
-                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="centerX" secondItem="dq2-OI-lEO" secondAttribute="centerX" id="RmA-8k-Twv"/>
-                            <constraint firstItem="Ezc-QL-RfN" firstAttribute="leading" secondItem="dq2-OI-lEO" secondAttribute="leadingMargin" constant="16" id="yjU-FJ-KxY"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="k4o-oE-Ynl" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4938.5" y="1181.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="7cO-4l-3Gk">
-            <objects>
-                <viewController id="OOs-Ks-dfG" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="tE8-M7-Qtd"/>
-                        <viewControllerLayoutGuide type="bottom" id="Tah-on-p0P"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="T1u-4V-MrQ" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xsr-Of-sFh" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="vHk-Ll-xew"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="Ra6-Uz-2x2" kind="show" id="aTe-dj-ZDJ">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="centerY" secondItem="T1u-4V-MrQ" secondAttribute="centerY" id="8vk-8F-70d"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Xsr-Of-sFh" secondAttribute="trailing" constant="16" id="Wsu-7q-VFB"/>
-                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="centerX" secondItem="T1u-4V-MrQ" secondAttribute="centerX" id="lkl-Ni-m2G"/>
-                            <constraint firstItem="Xsr-Of-sFh" firstAttribute="leading" secondItem="T1u-4V-MrQ" secondAttribute="leadingMargin" constant="16" id="nst-SC-via"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <toolbarItems/>
-                    <navigationItem key="navigationItem" id="8W3-Y5-383">
-                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="jfV-nc-Bxa">
-                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                            <connections>
-                                <segue destination="I6E-3F-98f" kind="unwind" unwindAction="dismissCurrentViewController:" id="GBV-bc-hgD"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="nQE-Wy-xYF" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="I6E-3F-98f" userLabel="Exit" sceneMemberID="exit"/>
-            </objects>
-            <point key="canvasLocation" x="4073.5" y="1926.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="R4R-1Q-thB">
-            <objects>
-                <viewController id="Ra6-Uz-2x2" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="bGe-Dd-xRH"/>
-                        <viewControllerLayoutGuide type="bottom" id="4RH-KN-alU"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="tYl-mR-A8l" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6lL-np-eaw" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="biw-fE-Qqn"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="uzv-bm-0GO" kind="show" id="W9e-AJ-whj">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="6lL-np-eaw" firstAttribute="centerX" secondItem="tYl-mR-A8l" secondAttribute="centerX" id="AmS-zZ-Rmj"/>
-                            <constraint firstItem="6lL-np-eaw" firstAttribute="leading" secondItem="tYl-mR-A8l" secondAttribute="leadingMargin" constant="16" id="P6v-pZ-5MM"/>
-                            <constraint firstItem="6lL-np-eaw" firstAttribute="centerY" secondItem="tYl-mR-A8l" secondAttribute="centerY" id="YuF-dR-zJn"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="6lL-np-eaw" secondAttribute="trailing" constant="16" id="rgk-Mc-LQB"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatBelizeHole"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="mGU-VZ-dXR" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4507.5" y="1926.5"/>
-        </scene>
-        <!--Animatable Navigation Controller-->
-        <scene sceneID="o5b-xL-yU1">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="U4T-2U-1G1" customClass="AnimatableNavigationController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="a02-g7-W4t">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="CubeFromBottom"/>
-                    </userDefinedRuntimeAttributes>
-                    <connections>
-                        <segue destination="OOs-Ks-dfG" kind="relationship" relationship="rootViewController" id="PKr-78-Bfo"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="4jP-rx-4Xn" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3638.5" y="1926.5"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="iAS-4C-XWE">
-            <objects>
-                <viewController id="uzv-bm-0GO" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="gpH-cU-jnq"/>
-                        <viewControllerLayoutGuide type="bottom" id="tGh-Zj-fWs"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="Q9K-Wx-ALF" customClass="AnimatableView" customModule="IBAnimatableApp" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V3H-rC-JH2" userLabel="pop" customClass="AnimatableButton" customModule="IBAnimatableApp" customModuleProvider="target">
-                                <rect key="frame" x="32" y="304" width="311" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="Gew-aw-pQh"/>
-                                </constraints>
-                                <state key="normal" title="Tap to push">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="Ra6-Uz-2x2" kind="show" id="ZI6-kP-eKH">
-                                        <nil key="action"/>
-                                    </segue>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="V3H-rC-JH2" firstAttribute="centerY" secondItem="Q9K-Wx-ALF" secondAttribute="centerY" id="1db-FP-77H"/>
-                            <constraint firstItem="V3H-rC-JH2" firstAttribute="leading" secondItem="Q9K-Wx-ALF" secondAttribute="leadingMargin" constant="16" id="2MY-ZM-P9o"/>
-                            <constraint firstItem="V3H-rC-JH2" firstAttribute="centerX" secondItem="Q9K-Wx-ALF" secondAttribute="centerX" id="R3d-sB-Pe0"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="V3H-rC-JH2" secondAttribute="trailing" constant="16" id="ZJO-nE-vOu"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatWetAsphalt"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2qt-PY-eRd" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4938.5" y="1926.5"/>
+            <point key="canvasLocation" x="4567.5" y="114.5"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="1gA-sk-a4Q">
@@ -985,13 +390,10 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yqc-zm-1iX" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="nWz-fC-GLe" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="5846.5" y="-281.5"/>
+            <point key="canvasLocation" x="5034.5" y="114.5"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="ftd-QI-Jx6"/>
-        <segue reference="aTe-dj-ZDJ"/>
-        <segue reference="j7j-cv-Wcs"/>
-        <segue reference="eEs-IF-sK1"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -341,10 +341,10 @@
             </objects>
             <point key="canvasLocation" x="2775.5" y="-281.5"/>
         </scene>
-        <!--Animatable View Controller-->
+        <!--View Controller-->
         <scene sceneID="bf7-Dg-a9m">
             <objects>
-                <viewController storyboardIdentifier="PresentedSecondViewController" id="J3N-gN-3lD" customClass="AnimatableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="J3N-gN-3lD" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="OjE-jf-D7p"/>
                         <viewControllerLayoutGuide type="bottom" id="Dxn-mh-kw0"/>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -59,10 +59,10 @@
             </objects>
             <point key="canvasLocation" x="3205.5" y="-281.5"/>
         </scene>
-        <!--Animatable View Controller-->
+        <!--Transition View Controller-->
         <scene sceneID="j4X-Oe-hEs">
             <objects>
-                <viewController id="NTx-bf-G81" customClass="AnimatableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="NTx-bf-G81" customClass="TransitionViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="G7z-Tg-1Gv"/>
                         <viewControllerLayoutGuide type="bottom" id="Kjd-MK-vGJ"/>
@@ -102,7 +102,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="9Qt-ed-0ZI" kind="custom" customClass="PresentFadeInSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="WyK-21-zHP"/>
+                                            <action selector="presentButtonDidTap:" destination="NTx-bf-G81" eventType="touchUpInside" id="cwO-1N-TwF"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -252,10 +252,10 @@
             </objects>
             <point key="canvasLocation" x="5034.5" y="-667.5"/>
         </scene>
-        <!--View Controller-->
+        <!--Animatable View Controller-->
         <scene sceneID="D7y-Bi-dz5">
             <objects>
-                <viewController id="9Qt-ed-0ZI" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PresentedFirstViewController" id="9Qt-ed-0ZI" customClass="AnimatableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="3M5-bf-nzE"/>
                         <viewControllerLayoutGuide type="bottom" id="zRb-Me-7Vv"/>
@@ -295,7 +295,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="J3N-gN-3lD" kind="custom" customClass="PresentFadeOutSegue" customModule="IBAnimatableApp" customModuleProvider="target" id="pEU-RW-fT6"/>
+                                            <segue destination="J3N-gN-3lD" kind="presentation" id="vKc-OD-kQz"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -341,10 +341,10 @@
             </objects>
             <point key="canvasLocation" x="2775.5" y="-281.5"/>
         </scene>
-        <!--View Controller-->
+        <!--Animatable View Controller-->
         <scene sceneID="bf7-Dg-a9m">
             <objects>
-                <viewController id="J3N-gN-3lD" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PresentedSecondViewController" id="J3N-gN-3lD" customClass="AnimatableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="OjE-jf-D7p"/>
                         <viewControllerLayoutGuide type="bottom" id="Dxn-mh-kw0"/>

--- a/IBAnimatableApp/Functions.swift
+++ b/IBAnimatableApp/Functions.swift
@@ -1,0 +1,17 @@
+//
+//  Created by Jake Lin on 3/1/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+// http://stackoverflow.com/a/28341290/749786
+func iterateEnum<T: Hashable>(_: T.Type) -> AnyGenerator<T> {
+  var i = 0
+  return anyGenerator {
+    let next = withUnsafePointer(&i) { UnsafePointer<T>($0).memory }
+    let currentI = i
+    i = i + 1
+    return next.hashValue == currentI ? next : nil
+  }
+}

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -7,13 +7,15 @@ import UIKit
 
 class TransitionTableViewController: UITableViewController {
 
-  private var transitionAnimations = [TransitionAnimationType.Fade, .FadeIn, .FadeOut, .SystemCubeFromLeft]
+  private var transitionAnimations = [TransitionAnimationType]()
 
   // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    // TODO: Loop through `TransitionAnimationType` enum to generate the table dynamically.
+    for type in iterateEnum(TransitionAnimationType) {
+      transitionAnimations.append(type)
+    }
   }
 
   // MARK: - UITableViewDataSource

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -40,5 +40,4 @@ class TransitionTableViewController: UITableViewController {
   
     toViewController.transitionAnimationType = String(transitionAnimations[path.row])
   }
-  
 }

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -38,6 +38,11 @@ class TransitionTableViewController: UITableViewController {
       return
     }
   
-    toViewController.transitionAnimationType = String(transitionAnimations[path.row])
+    let transitionAnimationType = String(transitionAnimations[path.row])
+    toViewController.transitionAnimationType = transitionAnimationType
+    
+    if let transitionViewController = toViewController.topViewController as? TransitionViewController{
+      transitionViewController.animationType = transitionAnimationType
+    }
   }
 }

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Jake Lin on 2/29/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+class TransitionTableViewController: UITableViewController {
+
+  // MARK: - UITableViewDataSource
+  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell")
+    return cell!
+  }
+}

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -7,9 +7,36 @@ import UIKit
 
 class TransitionTableViewController: UITableViewController {
 
+  private var transitionAnimations = [TransitionAnimationType.Fade, .FadeIn, .FadeOut, .SystemCubeFromLeft]
+
+  // MARK: - Lifecycle
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // TODO: Loop through `TransitionAnimationType` enum to generate the table dynamically.
+  }
+
   // MARK: - UITableViewDataSource
   override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell")
-    return cell!
+    guard let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell") else {
+      return UITableViewCell()
+    }
+    cell.textLabel?.text = transitionAnimations[indexPath.row].rawValue
+    return cell
   }
+
+  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return transitionAnimations.count
+  }
+  
+  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    super.prepareForSegue(segue, sender: sender)
+    
+    guard let toViewController = segue.destinationViewController as? AnimatableNavigationController, path = tableView.indexPathForSelectedRow else {
+      return
+    }
+  
+    toViewController.transitionAnimationType = String(transitionAnimations[path.row])
+  }
+  
 }

--- a/IBAnimatableApp/TransitionViewController.swift
+++ b/IBAnimatableApp/TransitionViewController.swift
@@ -1,0 +1,19 @@
+//
+//  Created by Jake Lin on 3/1/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+class TransitionViewController: AnimatableViewController {
+  @IBAction func presentButtonDidTap(sender: AnyObject) {
+    guard let toViewController = storyboard?.instantiateViewControllerWithIdentifier("PresentedFirstViewController") as? AnimatableViewController else {
+      return
+    }
+    
+    toViewController.transitionAnimationType = String(TransitionAnimationType.FadeIn)
+    let segue = PresentFadeSegue(identifier: String(PresentFadeSegue), source: self, destination: toViewController)
+    prepareForSegue(segue, sender: self)
+    segue.perform()
+  }
+}

--- a/IBAnimatableApp/TransitionViewController.swift
+++ b/IBAnimatableApp/TransitionViewController.swift
@@ -6,13 +6,20 @@
 import UIKit
 
 class TransitionViewController: AnimatableViewController {
+  var animationType: String?
+  
   @IBAction func presentButtonDidTap(sender: AnyObject) {
-    guard let toViewController = storyboard?.instantiateViewControllerWithIdentifier("PresentedFirstViewController") as? AnimatableViewController else {
+    guard let toViewController = storyboard?.instantiateViewControllerWithIdentifier("PresentedFirstViewController") as? AnimatableViewController, animationType = animationType else {
       return
     }
     
-    toViewController.transitionAnimationType = String(TransitionAnimationType.FadeIn)
-    let segue = PresentFadeSegue(identifier: String(PresentFadeSegue), source: self, destination: toViewController)
+    toViewController.transitionAnimationType = animationType
+    let segueName = "IBAnimatable.Present" + animationType + "Segue"
+    guard let segueClass = NSClassFromString(segueName) as? UIStoryboardSegue.Type else {
+      return
+    }
+    
+    let segue = segueClass.init(identifier: String(PresentFadeSegue), source: self, destination: toViewController)
     prepareForSegue(segue, sender: self)
     segue.perform()
   }

--- a/IBAnimatableApp/TransitionViewController.swift
+++ b/IBAnimatableApp/TransitionViewController.swift
@@ -8,6 +8,17 @@ import UIKit
 class TransitionViewController: AnimatableViewController {
   var animationType: String?
   
+    @IBOutlet var presentButton: AnimatableButton!
+    
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // Transition animations start with `System` do not support Present transition, so hide it
+    if let animationType = animationType where animationType.hasPrefix("System") {
+        presentButton.alpha = 0
+    }
+  }
+  
   @IBAction func presentButtonDidTap(sender: AnyObject) {
     guard let toViewController = storyboard?.instantiateViewControllerWithIdentifier("PresentedFirstViewController") as? AnimatableViewController, animationType = animationType else {
       return


### PR DESCRIPTION
In this PR, we add a TableViewController to demonstrate all supported transition animations for Push and Present. 

The supported transition animations will be automatically picked up from `TransitionAnimationType`. And automatically set the animation type for `AnimatableNavigationController`, all push and pop transitions will use that setting. Also dynamically create the corresponding object for `Present***Segue` to support custom animation for Present and Dismiss. 

After this PR, the transition architecture for IBAnimatable is done. We will add more custom transition animations in the future.

Refer to #19    
