### PR TITLE
Fixed mask frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 #### Bugfixes
 
 - Fixed a bug that was making `GradientDesignable` not filling the dedicated frame [#129](https://github.com/JakeLin/IBAnimatable/issues/129)
+- Fixed a bug that was making `MaskDesignable` not filling the dedicated frame
 
 ### [2.0](https://github.com/JakeLin/IBAnimatable/releases/tag/2.0)
 

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -120,6 +120,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
+    configMask()
     configBorder()
   }
 }

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -155,6 +155,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
+    configMask()
     configBorder()
   }
 }

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -145,6 +145,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
+    configMask()
     configBorder()
     configGradient()    
   }

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -147,6 +147,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
+    configMask()
     configBorder()
     configGradient()
   }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -145,6 +145,7 @@ import UIKit
   }
   
   private func configAfterLayoutSubviews() {
+    configMask()
     configBorder()
     configGradient()
   }


### PR DESCRIPTION
Same context as the border, gradient...: we need to `configMask()` in the `layoutSubviews` in order to be sure that we draw the right frame.
That bug is easily reproductible when drawing a mask (wave for example) taking all the width on a second screen.
