### PR TITLE
System curl transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ TBD
 #### Enhancements
 
 - Support Xcode 7.3 and Swift 2.2
-- Add `SystemCurlAnimator` to support `SystemCurlFromTop` and `SystemCurlFromBottom` transition animations
+- Add `SystemPageCurlAnimator` to support `SystemPageCurlFromTop` and `SystemPageCurlFromBottom` transition animations
 
 #### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ TBD
 
 #### Enhancements
 
-Support Xcode 7.3 and Swift 2.2
+- Support Xcode 7.3 and Swift 2.2
+- Add `SystemCurlAnimator` to support `SystemCurlFromTop` and `SystemCurlFromBottom` transition animations
 
 #### Bugfixes
 

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -36,6 +36,10 @@ struct AnimatorFactory {
       return SystemFlipAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
     case .SystemFlipFromBottom:
       return SystemFlipAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
+    case .SystemCurlFromTop:
+      return SystemCurlAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
+    case .SystemCurlFromBottom:
+      return SystemCurlAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
     }
   }
 }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -36,10 +36,10 @@ struct AnimatorFactory {
       return SystemFlipAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
     case .SystemFlipFromBottom:
       return SystemFlipAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
-    case .SystemCurlFromTop:
-      return SystemCurlAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
-    case .SystemCurlFromBottom:
-      return SystemCurlAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
+    case .SystemPageCurlFromTop:
+      return SystemPageCurlAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
+    case .SystemPageCurlFromBottom:
+      return SystemPageCurlAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
     }
   }
 }

--- a/IBAnimatable/SystemCurlAnimator.swift
+++ b/IBAnimatable/SystemCurlAnimator.swift
@@ -1,0 +1,61 @@
+//
+//  Created by Tom Baranes on 28/03/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+/**
+ System Page Curl Animator - To support Page Curl animation (Four page curl directions supported: left, right, top, bottom)
+ */
+public class SystemCurlAnimator: NSObject, AnimatedTransitioning {
+  // MARK: - AnimatorProtocol
+  public var transitionAnimationType: TransitionAnimationType
+  public var transitionDuration: Duration = defaultTransitionDuration
+  public var reverseAnimationType: TransitionAnimationType?
+  public var interactiveGestureType: InteractiveGestureType?
+  
+  // MARK: - private
+  private var fromDirection: TransitionFromDirection
+  private var animationOption: UIViewAnimationOptions
+  
+  init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+    self.fromDirection = fromDirection
+    self.transitionDuration = transitionDuration
+    
+    switch fromDirection {
+    case .Top, .Left:
+      self.transitionAnimationType = .SystemCurlFromTop
+      self.reverseAnimationType = .SystemCurlFromBottom
+      self.animationOption = .TransitionCurlUp
+    case .Bottom, .Right:
+      self.transitionAnimationType = .SystemCurlFromBottom
+      self.reverseAnimationType = .SystemCurlFromTop
+      self.animationOption = .TransitionCurlDown
+    }
+    
+    super.init()
+  }
+}
+
+extension SystemCurlAnimator: UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return retrieveTransitionDuration(transitionContext)
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    let (tempFromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
+    guard let fromView = tempFromView, toView = tempToView, _ = tempContainerView else {
+      transitionContext.completeTransition(true)
+      return
+    }
+    
+    UIView.transitionFromView(fromView, toView: toView,
+                              duration: transitionDuration(transitionContext), options: animationOption,
+                              completion: { _ in
+                                transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+      }
+    )
+  }
+}
+

--- a/IBAnimatable/SystemPageCurlAnimator.swift
+++ b/IBAnimatable/SystemPageCurlAnimator.swift
@@ -8,7 +8,7 @@ import UIKit
 /**
  System Page Curl Animator - To support Page Curl animation (Four page curl directions supported: left, right, top, bottom)
  */
