### PR TITLE
Refactoring TransitionAnimationType

### DIFF
--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -23,7 +23,7 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
   private var navigator: Navigator?
 
   private func configureNavigationControllerDelegate() {
-    guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType(rawValue: transitionAnimationType) else {
+    guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType.fromString(transitionAnimationType) else {
       return
     }
     var duration = transitionDuration

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -43,7 +43,7 @@ import UIKit
     super.prepareForSegue(segue, sender: sender)
     
     // Configure custom transition animation
-    guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType(rawValue: transitionAnimationType) else {
+    guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType.fromString(transitionAnimationType) else {
       super.prepareForSegue(segue, sender: sender)
       return
     }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -20,26 +20,13 @@ struct AnimatorFactory {
       return FadeAnimator(fadeType: .FadeIn, transitionDuration: transitionDuration)
     case .FadeOut:
       return FadeAnimator(fadeType: .FadeOut, transitionDuration: transitionDuration)
-    case .SystemCubeFromLeft:
-      return SystemCubeAnimator(fromDirection: .Left, transitionDuration: transitionDuration)
-    case .SystemCubeFromRight:
-      return SystemCubeAnimator(fromDirection: .Right, transitionDuration: transitionDuration)
-    case .SystemCubeFromTop:
-      return SystemCubeAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
-    case .SystemCubeFromBottom:
-      return SystemCubeAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
-    case .SystemFlipFromLeft:
-      return SystemFlipAnimator(fromDirection: .Left, transitionDuration: transitionDuration)
-    case .SystemFlipFromRight:
-      return SystemFlipAnimator(fromDirection: .Right, transitionDuration: transitionDuration)
-    case .SystemFlipFromTop:
-      return SystemFlipAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
-    case .SystemFlipFromBottom:
-      return SystemFlipAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
-    case .SystemPageCurlFromTop:
-      return SystemPageCurlAnimator(fromDirection: .Top, transitionDuration: transitionDuration)
-    case .SystemPageCurlFromBottom:
-      return SystemPageCurlAnimator(fromDirection: .Bottom, transitionDuration: transitionDuration)
+    case .SystemCube(let direction):
+      return SystemCubeAnimator(fromDirection: direction, transitionDuration: transitionDuration)
+    case .SystemFlip(let direction):
+      return SystemFlipAnimator(fromDirection: direction, transitionDuration: transitionDuration)
+    case .SystemPageCurl(let direction):
+      return SystemPageCurlAnimator(fromDirection: direction, transitionDuration: transitionDuration)
     }
   }
+  
 }

--- a/IBAnimatable/PresenterManager.swift
+++ b/IBAnimatable/PresenterManager.swift
@@ -19,12 +19,12 @@ class PresenterManager {
   }
   
   // MARK: - Private
-  private var cache = [TransitionAnimationType: Presenter]()
+  private var cache = [String: Presenter]()
   
   // MARK: Inertnal Interface
   func retrievePresenter(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration, interactiveGestureType: InteractiveGestureType? = nil) -> Presenter {
     // Get the cached presenter
-    let presenter = cache[transitionAnimationType]
+    let presenter = cache[transitionAnimationType.stringValue]
     if let presenter = presenter {
       // Update the `transitionDuration` and `interactiveGestureType` every time to reuse the same presenter with the same type
       presenter.transitionDuration = transitionDuration
@@ -34,7 +34,7 @@ class PresenterManager {
     
     // Create a new if cache doesn't exist
     let newPresenter = Presenter(transitionAnimationType: transitionAnimationType, transitionDuration: transitionDuration, interactiveGestureType: interactiveGestureType)
-    cache[transitionAnimationType] = newPresenter
+    cache[transitionAnimationType.stringValue] = newPresenter
     return newPresenter
   }
 }

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -23,20 +23,20 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Left:
-      self.transitionAnimationType = .SystemCubeFromLeft
-      self.reverseAnimationType = .SystemCubeFromRight
+      self.transitionAnimationType = .SystemCube(direction: .Left)
+      self.reverseAnimationType = .SystemCube(direction: .Right)
       self.interactiveGestureType = .PanFromRight
     case .Right:
-      self.transitionAnimationType = .SystemCubeFromRight
-      self.reverseAnimationType = .SystemCubeFromLeft
+      self.transitionAnimationType = .SystemCube(direction: .Right)
+      self.reverseAnimationType = .SystemCube(direction: .Left)
       self.interactiveGestureType = .PanFromLeft
     case .Top:
-      self.transitionAnimationType = .SystemCubeFromTop
-      self.reverseAnimationType = .SystemCubeFromBottom
+      self.transitionAnimationType = .SystemCube(direction: .Top)
+      self.reverseAnimationType = .SystemCube(direction: .Bottom)
       self.interactiveGestureType = .PanFromTop
     case .Bottom:
-      self.transitionAnimationType = .SystemCubeFromBottom
-      self.reverseAnimationType = .SystemCubeFromTop
+      self.transitionAnimationType = .SystemCube(direction: .Bottom)
+      self.reverseAnimationType = .SystemCube(direction: .Top)
       self.interactiveGestureType = .PanFromBottom
     }
     

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -25,20 +25,20 @@ public class SystemFlipAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Left:
-      self.transitionAnimationType = .SystemFlipFromLeft
-      self.reverseAnimationType = .SystemFlipFromRight
+      self.transitionAnimationType = .SystemFlip(direction: .Left)
+      self.reverseAnimationType = .SystemFlip(direction: .Right)
       self.animationOption = .TransitionFlipFromLeft
     case .Right:
-      self.transitionAnimationType = .SystemFlipFromRight
-      self.reverseAnimationType = .SystemFlipFromLeft
+      self.transitionAnimationType = .SystemFlip(direction: .Right)
+      self.reverseAnimationType = .SystemFlip(direction: .Left)
       self.animationOption = .TransitionFlipFromRight
     case .Top:
-      self.transitionAnimationType = .SystemFlipFromTop
-      self.reverseAnimationType = .SystemFlipFromBottom
+      self.transitionAnimationType = .SystemFlip(direction: .Top)
+      self.reverseAnimationType = .SystemFlip(direction: .Bottom)
       self.animationOption = .TransitionFlipFromTop
     case .Bottom:
-      self.transitionAnimationType = .SystemFlipFromBottom
-      self.reverseAnimationType = .SystemFlipFromTop
+      self.transitionAnimationType = .SystemFlip(direction: .Bottom)
+      self.reverseAnimationType = .SystemFlip(direction: .Top)
       self.animationOption = .TransitionFlipFromBottom
     }
     

