### PR TITLE
Removing useless system type transitions

### DIFF
--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -52,17 +52,6 @@ extension SystemFlipAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    let (tempFromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
-    guard let fromView = tempFromView, toView = tempToView, _ = tempContainerView else {
-      transitionContext.completeTransition(true)
-      return
-    }
-    
-    UIView.transitionFromView(fromView, toView: toView,
-      duration: transitionDuration(transitionContext), options: animationOption,
-      completion: { _ in
-        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
-      }
-    )
+    animateWithCATransition(transitionContext, type: SystemTransitionType.Flip, subtype: fromDirection.stringValue)
   }
 }

--- a/IBAnimatable/SystemTransitionType.swift
+++ b/IBAnimatable/SystemTransitionType.swift
@@ -15,8 +15,6 @@ public enum SystemTransitionType: String {
   case Push = "push"
   case Reveal = "reveal"
   case Flip = "flip"
-  case AlignedFlip = "alignedFlip"
-  case OglFlip = "oglFlip"
   case Cube = "cube"
   case AlignedCube = "alignedCube"
   case PageCurl = "pageCurl"

--- a/IBAnimatable/SystemTransitionType.swift
+++ b/IBAnimatable/SystemTransitionType.swift
@@ -16,7 +16,6 @@ public enum SystemTransitionType: String {
   case Reveal = "reveal"
   case Flip = "flip"
   case Cube = "cube"
-  case AlignedCube = "alignedCube"
   case PageCurl = "pageCurl"
   case PageUnCurl = "pageUnCurl"
   case RippleEffect = "rippleEffect"


### PR DESCRIPTION
This PR contains only two minor refactors:
- Make `FlipAnimator` using the method `animateWithCATransition` which clean a little bit the code
- Removing `oglFlip`, `alignedFlip`, `alignedCube` because the transition is the same as `Flip` and `Cube`. I try the three of them, but can't see any differences in the animation. If there any reasons, I don't see a reason to support them since it will just confuse the user: which one between the three should I use to make a flip transition?

For that last point, I may missing the main point :laughing: 

PS: I also clean the todo list in the issue #126 
