### PR TITLE
Fix slideIn/Out animations on external screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 #### Bugfixes
 
 - Fix potential crash when using `GradientDesignable`
+- Fix slideIn/Out animations on second screens
 
 ### [1.2](https://github.com/JakeLin/IBAnimatable/releases/tag/1.2)
 

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -721,7 +721,7 @@ public extension Animatable where Self: UIView {
   
   // MARK: Private helper
   private var screenSize: CGSize {
-    return UIScreen.mainScreen().bounds.size
+    return self.window?.screen.bounds.size ?? CGSize.zero
   }
 }
 


### PR DESCRIPTION
Using airplay / cable, the slideIn/Out animations won't use the right frame, here a fix! :)