--- a/IBAnimatable/SystemPageCurlAnimator.swift
+++ b/IBAnimatable/SystemPageCurlAnimator.swift
@@ -25,12 +25,12 @@ public class SystemPageCurlAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Top, .Left:
-      self.transitionAnimationType = .SystemPageCurlFromTop
-      self.reverseAnimationType = .SystemPageCurlFromBottom
+      self.transitionAnimationType = .SystemPageCurl(direction: .Top)
+      self.reverseAnimationType = .SystemPageCurl(direction: .Bottom)
       self.animationOption = .TransitionCurlUp
     case .Bottom, .Right:
-      self.transitionAnimationType = .SystemPageCurlFromBottom
-      self.reverseAnimationType = .SystemPageCurlFromTop
+      self.transitionAnimationType = .SystemPageCurl(direction: .Bottom)
+      self.reverseAnimationType = .SystemPageCurl(direction: .Top)
       self.animationOption = .TransitionCurlDown
     }
     

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -20,13 +20,60 @@ public enum TransitionAnimationType {
     return String(self)
   }
 
-  static func fromString(string: String) -> TransitionAnimationType? {
-    if String(TransitionAnimationType.Fade) == string {
-      return .Fade
-    } else if String(TransitionAnimationType.SystemCube(direction: .Left)) == string {
-      return .SystemCube(direction: .Left)
+  static func fromString(transitionType: String) -> TransitionAnimationType? {
+    if transitionType.hasPrefix("Fade") {
+      return fadeTransitionAnmationType(transitionType)
+    } else  {
+      return fromStringWithDirection(transitionType)
+    }
+  }
+
+}
+
+// MARK: - TransitionAnimationType from string
+
+private extension TransitionAnimationType {
+  
+  static func transitionDirection(forTransitionType transitionType: String) -> TransitionFromDirection? {
+    let range = transitionType.rangeOfString("(")
+    let transitionType = transitionType.stringByReplacingOccurrencesOfString(" ", withString: "")
+                                        .lowercaseString
+                                        .substringFromIndex(range?.startIndex ?? transitionType.endIndex)
+    if transitionType.containsString("left") {
+      return .Left
+    } else if transitionType.containsString("right") {
+      return .Right
+    } else if transitionType.containsString("top") {
+      return .Top
+    } else if transitionType.containsString("bottom") {
+      return .Bottom
     }
     return nil
   }
-
+  
+  
+  static func fadeTransitionAnmationType(transitionType: String) -> TransitionAnimationType {
+    if transitionType.hasSuffix("In") {
+      return .FadeIn
+    } else if transitionType.hasSuffix("Out") {
+      return .FadeOut
+    }
+    return .Fade
+  }
+ 
+  static func fromStringWithDirection(transitionType: String) -> TransitionAnimationType? {
+    guard let direction = transitionDirection(forTransitionType: transitionType) else {
+      return nil
+    }
+    
+    if transitionType.hasPrefix("SystemCube") {
+      return .SystemCube(direction: direction)
+    } else if transitionType.hasPrefix("SystemFlip") {
+      return .SystemFlip(direction: direction)
+    } else if transitionType.hasPrefix("SystemPageCurl") {
+      return .SystemPageCurl(direction: direction)
+    }
+    return nil
+  }
+  
 }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -8,18 +8,25 @@ import Foundation
 /**
  Predefined Transition Animation Type
  */
-public enum TransitionAnimationType: String {
+public enum TransitionAnimationType {
   case Fade             // ToView fades in and FromeView fades out
   case FadeIn           // ToView fades in
   case FadeOut          // FromView Fades out
-  case SystemCubeFromLeft
-  case SystemCubeFromRight
-  case SystemCubeFromTop
-  case SystemCubeFromBottom
-  case SystemFlipFromLeft
-  case SystemFlipFromRight
-  case SystemFlipFromTop
-  case SystemFlipFromBottom
-  case SystemPageCurlFromTop
-  case SystemPageCurlFromBottom
+  case SystemCube(direction: TransitionFromDirection)
+  case SystemFlip(direction: TransitionFromDirection)
+  case SystemPageCurl(direction: TransitionFromDirection)
+
+  var stringValue: String {
+    return String(self)
+  }
+
+  static func fromString(string: String) -> TransitionAnimationType? {
+    if String(TransitionAnimationType.Fade) == string {
+      return .Fade
+    } else if String(TransitionAnimationType.SystemCube(direction: .Left)) == string {
+      return .SystemCube(direction: .Left)
+    }
+    return nil
+  }
+
 }

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tFh-B7-Fcy">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tFh-B7-Fcy">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -9,13 +9,13 @@
         <scene sceneID="q1o-VY-0TT">
             <objects>
                 <tableViewController id="oAB-Bz-TaE" customClass="TransitionTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NP4-Ex-cLZ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="NP4-Ex-cLZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mDV-Ii-W8m" style="IBUITableViewCellStyleDefault" id="gTl-GY-SNY">
-                                <rect key="frame" x="0.0" y="92" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="113.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gTl-GY-SNY" id="qhN-8T-xDf">
                                     <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -12,16 +12,17 @@ class TransitionTableViewController: UITableViewController {
   // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    for type in iterateEnum(TransitionAnimationType) {
-      transitionAnimations.append(type)
-    }
+    transitionAnimations.append(.Fade)
+    transitionAnimations.append(.SystemCube(direction: .Left))
+//    for type in iterateEnum(TransitionAnimationType) {
+//      transitionAnimations.append(type)
+//    }
   }
 
   // MARK: - UITableViewDataSource
   override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell", forIndexPath: indexPath) as UITableViewCell
-    cell.textLabel?.text = transitionAnimations[indexPath.row].rawValue
+    cell.textLabel?.text = transitionAnimations[indexPath.row].stringValue
     return cell
   }
 

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -7,41 +7,74 @@ import UIKit
 
 class TransitionTableViewController: UITableViewController {
 
-  private var transitionAnimations = [String]()
+  private var transitionAnimationsHeaders = [String]()
+  private var transitionAnimations = [[String]]()
 
   // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    transitionAnimations.append("Fade")
-    transitionAnimations.append("SystemCube(Left)")
-//    for type in iterateEnum(TransitionAnimationType) {
-//      transitionAnimations.append(type)
-//    }
+    generateTransitionTypeData()
   }
 
