### PR TITLE
Fixed gradient cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 #### Bugfixes
 
-TBD
+- Fixed a bug that was making `GradientDesignable` not filling the dedicated frame
 
 ### [2.0](https://github.com/JakeLin/IBAnimatable/releases/tag/2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 #### API breaking changes
 
-- Removing `MaskDesignable` public methods:
+- Removing `MaskDesignable` public methods ([#101](https://github.com/JakeLin/IBAnimatable/issues/101)): 
    - `maskCircle()`, use instead: `view.maskType = String(MaskType.Circle)`
    - `maskStar(_:)`, use instead: `view.maskType = `Star(6)`
    - `maskPolygon()`, use instead: `view.maskType = `String(MaskType.Polygon)`
@@ -18,12 +18,12 @@ All notable changes to this project will be documented in this file.
 #### Enhancements
 
 - Support Xcode 7.3 and Swift 2.2
-- Configurable mask polygon (sides)
-- Add `SystemPageCurlAnimator` to support `SystemPageCurlFromTop` and `SystemPageCurlFromBottom` transition animations
+- Configurable mask polygon (sides) [#112](https://github.com/JakeLin/IBAnimatable/issues/112)
+- Add `SystemPageCurlAnimator` to support `SystemPageCurlFromTop` and `SystemPageCurlFromBottom` transition animations [#126](https://github.com/JakeLin/IBAnimatable/issues/126)
 
 #### Bugfixes
 
-- Fixed a bug that was making `GradientDesignable` not filling the dedicated frame
+- Fixed a bug that was making `GradientDesignable` not filling the dedicated frame [#129](https://github.com/JakeLin/IBAnimatable/issues/129)
 
 ### [2.0](https://github.com/JakeLin/IBAnimatable/releases/tag/2.0)
 

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -142,10 +142,10 @@ import UIKit
     configAnimatableProperties()
     configTintedColor()
     configBlurEffectStyle()
-    configGradient()
   }
   
   private func configAfterLayoutSubviews() {
     configBorder()
+    configGradient()    
   }
 }

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -144,10 +144,10 @@ import UIKit
     configAnimatableProperties()
     configTintedColor()
     configBlurEffectStyle()
-    configGradient()
   }
   
   private func configAfterLayoutSubviews() {
     configBorder()
+    configGradient()
   }
 }

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -84,10 +84,11 @@ import UIKit
   private func configInspectableProperties() {
     configAnimatableProperties()
     configOpacity()
-    configGradient()
+    
   }
   
   private func configAfterLayoutSubviews() {
     configBorder()
+    configGradient()
   }
 }

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -88,10 +88,10 @@ import UIKit
     configAnimatableProperties()
     configOpacity()
     configSeparatorMargins()
-    configGradient()
   }
   
   private func configAfterLayoutSubviews() {
     configBorder()
+    configGradient()
   }
 }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -145,7 +145,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
-    configGradient()
     configBorder()
+    configGradient()
   }
 }


### PR DESCRIPTION
Should close #129 
The issue here was the same as the border. Drawing the gradient in `configInspectableProperties()` isn't enough because we don't know the _real_ frame. In our case, the frame was `(600,600)` (xib frame), but not the final one.

Moving the `configGradient()` in `layoutSubviews()` fixed this.
