### PR TITLE
Fix the FromTop and FromBottom directions in system built-in animations

### DIFF
--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -33,11 +33,11 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
     case .Top:
       self.transitionAnimationType = .SystemCube(direction: .Top)
       self.reverseAnimationType = .SystemCube(direction: .Bottom)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .PanFromBottom
     case .Bottom:
       self.transitionAnimationType = .SystemCube(direction: .Bottom)
       self.reverseAnimationType = .SystemCube(direction: .Top)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .PanFromTop
     }
     
     super.init()

--- a/IBAnimatable/SystemMoveInAnimator.swift
+++ b/IBAnimatable/SystemMoveInAnimator.swift
@@ -31,11 +31,11 @@ public class SystemMoveInAnimator: NSObject, AnimatedTransitioning {
     case .Top:
       self.transitionAnimationType = .SystemMoveIn(direction: .Top)
       self.reverseAnimationType = .SystemMoveIn(direction: .Bottom)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .PanFromBottom
     case .Bottom:
       self.transitionAnimationType = .SystemMoveIn(direction: .Bottom)
       self.reverseAnimationType = .SystemMoveIn(direction: .Top)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .PanFromTop
     }
     
     super.init()

--- a/IBAnimatable/SystemPushAnimator.swift
+++ b/IBAnimatable/SystemPushAnimator.swift
@@ -34,11 +34,11 @@ public class SystemPushAnimator: NSObject, AnimatedTransitioning {
     case .Top:
       self.transitionAnimationType = .SystemPush(direction: .Top)
       self.reverseAnimationType = .SystemPush(direction: .Bottom)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .PanFromBottom
     case .Bottom:
       self.transitionAnimationType = .SystemPush(direction: .Bottom)
       self.reverseAnimationType = .SystemPush(direction: .Top)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .PanFromTop
     }
     
     super.init()

--- a/IBAnimatable/SystemRevealAnimator.swift
+++ b/IBAnimatable/SystemRevealAnimator.swift
@@ -31,11 +31,11 @@ public class SystemRevealAnimator: NSObject, AnimatedTransitioning {
     case .Top:
       self.transitionAnimationType = .SystemReveal(direction: .Top)
       self.reverseAnimationType = .SystemReveal(direction: .Bottom)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .PanFromBottom
     case .Bottom:
       self.transitionAnimationType = .SystemReveal(direction: .Bottom)
       self.reverseAnimationType = .SystemReveal(direction: .Top)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .PanFromTop
     }
     
     super.init()

--- a/IBAnimatable/TransitionFromDirection.swift
+++ b/IBAnimatable/TransitionFromDirection.swift
@@ -20,9 +20,11 @@ public enum TransitionFromDirection {
     case .Right:
       return kCATransitionFromRight
     case .Top:
-      return kCATransitionFromTop
-    case .Bottom:
+      // The actual transition direction is oposite, need to reverse
       return kCATransitionFromBottom
+    case .Bottom:
+      // The actual transition direction is oposite, need to reverse
+      return kCATransitionFromTop
     }
   }
 }


### PR DESCRIPTION
After tested, the implementation of `PanInteractiveAnimator` is right, but the directions `FromTop` and `FromBottom` in `SystemCubeAnimator`, `SystemMoveInAnimator`, `SystemPushAnimator` and `SystemRevealAnimator` are wrong, I don't know why, but after I reverse them in `TransitionFromDirection`, everything works as expected. 

@tbaranes please have a look. Thanks.