-  // MARK: - UITableViewDataSource
-  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell", forIndexPath: indexPath) as UITableViewCell
-    cell.textLabel?.text = transitionAnimations[indexPath.row]
-    return cell
-  }
-
-  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return transitionAnimations.count
-  }
-  
+  // MARK: - Navigation
   override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     super.prepareForSegue(segue, sender: sender)
     
-    guard let toNavigationController = segue.destinationViewController as? AnimatableNavigationController, path = tableView.indexPathForSelectedRow else {
+    guard let toNavigationController = segue.destinationViewController as? AnimatableNavigationController, indexPath = tableView.indexPathForSelectedRow else {
       return
     }
-  
-    let transitionAnimationType = String(transitionAnimations[path.row])
+    
+    let transitionAnimationType = String(transitionAnimations[indexPath.section][indexPath.row])
     toNavigationController.transitionAnimationType = transitionAnimationType
     
     if let transitionViewController = toNavigationController.topViewController as? TransitionViewController{
       transitionViewController.animationType = transitionAnimationType
     }
   }
+
+}
+
+// MARK: - Factory
+
+private extension TransitionTableViewController {
+  
+  func generateTransitionTypeData() {
+    transitionAnimationsHeaders.append("Fade")
+    transitionAnimations.append(["Fade", "FadeIn", "FadeOut"])
+    transitionAnimationsHeaders.append("SystemCube")
+    transitionAnimations.append(transitionTypeWithDirections(forName: "SystemCube"))
+    transitionAnimationsHeaders.append("SystemFlip")
+    transitionAnimations.append(transitionTypeWithDirections(forName: "SystemFlip"))
+    transitionAnimationsHeaders.append("SystemPageCurl")
+    transitionAnimations.append(["SystemPageCurl(Top)", "SystemPageCurl(Bottom)"])
+  }
+  
+  func transitionTypeWithDirections(forName prefixName: String) -> [String] {
+    return [prefixName + "(Left)", prefixName + "(Right)", prefixName + "(Top)", prefixName + "(Bottom)"]
+  }
+  
+}
+
+// MARK: - UITableViewDataSource / UITableViewDelegate
+
+extension TransitionTableViewController {
+  
+  override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    return transitionAnimations.count
+  }
+  
+  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return transitionAnimations[section].count
+  }
+  
+  override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    return transitionAnimationsHeaders[section]
+  }
+  
+  override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell", forIndexPath: indexPath) as UITableViewCell
+    cell.textLabel?.text = transitionAnimations[indexPath.section][indexPath.row]
+    return cell
+  }
+  
 }

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -7,13 +7,13 @@ import UIKit
 
 class TransitionTableViewController: UITableViewController {
 
-  private var transitionAnimations = [TransitionAnimationType]()
+  private var transitionAnimations = [String]()
 
   // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    transitionAnimations.append(.Fade)
-    transitionAnimations.append(.SystemCube(direction: .Left))
+    transitionAnimations.append("Fade")
+    transitionAnimations.append("SystemCube(Left)")
 //    for type in iterateEnum(TransitionAnimationType) {
 //      transitionAnimations.append(type)
 //    }
@@ -22,7 +22,7 @@ class TransitionTableViewController: UITableViewController {
   // MARK: - UITableViewDataSource
   override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCellWithIdentifier("transitionCell", forIndexPath: indexPath) as UITableViewCell
-    cell.textLabel?.text = transitionAnimations[indexPath.row].stringValue
+    cell.textLabel?.text = transitionAnimations[indexPath.row]
     return cell
   }
 


### PR DESCRIPTION
Following the discussion in #134, I tried to review the implementation of `TransitionAnimationType` in order to make it thiner. The current implementation is answering that needs: the enum is really smaller, and the switch is more generic / readable.

The architecture seems nice, but there are some points that need a generic solution:
- `TransitionAnimationType` from string -> how to implement it?
- Iterating on TransitionAnimationType and handles all the cases (which means with the different directions...) to update the examples. That also implicate a way to divide the final array in different section for each transition family and _readable_ name
  For now, I just hard coded one case of `SystemCube`, and `Fade`, it's working as expected.

Any suggestions for these issues? Until now, I didn't find any nicer solution than the implementation currently used in master.

If you want to make some tests, use this branch, it's still very experimental :thought_balloon: 

/!\ NOT READY TO BE MERGED /!\