-public class SystemCurlAnimator: NSObject, AnimatedTransitioning {
+public class SystemPageCurlAnimator: NSObject, AnimatedTransitioning {
   // MARK: - AnimatorProtocol
   public var transitionAnimationType: TransitionAnimationType
   public var transitionDuration: Duration = defaultTransitionDuration
@@ -25,12 +25,12 @@ public class SystemCurlAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Top, .Left:
-      self.transitionAnimationType = .SystemCurlFromTop
-      self.reverseAnimationType = .SystemCurlFromBottom
+      self.transitionAnimationType = .SystemPageCurlFromTop
+      self.reverseAnimationType = .SystemPageCurlFromBottom
       self.animationOption = .TransitionCurlUp
     case .Bottom, .Right:
-      self.transitionAnimationType = .SystemCurlFromBottom
-      self.reverseAnimationType = .SystemCurlFromTop
+      self.transitionAnimationType = .SystemPageCurlFromBottom
+      self.reverseAnimationType = .SystemPageCurlFromTop
       self.animationOption = .TransitionCurlDown
     }
     
@@ -38,24 +38,13 @@ public class SystemCurlAnimator: NSObject, AnimatedTransitioning {
   }
 }
 
-extension SystemCurlAnimator: UIViewControllerAnimatedTransitioning {
+extension SystemPageCurlAnimator: UIViewControllerAnimatedTransitioning {
   public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
     return retrieveTransitionDuration(transitionContext)
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    let (tempFromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
-    guard let fromView = tempFromView, toView = tempToView, _ = tempContainerView else {
-      transitionContext.completeTransition(true)
-      return
-    }
-    
-    UIView.transitionFromView(fromView, toView: toView,
-                              duration: transitionDuration(transitionContext), options: animationOption,
-                              completion: { _ in
-                                transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
-      }
-    )
+    animateWithCATransition(transitionContext, type: SystemTransitionType.PageCurl, subtype: fromDirection.stringValue)
   }
 }
 

--- a/IBAnimatable/SystemPageCurlAnimator.swift
+++ b/IBAnimatable/SystemPageCurlAnimator.swift
@@ -44,7 +44,18 @@ extension SystemPageCurlAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.PageCurl, subtype: fromDirection.stringValue)
+    let (tempFromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
+    guard let fromView = tempFromView, toView = tempToView, _ = tempContainerView else {
+      transitionContext.completeTransition(true)
+      return
+    }
+    
+    UIView.transitionFromView(fromView, toView: toView,
+                              duration: transitionDuration(transitionContext), options: animationOption,
+                              completion: { _ in
+                                transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+      }
+    )
   }
 }
 

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -20,6 +20,6 @@ public enum TransitionAnimationType: String {
   case SystemFlipFromRight
   case SystemFlipFromTop
   case SystemFlipFromBottom
-  case SystemCurlFromTop
-  case SystemCurlFromBottom
+  case SystemPageCurlFromTop
+  case SystemPageCurlFromBottom
 }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -20,4 +20,6 @@ public enum TransitionAnimationType: String {
   case SystemFlipFromRight
   case SystemFlipFromTop
   case SystemFlipFromBottom
+  case SystemCurlFromTop
+  case SystemCurlFromBottom
 }

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -149,8 +149,8 @@
 		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56E8FA0F35057290D67C4 /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
 		CAB56F164EE0CC8E0510FEC6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
-		E23D08B81CA9336500440E7C /* SystemCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */; };
-		E23D08B91CA9358000440E7C /* SystemCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */; };
+		E23D08B81CA9336500440E7C /* SystemPageCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageCurlAnimator.swift */; };
+		E23D08B91CA9358000440E7C /* SystemPageCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageCurlAnimator.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
@@ -253,7 +253,7 @@
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
-		E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCurlAnimator.swift; sourceTree = "<group>"; };
+		E23D08B71CA9336500440E7C /* SystemPageCurlAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPageCurlAnimator.swift; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
 		E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatColorsTypeScript.swift; path = Scripts/FlatColorsTypeScript.swift; sourceTree = SOURCE_ROOT; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
@@ -347,7 +347,7 @@
 				AEE552A61C815AC5009CF623 /* FadeAnimator.swift */,
 				33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */,
 				AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */,
-				E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */,
+				E23D08B71CA9336500440E7C /* SystemPageCurlAnimator.swift */,
 			);
 			name = "transition animator";
 			sourceTree = "<group>";
@@ -689,7 +689,7 @@
 				AE154B8F1C7D89CB0093C05B /* Presenter.swift in Sources */,
 				AED5F6951C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
