### PR TITLE
Explode transition

### DIFF
--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -24,6 +24,8 @@ struct AnimatorFactory {
       return SystemSuckEffectAnimator(transitionDuration: transitionDuration)
     case .SystemRippleEffect:
       return SystemRippleEffectAnimator(transitionDuration: transitionDuration)
+    case .Explode:
+      return ExplodeAnimator(transitionDuration: transitionDuration)
     case .SystemCube(let direction):
       return SystemCubeAnimator(fromDirection: direction, transitionDuration: transitionDuration)
     case .SystemFlip(let direction):

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -24,8 +24,8 @@ struct AnimatorFactory {
       return SystemSuckEffectAnimator(transitionDuration: transitionDuration)
     case .SystemRippleEffect:
       return SystemRippleEffectAnimator(transitionDuration: transitionDuration)
-    case .Explode:
-      return ExplodeAnimator(transitionDuration: transitionDuration)
+    case .Explode(let params):
+      return ExplodeAnimator(params: params, transitionDuration: transitionDuration)
     case .SystemCube(let direction):
       return SystemCubeAnimator(fromDirection: direction, transitionDuration: transitionDuration)
     case .SystemFlip(let direction):

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -72,11 +72,14 @@ private extension ExplodeAnimator {
       snapshots.forEach{
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
-        $0.frame = CGRectOffset($0.frame, xOffset, yOffset)
-        $0.alpha = 0.0
-        
         let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
-        $0.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 0.01, 0.01)
+
+        let translateTransform = CGAffineTransformMakeTranslation($0.frame.origin.x - xOffset, $0.frame.origin.y - yOffset)
+        let angleTransform = CGAffineTransformRotate(translateTransform, angle)
+        let scaleTransform = CGAffineTransformScale(angleTransform, 0.1, 0.1)
+
+        $0.transform = scaleTransform
+        $0.alpha = 0.0
       }
     },
     completion: { _ in

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -35,8 +35,7 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
       return
     }
     
-    containerView.addSubview(toView)
-    containerView.sendSubviewToBack(toView)
+    containerView.insertSubview(toView, atIndex: 0)
     
     let snapshots = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     containerView.sendSubviewToBack(fromView)
@@ -57,7 +56,7 @@ private extension ExplodeAnimator {
     
     let fromViewSnapshot = fromView.snapshotViewAfterScreenUpdates(false)
     for x in 0.stride(to: Int(size.width), by: Int(size.width / xFactor)) {
-      for y in 0.stride(to: Int(size.height), by: Int(size.width / yFactor)) {
+      for y in 0.0.stride(to: Double(size.height), by: Double(size.width / yFactor)) {
         let snapshotRegion = CGRect(x: CGFloat(x), y: CGFloat(y), width: size.width / xFactor, height: size.height / yFactor)
         let snapshot = fromViewSnapshot.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: false, withCapInsets: UIEdgeInsetsZero)
         snapshot.frame = snapshotRegion
@@ -69,16 +68,16 @@ private extension ExplodeAnimator {
   }
   
   func animateSnapshotsExplode(snapshots: [UIView], completion: () -> Void) {
-    UIView.animateWithDuration(2, animations: {
-      for view in snapshots {
+    UIView.animateWithDuration(transitionDuration, animations: {
+      snapshots.forEach({
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
-        view.frame = CGRectOffset(view.frame, xOffset, yOffset)
-        view.alpha = 0.0
+        $0.frame = CGRectOffset($0.frame, xOffset, yOffset)
+        $0.alpha = 0.0
         
         let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
-        view.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 0.1, 0.1)
-      }
+        $0.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 0.01, 0.01)
+      })
     }) { _ in
       for view in snapshots {
         view.removeFromSuperview()

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -15,10 +15,25 @@ public class ExplodeAnimator: NSObject, AnimatedTransitioning {
   public var reverseAnimationType: TransitionAnimationType?
   public var interactiveGestureType: InteractiveGestureType?
   
-  init(transitionDuration: Duration) {
+  // MARK: - private
+  private var xFactor: CGFloat = 10.0
+  private var minAngle: CGFloat = -10.0
+  private var maxAngle: CGFloat = 10.0
+  
+  init(params: String, transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
-    self.transitionAnimationType = .Explode
-    self.reverseAnimationType = .Explode
+    self.transitionAnimationType = .Explode(params: params)
+    self.reverseAnimationType = .Explode(params: params)
+    
+    let params = params.componentsSeparatedByString(",")
+    if  let unwrappedXFactor = Double(params[0]),
+            unwrappedMinAngle = Double(params[1]),
+            unwrappedMaxAngle = Double(params[2])
+      where params.count == 3 {
+        self.xFactor = CGFloat(unwrappedXFactor)
+        self.minAngle = CGFloat(unwrappedMinAngle)
+        self.maxAngle = CGFloat(unwrappedMaxAngle)
+    }
     super.init()
   }
 }
@@ -51,7 +66,6 @@ private extension ExplodeAnimator {
   func createSnapshots(toView toView: UIView, fromView: UIView, containerView: UIView) -> [UIView] {
     let size = toView.frame.size
     var snapshots = [UIView]()
-    let xFactor: CGFloat = 10.0
     let yFactor = xFactor * size.height / size.width
     
     let fromViewSnapshot = fromView.snapshotViewAfterScreenUpdates(false)
@@ -72,12 +86,12 @@ private extension ExplodeAnimator {
       snapshots.forEach{
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
-        let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
+        let angle = self.randomFloatBetween(lower: self.minAngle, upper: self.maxAngle)
 
         let translateTransform = CGAffineTransformMakeTranslation($0.frame.origin.x - xOffset, $0.frame.origin.y - yOffset)
         let angleTransform = CGAffineTransformRotate(translateTransform, angle)
-        let scaleTransform = CGAffineTransformScale(angleTransform, 0.1, 0.1)
-
+        let scaleTransform = CGAffineTransformScale(angleTransform, 0.01, 0.01)
+        
         $0.transform = scaleTransform
         $0.alpha = 0.0
       }

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -69,7 +69,7 @@ private extension ExplodeAnimator {
   }
   
   func animateSnapshotsExplode(snapshots: [UIView], completion: () -> Void) {
-    UIView.animateWithDuration(transitionDuration, animations: {
+    UIView.animateWithDuration(2, animations: {
       for view in snapshots {
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
@@ -77,7 +77,7 @@ private extension ExplodeAnimator {
         view.alpha = 0.0
         
         let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
-        view.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 1.0, 1.0)
+        view.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 0.1, 0.1)
       }
     }) { _ in
       for view in snapshots {

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -38,11 +38,23 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
     containerView.addSubview(toView)
     containerView.sendSubviewToBack(toView)
     
+    let snapshots = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
+    containerView.sendSubviewToBack(fromView)
+    animateSnapshotsExplode(snapshots) {
+      transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }
+  }
+  
+}
+
+private extension ExplodeAnimator {
+  
+  func createSnapshots(toView toView: UIView, fromView: UIView, containerView: UIView) -> [UIView] {
     let size = toView.frame.size
     var snapshots = [UIView]()
     let xFactor: CGFloat = 10.0
     let yFactor = xFactor * size.height / size.width
-
+    
     let fromViewSnapshot = fromView.snapshotViewAfterScreenUpdates(false)
     for x in 0.stride(to: Int(size.width), by: Int(size.width / xFactor)) {
       for y in 0.stride(to: Int(size.height), by: Int(size.width / yFactor)) {
@@ -53,8 +65,10 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
         snapshots.append(snapshot)
       }
     }
-
-    containerView.sendSubviewToBack(fromView)
+    return snapshots
+  }
+  
+  func animateSnapshotsExplode(snapshots: [UIView], completion: () -> Void) {
     UIView.animateWithDuration(transitionDuration, animations: {
       for view in snapshots {
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
@@ -65,16 +79,16 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
         let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
         view.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 1.0, 1.0)
       }
-      }) { _ in
-        for view in snapshots {
-          view.removeFromSuperview()
-        }
-        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }) { _ in
+      for view in snapshots {
+        view.removeFromSuperview()
+      }
+      completion()
     }
   }
   
-  private func randomFloatBetween(lower lower: CGFloat, upper: CGFloat) -> CGFloat {
+  func randomFloatBetween(lower lower: CGFloat, upper: CGFloat) -> CGFloat {
     return CGFloat(arc4random_uniform(UInt32(upper - lower))) + lower
-  }
   
+  }
 }

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -1,0 +1,80 @@
+//
+//  ExplodeAnimator.swift
+//  IBAnimatableApp
+//
+//  Created by Tom Baranes on 03/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class ExplodeAnimator: NSObject, AnimatedTransitioning {
+  // MARK: - AnimatorProtocol
+  public var transitionAnimationType: TransitionAnimationType
+  public var transitionDuration: Duration = defaultTransitionDuration
+  public var reverseAnimationType: TransitionAnimationType?
+  public var interactiveGestureType: InteractiveGestureType?
+  
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    self.transitionAnimationType = .Explode
+    self.reverseAnimationType = .Explode
+    super.init()
+  }
+}
+
+extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return retrieveTransitionDuration(transitionContext)
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    let (tempfromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
+    guard let fromView = tempfromView, toView = tempToView, containerView = tempContainerView else {
+      transitionContext.completeTransition(true)
+      return
+    }
+    
+    containerView.addSubview(toView)
+    containerView.sendSubviewToBack(toView)
+    
+    let size = toView.frame.size
+    var snapshots = [UIView]()
+    let xFactor: CGFloat = 10.0
+    let yFactor = xFactor * size.height / size.width
+
+    let fromViewSnapshot = fromView.snapshotViewAfterScreenUpdates(false)
+    for x in 0.stride(to: Int(size.width), by: Int(size.width / xFactor)) {
+      for y in 0.stride(to: Int(size.height), by: Int(size.width / yFactor)) {
+        let snapshotRegion = CGRect(x: CGFloat(x), y: CGFloat(y), width: size.width / xFactor, height: size.height / yFactor)
+        let snapshot = fromViewSnapshot.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: false, withCapInsets: UIEdgeInsetsZero)
+        snapshot.frame = snapshotRegion
+        containerView.addSubview(snapshot)
+        snapshots.append(snapshot)
+      }
+    }
+
+    containerView.sendSubviewToBack(fromView)
+    UIView.animateWithDuration(transitionDuration, animations: {
+      for view in snapshots {
+        let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
+        let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
+        view.frame = CGRectOffset(view.frame, xOffset, yOffset)
+        view.alpha = 0.0
+        
+        let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
+        view.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 1.0, 1.0)
+      }
+      }) { _ in
+        for view in snapshots {
+          view.removeFromSuperview()
+        }
+        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }
+  }
+  
+  private func randomFloatBetween(lower lower: CGFloat, upper: CGFloat) -> CGFloat {
+    return CGFloat(arc4random_uniform(UInt32(upper - lower))) + lower
+  }
+  
+}

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -55,7 +55,7 @@ private extension ExplodeAnimator {
     let yFactor = xFactor * size.height / size.width
     
     let fromViewSnapshot = fromView.snapshotViewAfterScreenUpdates(false)
-    for x in 0.stride(to: Int(size.width), by: Int(size.width / xFactor)) {
+    for x in 0.0.stride(to: Double(size.width), by: Double(size.width / xFactor)) {
       for y in 0.0.stride(to: Double(size.height), by: Double(size.width / yFactor)) {
         let snapshotRegion = CGRect(x: CGFloat(x), y: CGFloat(y), width: size.width / xFactor, height: size.height / yFactor)
         let snapshot = fromViewSnapshot.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: false, withCapInsets: UIEdgeInsetsZero)
@@ -67,9 +67,9 @@ private extension ExplodeAnimator {
     return snapshots
   }
   
-  func animateSnapshotsExplode(snapshots: [UIView], completion: () -> Void) {
+  func animateSnapshotsExplode(snapshots: [UIView], completion: AnimatableCompletion) {
     UIView.animateWithDuration(transitionDuration, animations: {
-      snapshots.forEach({
+      snapshots.forEach{
         let xOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         let yOffset = self.randomFloatBetween(lower: -100.0, upper: 100.0)
         $0.frame = CGRectOffset($0.frame, xOffset, yOffset)
@@ -77,17 +77,16 @@ private extension ExplodeAnimator {
         
         let angle = self.randomFloatBetween(lower: -10.0, upper: 10.0)
         $0.transform = CGAffineTransformScale(CGAffineTransformMakeRotation(angle), 0.01, 0.01)
-      })
-    }) { _ in
-      for view in snapshots {
-        view.removeFromSuperview()
       }
+    },
+    completion: { _ in
+      snapshots.forEach{ $0.removeFromSuperview() }
       completion()
-    }
+    })
   }
   
   func randomFloatBetween(lower lower: CGFloat, upper: CGFloat) -> CGFloat {
     return CGFloat(arc4random_uniform(UInt32(upper - lower))) + lower
-  
   }
+  
 }

--- a/IBAnimatable/PresentExplodeSegue.swift
+++ b/IBAnimatable/PresentExplodeSegue.swift
@@ -1,0 +1,13 @@
+//
+//  Created by Tom Baranes on 03/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentExplodeSegue: UIStoryboardSegue {
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentExplodeSegue.swift
+++ b/IBAnimatable/PresentExplodeSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentExplodeSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: ""))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentExplodeSegue.swift
+++ b/IBAnimatable/PresentExplodeSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentExplodeSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PresentExplodeWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: ""), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PresentExplodeWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  IBAnimatableApp
+//
+//  Created by Tom Baranes on 03/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentExplodeWithDismissInteractionSegue: UIStoryboardSegue {
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PresentExplodeWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode, interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -14,7 +14,7 @@ public enum TransitionAnimationType {
   case FadeOut          // FromView Fades out
   case SystemSuckEffect
   case SystemRippleEffect
-  case Explode
+  case Explode(params: String)
   case SystemCube(direction: TransitionFromDirection)
   case SystemFlip(direction: TransitionFromDirection)
   case SystemMoveIn(direction: TransitionFromDirection)
@@ -34,7 +34,7 @@ public enum TransitionAnimationType {
     } else if transitionType.hasPrefix("SystemSuckEffect") {
         return .SystemSuckEffect
     } else if transitionType.hasPrefix("Explode") {
-      return .Explode
+      return .Explode(params: params(forTransitionType: transitionType))
     } else if transitionType.hasPrefix("Fade") {
       return fadeTransitionAnimationType(transitionType)
     } else if transitionType.hasPrefix("SystemCameraIris") {
@@ -64,7 +64,7 @@ private extension TransitionAnimationType {
   }
  
   static func cameraIrisTransitionAnimationType(transitionType: String) -> TransitionAnimationType? {
-    let transitionType = cleanTransitionType(transitionType)
+    let transitionType = params(forTransitionType: transitionType)
     if transitionType.containsString("hollowopen") {
       return .SystemCameraIris(hollowState: .Open)
     } else if transitionType.containsString("hollowclose") {
@@ -74,7 +74,7 @@ private extension TransitionAnimationType {
   }
   
   static func pageTransitionAnimationType(transitionType: String) -> TransitionAnimationType? {
-    let transitionType = cleanTransitionType(transitionType)
+    let transitionType = params(forTransitionType: transitionType)
     if transitionType.containsString("uncurl") {
       return .SystemPage(type: .UnCurl)
     } else if transitionType.containsString("curl") {
@@ -84,7 +84,7 @@ private extension TransitionAnimationType {
   }
   
   static func rotateTransitionAnimationType(transitionType: String) -> TransitionAnimationType? {
-    let transitionType = cleanTransitionType(transitionType)
+    let transitionType = params(forTransitionType: transitionType)
     if transitionType.containsString("90ccw") || transitionType.containsString("ninetyccw") {
       return .SystemRotate(degree: .NinetyCCW)
     } else if transitionType.containsString("90") || transitionType.containsString("ninety") {
@@ -122,16 +122,18 @@ private extension TransitionAnimationType {
 
 private extension TransitionAnimationType {
   
-  static func cleanTransitionType(transitionType: String) -> String {
+  static func params(forTransitionType transitionType: String) -> String {
     let range = transitionType.rangeOfString("(")
-    let transitionType = transitionType.stringByReplacingOccurrencesOfString(" ", withString: "")
+    var transitionType = transitionType.stringByReplacingOccurrencesOfString(" ", withString: "")
       .lowercaseString
       .substringFromIndex(range?.startIndex ?? transitionType.endIndex)
+      .stringByReplacingOccurrencesOfString("(", withString: "")
+      .stringByReplacingOccurrencesOfString(")", withString: "")
     return transitionType
   }
   
   static func transitionDirection(forTransitionType transitionType: String) -> TransitionFromDirection? {
-    let transitionType = cleanTransitionType(transitionType)
+    let transitionType = params(forTransitionType: transitionType)
     if transitionType.containsString("left") {
       return .Left
     } else if transitionType.containsString("right") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -14,6 +14,7 @@ public enum TransitionAnimationType {
   case FadeOut          // FromView Fades out
   case SystemSuckEffect
   case SystemRippleEffect
+  case Explode
   case SystemCube(direction: TransitionFromDirection)
   case SystemFlip(direction: TransitionFromDirection)
   case SystemMoveIn(direction: TransitionFromDirection)
@@ -32,6 +33,8 @@ public enum TransitionAnimationType {
       return .SystemRippleEffect
     } else if transitionType.hasPrefix("SystemSuckEffect") {
         return .SystemSuckEffect
+    } else if transitionType.hasPrefix("Explode") {
+      return .Explode
     } else if transitionType.hasPrefix("Fade") {
       return fadeTransitionAnimationType(transitionType)
     } else if transitionType.hasPrefix("SystemCameraIris") {

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -95,6 +95,9 @@
 		E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */; };
 		E27691F11CAFCBCF004A725C /* TransitionRotateDegree.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691F01CAFCBCF004A725C /* TransitionRotateDegree.swift */; };
 		E27691F31CAFCD67004A725C /* SystemRotateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */; };
+		E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */; };
+		E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */; };
+		E2A062B71CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */; };
 		E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
 		E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */; };
 /* End PBXBuildFile section */
@@ -206,6 +209,9 @@
 		E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRevealAnimator.swift; sourceTree = "<group>"; };
 		E27691F01CAFCBCF004A725C /* TransitionRotateDegree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionRotateDegree.swift; sourceTree = "<group>"; };
 		E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRotateAnimator.swift; sourceTree = "<group>"; };
+		E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplodeAnimator.swift; sourceTree = "<group>"; };
+		E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeSegue.swift; sourceTree = "<group>"; };
+		E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
 		E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		E2E28E711C6A6E70003F3852 /* GradientsTypeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradientsTypeScript.swift; path = Scripts/GradientsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -250,6 +256,8 @@
 				AE65CF911C96E35600A723F8 /* PresentFadeWithDismissInteractionSegue.swift */,
 				AE0635F71C9837DC003F9815 /* PresentFadeInWithDismissInteractionSegue.swift */,
 				AE0635FA1C9837E9003F9815 /* PresentFadeOutWithDismissInteractionSegue.swift */,
+				E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */,
+				E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */,
 			);
 			name = segue;
 			sourceTree = "<group>";
@@ -305,6 +313,7 @@
 				E20E91121CAC374200625094 /* SystemRippleEffectAnimator.swift */,
 				E20E91211CAC465A00625094 /* SystemSuckEffectAnimator.swift */,
 				E20E911D1CAC432400625094 /* SystemCameraIrisAnimator.swift */,
+				E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */,
 			);
 			name = "transition animator";
 			sourceTree = "<group>";
@@ -619,6 +628,7 @@
 				E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE6B016D1C2A444900950BB2 /* GradientDesignable.swift in Sources */,
 				AE677B9B1CADCFA800D62273 /* TransitionHollowState.swift in Sources */,
+				E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */,
 				AE65CF931C96E35600A723F8 /* PresentFadeWithDismissInteractionSegue.swift in Sources */,
 				AE677B981CADCF5900D62273 /* SystemSuckEffectAnimator.swift in Sources */,
 				AE154B061C787DDE0093C05B /* AnimatableNavigationController.swift in Sources */,
@@ -637,6 +647,7 @@
 				E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */,
 				E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				AE0635F91C9837DC003F9815 /* PresentFadeInWithDismissInteractionSegue.swift in Sources */,
+				E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */,
 				AEDD8A321C7EDAE30033175A /* SystemFlipAnimator.swift in Sources */,
 				AE6B01681C2A444900950BB2 /* BlurDesignable.swift in Sources */,
 				AE9407891CAE871C0084BCB8 /* TransitionPageType.swift in Sources */,
@@ -648,6 +659,7 @@
 				AE6B01701C2A444900950BB2 /* PaddingDesignable.swift in Sources */,
 				AE6B01841C2A445100950BB2 /* AnimatableTextView.swift in Sources */,
 				33A8B9F01C7E7A4C00082529 /* TransitionFromDirection.swift in Sources */,
+				E2A062B71CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift in Sources */,
 				AE94078A1CAE87860084BCB8 /* SystemPageAnimator.swift in Sources */,
 				AE6B01791C2A444900950BB2 /* ViewControllerDesignable.swift in Sources */,
 				AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */,

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -54,14 +54,13 @@ private extension TransitionTableViewController {
     transitionAnimations.append(transitionTypeWithDirections(forName: "SystemReveal"))
     transitionAnimationsHeaders.append("Page")
     transitionAnimations.append(["SystemPage(Curl)", "SystemPage(UnCurl)"])
-    transitionAnimationsHeaders.append("Suck Effect")
-    transitionAnimations.append(["SystemSuckEffect"])
     transitionAnimationsHeaders.append("Camera Iris")
     transitionAnimations.append(["SystemCameraIris", "SystemCameraIris(HollowOpen)", "SystemCameraIris(HollowClose)"])
-    transitionAnimationsHeaders.append("Ripple Effect")
-    transitionAnimations.append(["SystemRippleEffect"])
     transitionAnimationsHeaders.append("Rotate")
     transitionAnimations.append(["SystemRotate(90)", "SystemRotate(90ccw)", "SystemRotate(180)", "SystemRotate(180ccw)"])
+    transitionAnimationsHeaders.append("Others")
+    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode"])
+
   }
   
   func transitionTypeWithDirections(forName prefixName: String) -> [String] {

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -59,7 +59,7 @@ private extension TransitionTableViewController {
     transitionAnimationsHeaders.append("Rotate")
     transitionAnimations.append(["SystemRotate(90)", "SystemRotate(90ccw)", "SystemRotate(180)", "SystemRotate(180ccw)"])
     transitionAnimationsHeaders.append("Others")
-    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode"])
+    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode(10,-10,10)"])
 
   }
   


### PR DESCRIPTION
I always wanted to make an explode transition :laughing: 

Some points about that PR:
- You should definitely try it before validate it, it seems good to me, but we can adjust some default 
  values
- I didn't update the CHANGELOG, I think we shouldn't ship that transition with the new release, but keep it for the 2.3 in case we have breaking changes coming for custom transitions
- Didn't set any `InteractiveGestureType`, a nice gesture would be the pinch, but we need to create it before use it
- In the demo app, I group the transitions without parameters to make them clearer, but in a long term process, not sure what it will looks like
- Another thing we may improve is to make some values designable: number of snapshots, min / max, angle rotation... should we or is making it too complex? If we should, any thought about how to implement them?

Also, one question about the segue implementation, don't you think we can have a deeper abstraction? I mean, for most of them (currently implemented), they are all exactly the same, the only difference is `TransitionAnimationType` which is the most important part, but it duplicates a lot of code for only one parameter. I suppose the main reason for this is that we need one custom class by segue, but is there any way to improve it?

Once again, thanks for your great work on the transition abstraction, it's really easy to create new one :+1: 

Related to #155 