-				E23D08B81CA9336500440E7C /* SystemCurlAnimator.swift in Sources */,
+				E23D08B81CA9336500440E7C /* SystemPageCurlAnimator.swift in Sources */,
 				AE6D430D1C98B658006E2F67 /* TransitionType.swift in Sources */,
 				AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
 				AE6B01641C2A444000950BB2 /* BorderSide.swift in Sources */,
@@ -777,7 +777,7 @@
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
 				AED5F6941C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,
-				E23D08B91CA9358000440E7C /* SystemCurlAnimator.swift in Sources */,
+				E23D08B91CA9358000440E7C /* SystemPageCurlAnimator.swift in Sources */,
 				AEE552B01C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AEE552A71C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		CAB56CB79477DEE19E7B0420 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56E8FA0F35057290D67C4 /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
 		CAB56F164EE0CC8E0510FEC6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
+		E23D08B81CA9336500440E7C /* SystemCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */; };
+		E23D08B91CA9358000440E7C /* SystemCurlAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */; };
 		E2472EA41C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E2E28E6B1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
@@ -251,6 +253,7 @@
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
+		E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCurlAnimator.swift; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
 		E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatColorsTypeScript.swift; path = Scripts/FlatColorsTypeScript.swift; sourceTree = SOURCE_ROOT; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
@@ -344,6 +347,7 @@
 				AEE552A61C815AC5009CF623 /* FadeAnimator.swift */,
 				33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */,
 				AEDD8A301C7EDAE30033175A /* SystemFlipAnimator.swift */,
+				E23D08B71CA9336500440E7C /* SystemCurlAnimator.swift */,
 			);
 			name = "transition animator";
 			sourceTree = "<group>";
@@ -685,6 +689,7 @@
 				AE154B8F1C7D89CB0093C05B /* Presenter.swift in Sources */,
 				AED5F6951C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AE6B01781C2A444900950BB2 /* BarButtonItemDesignable.swift in Sources */,
+				E23D08B81CA9336500440E7C /* SystemCurlAnimator.swift in Sources */,
 				AE6D430D1C98B658006E2F67 /* TransitionType.swift in Sources */,
 				AE154B7C1C7D04A40093C05B /* TransitionAnimatable.swift in Sources */,
 				AE6B01641C2A444000950BB2 /* BorderSide.swift in Sources */,
@@ -772,6 +777,7 @@
 				AE0FADAF1C203F9A00B5289B /* AnimatableTableView.swift in Sources */,
 				AED5F6941C83E9C20052E57B /* PresentFadeOutSegue.swift in Sources */,
 				AED97B861C1710A900D2B0B8 /* BorderSide.swift in Sources */,
+				E23D08B91CA9358000440E7C /* SystemCurlAnimator.swift in Sources */,
 				AEE552B01C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AEE552A71C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				CAB569B1A6DDC08165BE389A /* FillDesignable.swift in Sources */,


### PR DESCRIPTION
This PR add a new transition animator: `SystemCurlAnimator`. 

First of all, you really did a great work @JakeLin on that animator implementation! It was really easy to implement it, I quickly read your wiki, but I mostly use the existing code to implement the new one. The wiki seems complete and easy to understand :tada: 

Some though about the current implementation of Animators:
- `TransitionFromDirection`: a bit annoying when we doesn't need all the direction. In my case, I'm only using  `Top` and `Bottom`, since I didn't want to make all my properties optional, I just make a useless hack, and say `Right` will have the same behaviour as `Up`... not really nice
- `AnimatorFactory`: we currently have 13 different animators, and that number will continue to grow. I can't imagine how that enum will looks like with 20, 30, 50 different animators. I don't have a better solution right now, but we definitely need to find another way to implement it. Maybe keeping the main enum, and creating several subenums in the main one?
- Animator example: same point as the previous one. It's easy to use now with 13 examples, but once we have 50? We need a nicer way to generate the example. An easy way (I think) would be to add sections and using grouped tableview

Anyway, nothing that important. We can think about it later if we think about a nice solution :+1: 

I'm gonna take a deeper look in that engine, and let you know if I foud others points to improve
