### PR TITLE
Support PanScreenDdgeGesture for dismiss or pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project will be documented in this file.
 
 #### API breaking changes
 
+- Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller.
+ 
 #### Enhancements
+
+- Add `ScreenEdgePanInteractiveAnimator` to support `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `ScreenEdgePan(Left)`, `ScreenEdgePan(Right)`, `ScreenEdgePan(Top)`, `ScreenEdgePan(Bottom)`, `ScreenEdgePan(Horizontal)` and `ScreenEdgePan(Vertical)` for `ScreenEdgePan` gesture transition controller.
 
 #### Bugfixes
 

--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -31,7 +31,7 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
     if transitionDuration.isNaN {
       duration = defaultTransitionDuration
     }
-    if let interactiveGestureType = interactiveGestureType, gestureType = InteractiveGestureType(rawValue: interactiveGestureType) {
+    if let interactiveGestureType = interactiveGestureType, gestureType = InteractiveGestureType.fromString(interactiveGestureType) {
       navigator = Navigator(transitionAnimationType: animationType, transitionDuration: duration, interactiveGestureType: gestureType)
     } else {
       navigator = Navigator(transitionAnimationType: animationType, transitionDuration: duration)

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -50,7 +50,7 @@ import UIKit
     
     let toViewController = segue.destinationViewController
     // If interactiveGestureType has been set
-    if let interactiveGestureType = interactiveGestureType, interactiveGestureTypeValue = InteractiveGestureType(rawValue: interactiveGestureType) {
+    if let interactiveGestureType = interactiveGestureType, interactiveGestureTypeValue = InteractiveGestureType.fromString(interactiveGestureType) {
       toViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(animationType, transitionDuration: transitionDuration, interactiveGestureType: interactiveGestureTypeValue)
     }
     else {

--- a/IBAnimatable/Constants.swift
+++ b/IBAnimatable/Constants.swift
@@ -7,4 +7,4 @@ import Foundation
 
 // Default transition duration.
 // The default UIKit transtion animation duration is 0.35, but too fast for most of custom transition animations.
-let defaultTransitionDuration: Duration = 0.5
+let defaultTransitionDuration: Duration = 0.75

--- a/IBAnimatable/FadeAnimator.swift
+++ b/IBAnimatable/FadeAnimator.swift
@@ -10,7 +10,7 @@ public class FadeAnimator: NSObject, AnimatedTransitioning {
   public var transitionAnimationType: TransitionAnimationType
   public var transitionDuration: Duration = defaultTransitionDuration
   public var reverseAnimationType: TransitionAnimationType?
-  public var interactiveGestureType: InteractiveGestureType? = .PanHorizontally
+  public var interactiveGestureType: InteractiveGestureType? = .Pan(direction: .Horizontal)
 
   // MARK: - private
   private var fadeType: TransitionFadeType

--- a/IBAnimatable/GestureDirection.swift
+++ b/IBAnimatable/GestureDirection.swift
@@ -8,7 +8,7 @@ import Foundation
 /**
  GestureDirection: Used to specify the direction in `InteractiveGestureType`
  */
-public enum GestureDirection {
+public enum GestureDirection: String {
   case Horizontal
   case Vertical
   case Left

--- a/IBAnimatable/GestureDirection.swift
+++ b/IBAnimatable/GestureDirection.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Jake Lin on 4/5/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import Foundation
+
+/**
+ GestureDirection: Used to specify the direction in `InteractiveGestureType`
+ */
+public enum GestureDirection {
+  case Horizontal
+  case Vertical
+  case Left
+  case Right
+  case Top
+  case Bottom
+}

--- a/IBAnimatable/InteractiveAnimator.swift
+++ b/IBAnimatable/InteractiveAnimator.swift
@@ -37,7 +37,8 @@ public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
     }
   }
   
-  func handleInteractiveTransitionProgress(progress: CGFloat, shouldFinishInteractiveTransition: Bool, gestureRecognizer: UIGestureRecognizer) {
+  func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+    let (progress, shouldFinishInteractiveTransition) = calculateProgress(gestureRecognizer)
     
     switch gestureRecognizer.state {
     case .Began:
@@ -72,8 +73,8 @@ public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
     preconditionFailure("This method must be overridden")
   }
   
-  func handleGesture(gestureRecognizer: UIGestureRecognizer) {
-    preconditionFailure("This method must be overridden") 
+  func calculateProgress(gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
+    preconditionFailure("This method must be overridden")
   }
-  
+
 }

--- a/IBAnimatable/InteractiveAnimator.swift
+++ b/IBAnimatable/InteractiveAnimator.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 // Super class for all interactive animators
-public class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition {
+public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
   internal(set) public var interacting = false
   
   // transitionType: Used to deteminate pop or dismiss
@@ -30,14 +30,14 @@ public class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTrans
   
   func connectGestureRecognizer(viewController: UIViewController) {
     self.viewController = viewController
-    let gestureRecognizerType = getGestureRecognizerType()
-    gestureRecognizer = gestureRecognizerType.init(target: self, action: #selector(handleGesture(_:)))
+    let gestureRecognizerType = createGestureRecognizer()
+    gestureRecognizer = gestureRecognizerType
     if let gestureRecognizer = gestureRecognizer {
       self.viewController?.view.addGestureRecognizer(gestureRecognizer)
     }
   }
   
-  func getGestureRecognizerType() -> UIGestureRecognizer.Type {
+  func createGestureRecognizer() -> UIGestureRecognizer {
     preconditionFailure("This method must be overridden")
   }
   

--- a/IBAnimatable/InteractiveAnimator.swift
+++ b/IBAnimatable/InteractiveAnimator.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-// Super class for all interactive animators
+// Super abstract class for all interactive animator subclasses
 public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
   internal(set) public var interacting = false
   
@@ -37,6 +37,37 @@ public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
     }
   }
   
+  func handleInteractiveTransitionProgress(progress: CGFloat, shouldFinishInteractiveTransition: Bool, gestureRecognizer: UIGestureRecognizer) {
+    
+    switch gestureRecognizer.state {
+    case .Began:
+      interacting = true
+      switch transitionType {
+      case .NavigationTransition(.Pop):
+        viewController?.navigationController?.popViewControllerAnimated(true)
+      case .PresentationTransition(.Dismissal):
+        viewController?.dismissViewControllerAnimated(true, completion: nil)
+      default:
+        break
+      }
+    case .Changed:
+      updateInteractiveTransition(progress)
+    case .Cancelled, .Ended:
+      interacting = false
+      if shouldFinishInteractiveTransition {
+        finishInteractiveTransition()
+      } else {
+        cancelInteractiveTransition()
+      }
+    default:
+      // Something happened. cancel the transition.
+      interacting = false
+      cancelInteractiveTransition()
+      break
+    }
+  }
+  
+  // Because Swift doesn't support pure virtual method, need to throw error
   func createGestureRecognizer() -> UIGestureRecognizer {
     preconditionFailure("This method must be overridden")
   }

--- a/IBAnimatable/InteractiveAnimatorFactory.swift
+++ b/IBAnimatable/InteractiveAnimatorFactory.swift
@@ -1,0 +1,21 @@
+//
+//  Created by Jake Lin on 4/6/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+/**
+ Interactive Animator Factory
+ */
+struct InteractiveAnimatorFactory {
+  static func generateInteractiveAnimator(interactiveGestureType: InteractiveGestureType, transitionType: TransitionType) -> InteractiveAnimator? {
+    switch interactiveGestureType {
+    case .Pan:
+      return PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: transitionType)
+    case .ScreenEdgePan:
+      return ScreenEdgePanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: transitionType)
+    default:
+      return nil
+    }
+  }
+}

--- a/IBAnimatable/InteractiveGestureType.swift
+++ b/IBAnimatable/InteractiveGestureType.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum InteractiveGestureType {
   case Default          // Will use the default interactive gesture type from `AnimatedTransitioning`
   case Pan(direction: GestureDirection)
+  case ScreenEdgePan(direction: GestureDirection)
 
   var stringValue: String {
     return String(self)
@@ -19,7 +20,7 @@ public enum InteractiveGestureType {
   static func fromString(interactiveGestureType: String) -> InteractiveGestureType? {
     if interactiveGestureType.hasPrefix("Default") {
       return .Default
-    } else if interactiveGestureType.hasPrefix("Pan") {
+    } else if interactiveGestureType.hasPrefix("Pan") || interactiveGestureType.hasPrefix("ScreenEdgePan") {
       return fromStringWithDirection(interactiveGestureType)
     }
     return nil
@@ -46,6 +47,9 @@ private extension InteractiveGestureType {
     
     if interactiveGestureType.hasPrefix("Pan") {
       return .Pan(direction: direction)
+    }
+    else if interactiveGestureType.hasPrefix("ScreenEdgePan") {
+      return .ScreenEdgePan(direction: direction)
     }
     return nil
   }

--- a/IBAnimatable/InteractiveGestureType.swift
+++ b/IBAnimatable/InteractiveGestureType.swift
@@ -8,12 +8,54 @@ import Foundation
 /**
  The interactive gesture type
  */
-public enum InteractiveGestureType: String {
+public enum InteractiveGestureType {
   case Default          // Will use the default interactive gesture type from `AnimatedTransitioning`
-  case PanHorizontally
-  case PanVertically
-  case PanFromLeft
-  case PanFromRight
-  case PanFromTop
-  case PanFromBottom
+  case Pan(direction: GestureDirection)
+
+  static func fromString(interactiveGestureType: String) -> InteractiveGestureType? {
+    if interactiveGestureType.hasPrefix("Default") {
+      return .Default
+    } else if interactiveGestureType.hasPrefix("Pan") {
+      return fromStringWithDirection(interactiveGestureType)
+    }
+    return nil
+  }
+}
+
+// MARK: - InteractiveGestureType from string
+
+private extension InteractiveGestureType {
+  static func cleanInteractiveGestureType(interactiveGestureType: String) -> String {
+    let range = interactiveGestureType.rangeOfString("(")
+    let interactiveGestureType = interactiveGestureType.stringByReplacingOccurrencesOfString(" ", withString: "")
+      .lowercaseString
+      .substringFromIndex(range?.startIndex ?? interactiveGestureType.endIndex)
+    return interactiveGestureType
+  }
+  
+  static func interactiveGestureDirection(forInteractiveGestureType interactiveGestureType: String) -> GestureDirection? {
+    let interactiveGestureType = cleanInteractiveGestureType(interactiveGestureType)
+    if interactiveGestureType.containsString("left") {
+      return .Left
+    } else if interactiveGestureType.containsString("right") {
+      return .Right
+    } else if interactiveGestureType.containsString("top") {
+      return .Top
+    } else if interactiveGestureType.containsString("bottom") {
+      return .Bottom
+    }
+    return nil
+  }
+
+  static func fromStringWithDirection(interactiveGestureType: String) -> InteractiveGestureType? {
+    guard let direction = interactiveGestureDirection(forInteractiveGestureType: interactiveGestureType) else {
+      return nil
+    }
+    
+    if interactiveGestureType.hasPrefix("Pan") {
+      return .Pan(direction: direction)
+    }
+    return nil
+  }
+
 }

--- a/IBAnimatable/InteractiveGestureType.swift
+++ b/IBAnimatable/InteractiveGestureType.swift
@@ -37,22 +37,10 @@ private extension InteractiveGestureType {
     return interactiveGestureType
   }
   
-  static func interactiveGestureDirection(forInteractiveGestureType interactiveGestureType: String) -> GestureDirection? {
-    let interactiveGestureType = cleanInteractiveGestureType(interactiveGestureType)
-    if interactiveGestureType.containsString("left") {
-      return .Left
-    } else if interactiveGestureType.containsString("right") {
-      return .Right
-    } else if interactiveGestureType.containsString("top") {
-      return .Top
-    } else if interactiveGestureType.containsString("bottom") {
-      return .Bottom
-    }
-    return nil
-  }
-
   static func fromStringWithDirection(interactiveGestureType: String) -> InteractiveGestureType? {
-    guard let direction = interactiveGestureDirection(forInteractiveGestureType: interactiveGestureType) else {
+    let gestureDirectionString = cleanInteractiveGestureType(interactiveGestureType).capitalizedString
+    
+    guard let direction = GestureDirection(rawValue: gestureDirectionString) else {
       return nil
     }
     

--- a/IBAnimatable/InteractiveGestureType.swift
+++ b/IBAnimatable/InteractiveGestureType.swift
@@ -12,6 +12,10 @@ public enum InteractiveGestureType {
   case Default          // Will use the default interactive gesture type from `AnimatedTransitioning`
   case Pan(direction: GestureDirection)
 
+  var stringValue: String {
+    return String(self)
+  }
+  
   static func fromString(interactiveGestureType: String) -> InteractiveGestureType? {
     if interactiveGestureType.hasPrefix("Default") {
       return .Default

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -15,7 +15,7 @@ public class Navigator: NSObject {
   // animation controller
   private var animator: AnimatedTransitioning?
   // interaction controller
-  private var interactiveAnimator: PanInteractiveAnimator?
+  private var interactiveAnimator: InteractiveAnimator?
   
   public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration, interactiveGestureType: InteractiveGestureType? = nil) {
     self.transitionAnimationType = transitionAnimationType
@@ -30,10 +30,10 @@ public class Navigator: NSObject {
       switch interactiveGestureType {
       case .Default:
         if let interactiveGestureType = animator?.interactiveGestureType {
-          interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .NavigationTransition(.Pop))
+          interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .NavigationTransition(.Pop))
         }
       default:
-        interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .NavigationTransition(.Pop))
+        interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .NavigationTransition(.Pop))
       }
     }
   }

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -27,11 +27,12 @@ public class Navigator: NSObject {
     // If interactiveGestureType has been set
     if let interactiveGestureType = interactiveGestureType {
       // If configured as `.Default` then use the default interactive gesture type from the Animator
-      if interactiveGestureType == .Default {
+      switch interactiveGestureType {
+      case .Default:
         if let interactiveGestureType = animator?.interactiveGestureType {
           interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .NavigationTransition(.Pop))
         }
-      } else {
+      default:
         interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .NavigationTransition(.Pop))
       }
     }

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -12,10 +12,10 @@ public class PanInteractiveAnimator: InteractiveAnimator {
     return UIPanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
   }
   
-  override func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+  override func calculateProgress(gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
     guard let  gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer,
       superview = gestureRecognizer.view?.superview else {
-      return
+      return (0, false)
     }
     let translation = gestureRecognizer.translationInView(superview)
     let velocity = gestureRecognizer.velocityInView(superview)
@@ -52,14 +52,13 @@ public class PanInteractiveAnimator: InteractiveAnimator {
         speed = -velocity.y
       }
     default:
-      return
+      return (0, false)
     }
     
     progress = min(max(progress, 0), 0.99)
     
     // Finish the transition when pass the threathold
     let shouldFinishInteractiveTransition =  progress > 0.5 || speed > 1000
-    
-    handleInteractiveTransitionProgress(progress, shouldFinishInteractiveTransition: shouldFinishInteractiveTransition, gestureRecognizer: gestureRecognizer)
+    return (progress, shouldFinishInteractiveTransition)
   }
 }

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -6,10 +6,10 @@
 import UIKit
 
 // Pan interactive animator: pan gesture transition controller
-public class PanInteractiveAnimator: PercentDrivenInteractiveTransition {
+public class PanInteractiveAnimator: InteractiveAnimator {
   
-  override func getGestureRecognizerType() -> UIGestureRecognizer.Type {
-    return UIPanGestureRecognizer.self
+  override func createGestureRecognizer() -> UIGestureRecognizer {
+    return UIPanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
   }
   
   override func handleGesture(gestureRecognizer: UIGestureRecognizer) {

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -5,38 +5,16 @@
 
 import UIKit
 
-public class PanInteractiveAnimator: UIPercentDrivenInteractiveTransition {
-  private(set) public var interacting = false
+// Pan interactive animator: pan gesture transition controller
+public class PanInteractiveAnimator: PercentDrivenInteractiveTransition {
   
-  // transitionType: Used to deteminate pop or dismiss
-  private let transitionType: TransitionType
-  // interactiveGestureType: Used to deteminate gesture type (direction)
-  private let interactiveGestureType: InteractiveGestureType
-  // viewController: the viewController will connect to the gestureRecognizer
-  private var viewController: UIViewController?
-  // gestureRecognizer: the gesture recognizer to handle gesture
-  private var gestureRecognizer: UIPanGestureRecognizer?
-  
-  init(interactiveGestureType: InteractiveGestureType, transitionType: TransitionType) {
-    self.interactiveGestureType = interactiveGestureType
-    self.transitionType = transitionType
-    super.init()
+  override func getGestureRecognizerType() -> UIGestureRecognizer.Type {
+    return UIPanGestureRecognizer.self
   }
   
-  deinit {
-    gestureRecognizer?.removeTarget(self, action: #selector(handleGesture(_:)))
-  }
-  
-  func connectGestureRecognizer(viewController: UIViewController) {
-    self.viewController = viewController
-    gestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
-    if let gestureRecognizer = gestureRecognizer {
-      self.viewController?.view.addGestureRecognizer(gestureRecognizer)
-    }
-  }
-  
-  func handleGesture(gestureRecognizer: UIPanGestureRecognizer) {
-    guard let superview = gestureRecognizer.view?.superview else {
+  override func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+    guard let  gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer,
+      superview = gestureRecognizer.view?.superview else {
       return
     }
     let translation = gestureRecognizer.translationInView(superview)
@@ -105,4 +83,5 @@ public class PanInteractiveAnimator: UIPercentDrivenInteractiveTransition {
       break
     }
   }
+  
 }

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -56,32 +56,10 @@ public class PanInteractiveAnimator: InteractiveAnimator {
     }
     
     progress = min(max(progress, 0), 0.99)
-    switch gestureRecognizer.state {
-    case .Began:
-      interacting = true
-      switch transitionType {
-      case .NavigationTransition(.Pop):
-        viewController?.navigationController?.popViewControllerAnimated(true)
-      case .PresentationTransition(.Dismissal):
-        viewController?.dismissViewControllerAnimated(true, completion: nil)
-      default:
-        break
-      }
-    case .Changed:
-      updateInteractiveTransition(progress)
-    case .Cancelled, .Ended:
-      interacting = false
-      // Finish the transition when pass the threathold
-      if progress > 0.5 || speed > 1000 {
-        finishInteractiveTransition()
-      } else {
-        cancelInteractiveTransition()
-      }
-    default:
-      // Something happened. cancel the transition.
-      cancelInteractiveTransition()
-      break
-    }
+    
+    // Finish the transition when pass the threathold
+    let shouldFinishInteractiveTransition =  progress > 0.5 || speed > 1000
+    
+    handleInteractiveTransitionProgress(progress, shouldFinishInteractiveTransition: shouldFinishInteractiveTransition, gestureRecognizer: gestureRecognizer)
   }
-  
 }

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -46,30 +46,33 @@ public class PanInteractiveAnimator: UIPercentDrivenInteractiveTransition {
     let distance: CGFloat
     let speed: CGFloat
     switch interactiveGestureType {
-    case .PanHorizontally:
-      distance = superview.frame.width
-      progress = abs(translation.x / distance)
-      speed = abs(velocity.x)
-    case .PanFromLeft:
-      distance = superview.frame.width
-      progress = translation.x / distance
-      speed = velocity.x
-    case .PanFromRight:
-      distance = superview.frame.width
-      progress = -(translation.x / distance)
-      speed = -velocity.x
-    case .PanVertically:
-      distance = superview.frame.height
-      progress = abs(translation.y / distance)
-      speed = abs(velocity.y)
-    case .PanFromTop:
-      distance = superview.frame.height
-      progress = translation.y / distance
-      speed = velocity.y
-    case .PanFromBottom:
-      distance = superview.frame.height
-      progress = -translation.y / distance
-      speed = -velocity.y
+    case .Pan(let direction):
+      switch direction {
+      case .Horizontal:
+        distance = superview.frame.width
+        progress = abs(translation.x / distance)
+        speed = abs(velocity.x)
+      case .Left:
+        distance = superview.frame.width
+        progress = translation.x / distance
+        speed = velocity.x
+      case .Right:
+        distance = superview.frame.width
+        progress = -(translation.x / distance)
+        speed = -velocity.x
+      case .Vertical:
+        distance = superview.frame.height
+        progress = abs(translation.y / distance)
+        speed = abs(velocity.y)
+      case .Top:
+        distance = superview.frame.height
+        progress = translation.y / distance
+        speed = velocity.y
+      case .Bottom:
+        distance = superview.frame.height
+        progress = -translation.y / distance
+        speed = -velocity.y
+      }
     default:
       return
     }

--- a/IBAnimatable/PercentDrivenInteractiveTransition.swift
+++ b/IBAnimatable/PercentDrivenInteractiveTransition.swift
@@ -1,0 +1,48 @@
+//
+//  Created by Jake Lin on 4/5/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+// Super class for all interactive animators
+public class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition {
+  internal(set) public var interacting = false
+  
+  // transitionType: Used to deteminate pop or dismiss
+  let transitionType: TransitionType
+  // interactiveGestureType: Used to deteminate gesture type (direction)
+  let interactiveGestureType: InteractiveGestureType
+  // viewController: the viewController will connect to the gestureRecognizer
+  var viewController: UIViewController?
+  // gestureRecognizer: the gesture recognizer to handle gesture
+  var gestureRecognizer: UIGestureRecognizer?
+  
+  init(interactiveGestureType: InteractiveGestureType, transitionType: TransitionType) {
+    self.interactiveGestureType = interactiveGestureType
+    self.transitionType = transitionType
+    super.init()
+  }
+  
+  deinit {
+    gestureRecognizer?.removeTarget(self, action: #selector(handleGesture(_:)))
+  }
+  
+  func connectGestureRecognizer(viewController: UIViewController) {
+    self.viewController = viewController
+    let gestureRecognizerType = getGestureRecognizerType()
+    gestureRecognizer = gestureRecognizerType.init(target: self, action: #selector(handleGesture(_:)))
+    if let gestureRecognizer = gestureRecognizer {
+      self.viewController?.view.addGestureRecognizer(gestureRecognizer)
+    }
+  }
+  
+  func getGestureRecognizerType() -> UIGestureRecognizer.Type {
+    preconditionFailure("This method must be overridden")
+  }
+  
+  func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+    preconditionFailure("This method must be overridden") 
+  }
+  
+}

--- a/IBAnimatable/Presenter.swift
+++ b/IBAnimatable/Presenter.swift
@@ -21,9 +21,10 @@ public class Presenter: NSObject {
   var interactiveGestureType: InteractiveGestureType? {
     // Update `interactiveAnimator` if needed
     didSet {
-      if oldValue != interactiveGestureType {
+      // TODO: 
+//      if oldValue != interactiveGestureType {
         updateInteractiveAnimator()
-      }
+//      }
     }
   }
   
@@ -57,11 +58,12 @@ public class Presenter: NSObject {
     // If interactiveGestureType has been set
     if let interactiveGestureType = interactiveGestureType {
       // If configured as `.Default` then use the default interactive gesture type from the Animator
-      if interactiveGestureType == .Default {
+      switch interactiveGestureType {
+      case .Default:
         if let interactiveGestureType = animator?.interactiveGestureType {
           interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
         }
-      } else {
+      default:
         interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
       }
     }

--- a/IBAnimatable/Presenter.swift
+++ b/IBAnimatable/Presenter.swift
@@ -21,10 +21,9 @@ public class Presenter: NSObject {
   var interactiveGestureType: InteractiveGestureType? {
     // Update `interactiveAnimator` if needed
     didSet {
-      // TODO: 
-//      if oldValue != interactiveGestureType {
+      if oldValue?.stringValue != interactiveGestureType?.stringValue {
         updateInteractiveAnimator()
-//      }
+      }
     }
   }
   

--- a/IBAnimatable/Presenter.swift
+++ b/IBAnimatable/Presenter.swift
@@ -31,7 +31,7 @@ public class Presenter: NSObject {
   private var animator: AnimatedTransitioning?
   
   // interaction controller
-  private var interactiveAnimator: PanInteractiveAnimator?
+  private var interactiveAnimator: InteractiveAnimator?
   
   public init(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration, interactiveGestureType: InteractiveGestureType? = nil) {
     self.transitionAnimationType = transitionAnimationType
@@ -60,10 +60,10 @@ public class Presenter: NSObject {
       switch interactiveGestureType {
       case .Default:
         if let interactiveGestureType = animator?.interactiveGestureType {
-          interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
+          interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
         }
       default:
-        interactiveAnimator = PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
+        interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .PresentationTransition(.Dismissal))
       }
     }
     else {

--- a/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
+++ b/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
@@ -33,10 +33,10 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
     return gestureRecognizer
   }
   
-  override func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+  override func calculateProgress(gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
     guard let  gestureRecognizer = gestureRecognizer as? UIScreenEdgePanGestureRecognizer,
       superview = gestureRecognizer.view?.superview else {
-        return
+        return (0, false)
     }
     let translation = gestureRecognizer.translationInView(superview)
     let velocity = gestureRecognizer.velocityInView(superview)
@@ -73,7 +73,7 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
         speed = -velocity.y
       }
     default:
-      return
+      return (0, false)
     }
     
     progress = min(max(progress, 0), 0.99)
@@ -81,6 +81,6 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
     // Finish the transition when pass the threathold
     let shouldFinishInteractiveTransition =  progress > 0.5 || speed > 1000
     
-    handleInteractiveTransitionProgress(progress, shouldFinishInteractiveTransition: shouldFinishInteractiveTransition, gestureRecognizer: gestureRecognizer)
+    return (progress, shouldFinishInteractiveTransition)
   }
 }

--- a/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
+++ b/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
@@ -16,10 +16,14 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
         gestureRecognizer.edges = .Left
       case .Right:
         gestureRecognizer.edges = .Right
+      case .Horizontal:
+        gestureRecognizer.edges = [.Left, .Right]
       case .Top:
         gestureRecognizer.edges = .Top
       case .Bottom:
         gestureRecognizer.edges = .Bottom
+      case .Vertical:
+        gestureRecognizer.edges = [.Top, .Bottom]
       default:
         gestureRecognizer.edges = .Left
       }
@@ -73,32 +77,10 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
     }
     
     progress = min(max(progress, 0), 0.99)
-    switch gestureRecognizer.state {
-    case .Began:
-      interacting = true
-      switch transitionType {
-      case .NavigationTransition(.Pop):
-        viewController?.navigationController?.popViewControllerAnimated(true)
-      case .PresentationTransition(.Dismissal):
-        viewController?.dismissViewControllerAnimated(true, completion: nil)
-      default:
-        break
-      }
-    case .Changed:
-      updateInteractiveTransition(progress)
-    case .Cancelled, .Ended:
-      interacting = false
-      // Finish the transition when pass the threathold
-      if progress > 0.5 || speed > 1000 {
-        finishInteractiveTransition()
-      } else {
-        cancelInteractiveTransition()
-      }
-    default:
-      // Something happened. cancel the transition.
-      cancelInteractiveTransition()
-      break
-    }
+  
+    // Finish the transition when pass the threathold
+    let shouldFinishInteractiveTransition =  progress > 0.5 || speed > 1000
+    
+    handleInteractiveTransitionProgress(progress, shouldFinishInteractiveTransition: shouldFinishInteractiveTransition, gestureRecognizer: gestureRecognizer)
   }
-
 }

--- a/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
+++ b/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
@@ -1,0 +1,10 @@
+//
+//  Created by Jake Lin on 4/5/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class ScreenEdgePanInteractiveAnimator: UIPercentDrivenInteractiveTransition {
+
+}

--- a/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
+++ b/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
@@ -5,6 +5,100 @@
 
 import UIKit
 
-public class ScreenEdgePanInteractiveAnimator: UIPercentDrivenInteractiveTransition {
+public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
+  
+  override func createGestureRecognizer() -> UIGestureRecognizer {
+    let gestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
+    switch interactiveGestureType {
+    case .ScreenEdgePan(let direction):
+      switch direction {
+      case .Left:
+        gestureRecognizer.edges = .Left
+      case .Right:
+        gestureRecognizer.edges = .Right
+      case .Top:
+        gestureRecognizer.edges = .Top
+      case .Bottom:
+        gestureRecognizer.edges = .Bottom
+      default:
+        gestureRecognizer.edges = .Left
+      }
+    default:
+      break
+    }
+    return gestureRecognizer
+  }
+  
+  override func handleGesture(gestureRecognizer: UIGestureRecognizer) {
+    guard let  gestureRecognizer = gestureRecognizer as? UIScreenEdgePanGestureRecognizer,
+      superview = gestureRecognizer.view?.superview else {
+        return
+    }
+    let translation = gestureRecognizer.translationInView(superview)
+    let velocity = gestureRecognizer.velocityInView(superview)
+    
+    var progress: CGFloat
+    let distance: CGFloat
+    let speed: CGFloat
+    switch interactiveGestureType {
+    case .ScreenEdgePan(let direction):
+      switch direction {
+      case .Horizontal:
+        distance = superview.frame.width
+        progress = abs(translation.x / distance)
+        speed = abs(velocity.x)
+      case .Left:
+        distance = superview.frame.width
+        progress = translation.x / distance
+        speed = velocity.x
+      case .Right:
+        distance = superview.frame.width
+        progress = -(translation.x / distance)
+        speed = -velocity.x
+      case .Vertical:
+        distance = superview.frame.height
+        progress = abs(translation.y / distance)
+        speed = abs(velocity.y)
+      case .Top:
+        distance = superview.frame.height
+        progress = translation.y / distance
+        speed = velocity.y
+      case .Bottom:
+        distance = superview.frame.height
+        progress = -translation.y / distance
+        speed = -velocity.y
+      }
+    default:
+      return
+    }
+    
+    progress = min(max(progress, 0), 0.99)
+    switch gestureRecognizer.state {
+    case .Began:
+      interacting = true
+      switch transitionType {
+      case .NavigationTransition(.Pop):
+        viewController?.navigationController?.popViewControllerAnimated(true)
+      case .PresentationTransition(.Dismissal):
+        viewController?.dismissViewControllerAnimated(true, completion: nil)
+      default:
+        break
+      }
+    case .Changed:
+      updateInteractiveTransition(progress)
+    case .Cancelled, .Ended:
+      interacting = false
+      // Finish the transition when pass the threathold
+      if progress > 0.5 || speed > 1000 {
+        finishInteractiveTransition()
+      } else {
+        cancelInteractiveTransition()
+      }
+    default:
+      // Something happened. cancel the transition.
+      cancelInteractiveTransition()
+      break
+    }
+  }
 
 }

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -25,19 +25,19 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
     case .Left:
       self.transitionAnimationType = .SystemCube(direction: .Left)
       self.reverseAnimationType = .SystemCube(direction: .Right)
-      self.interactiveGestureType = .PanFromRight
+      self.interactiveGestureType = .Pan(direction: .Right)
     case .Right:
       self.transitionAnimationType = .SystemCube(direction: .Right)
       self.reverseAnimationType = .SystemCube(direction: .Left)
-      self.interactiveGestureType = .PanFromLeft
+      self.interactiveGestureType = .Pan(direction: .Left)
     case .Top:
       self.transitionAnimationType = .SystemCube(direction: .Top)
       self.reverseAnimationType = .SystemCube(direction: .Bottom)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .Pan(direction: .Bottom)
     case .Bottom:
       self.transitionAnimationType = .SystemCube(direction: .Bottom)
       self.reverseAnimationType = .SystemCube(direction: .Top)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .Pan(direction: .Top)
     }
     
     super.init()

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -25,19 +25,19 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
     case .Left:
       self.transitionAnimationType = .SystemCube(direction: .Left)
       self.reverseAnimationType = .SystemCube(direction: .Right)
-      self.interactiveGestureType = .Pan(direction: .Right)
+      self.interactiveGestureType = .ScreenEdgePan(direction: .Right)
     case .Right:
       self.transitionAnimationType = .SystemCube(direction: .Right)
       self.reverseAnimationType = .SystemCube(direction: .Left)
-      self.interactiveGestureType = .Pan(direction: .Left)
+      self.interactiveGestureType = .ScreenEdgePan(direction: .Left)
     case .Top:
       self.transitionAnimationType = .SystemCube(direction: .Top)
       self.reverseAnimationType = .SystemCube(direction: .Bottom)
-      self.interactiveGestureType = .Pan(direction: .Bottom)
+      self.interactiveGestureType = .ScreenEdgePan(direction: .Bottom)
     case .Bottom:
       self.transitionAnimationType = .SystemCube(direction: .Bottom)
       self.reverseAnimationType = .SystemCube(direction: .Top)
-      self.interactiveGestureType = .Pan(direction: .Top)
+      self.interactiveGestureType = .ScreenEdgePan(direction: .Top)
     }
     
     super.init()

--- a/IBAnimatable/SystemMoveInAnimator.swift
+++ b/IBAnimatable/SystemMoveInAnimator.swift
@@ -23,19 +23,19 @@ public class SystemMoveInAnimator: NSObject, AnimatedTransitioning {
     case .Left:
       self.transitionAnimationType = .SystemMoveIn(direction: .Left)
       self.reverseAnimationType = .SystemMoveIn(direction: .Right)
-      self.interactiveGestureType = .PanFromRight
+      self.interactiveGestureType = .Pan(direction: .Right)
     case .Right:
       self.transitionAnimationType = .SystemMoveIn(direction: .Right)
       self.reverseAnimationType = .SystemMoveIn(direction: .Left)
-      self.interactiveGestureType = .PanFromLeft
+      self.interactiveGestureType = .Pan(direction: .Left)
     case .Top:
       self.transitionAnimationType = .SystemMoveIn(direction: .Top)
       self.reverseAnimationType = .SystemMoveIn(direction: .Bottom)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .Pan(direction: .Bottom)
     case .Bottom:
       self.transitionAnimationType = .SystemMoveIn(direction: .Bottom)
       self.reverseAnimationType = .SystemMoveIn(direction: .Top)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .Pan(direction: .Top)
     }
     
     super.init()

--- a/IBAnimatable/SystemPushAnimator.swift
+++ b/IBAnimatable/SystemPushAnimator.swift
@@ -26,19 +26,19 @@ public class SystemPushAnimator: NSObject, AnimatedTransitioning {
     case .Left:
       self.transitionAnimationType = .SystemPush(direction: .Left)
       self.reverseAnimationType = .SystemPush(direction: .Right)
-      self.interactiveGestureType = .PanFromRight
+      self.interactiveGestureType = .Pan(direction: .Right)
     case .Right:
       self.transitionAnimationType = .SystemPush(direction: .Right)
       self.reverseAnimationType = .SystemPush(direction: .Left)
-      self.interactiveGestureType = .PanFromLeft
+      self.interactiveGestureType = .Pan(direction: .Left)
     case .Top:
       self.transitionAnimationType = .SystemPush(direction: .Top)
       self.reverseAnimationType = .SystemPush(direction: .Bottom)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .Pan(direction: .Bottom)
     case .Bottom:
       self.transitionAnimationType = .SystemPush(direction: .Bottom)
       self.reverseAnimationType = .SystemPush(direction: .Top)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .Pan(direction: .Top)
     }
     
     super.init()

--- a/IBAnimatable/SystemRevealAnimator.swift
+++ b/IBAnimatable/SystemRevealAnimator.swift
@@ -23,19 +23,19 @@ public class SystemRevealAnimator: NSObject, AnimatedTransitioning {
     case .Left:
       self.transitionAnimationType = .SystemReveal(direction: .Left)
       self.reverseAnimationType = .SystemReveal(direction: .Right)
-      self.interactiveGestureType = .PanFromRight
+      self.interactiveGestureType = .Pan(direction: .Right)
     case .Right:
       self.transitionAnimationType = .SystemReveal(direction: .Right)
       self.reverseAnimationType = .SystemReveal(direction: .Left)
-      self.interactiveGestureType = .PanFromLeft
+      self.interactiveGestureType = .Pan(direction: .Left)
     case .Top:
       self.transitionAnimationType = .SystemReveal(direction: .Top)
       self.reverseAnimationType = .SystemReveal(direction: .Bottom)
-      self.interactiveGestureType = .PanFromBottom
+      self.interactiveGestureType = .Pan(direction: .Bottom)
     case .Bottom:
       self.transitionAnimationType = .SystemReveal(direction: .Bottom)
       self.reverseAnimationType = .SystemReveal(direction: .Top)
-      self.interactiveGestureType = .PanFromTop
+      self.interactiveGestureType = .Pan(direction: .Top)
     }
     
     super.init()

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		AE9407871CAE86DE0084BCB8 /* TransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6D430B1C98B658006E2F67 /* TransitionType.swift */; };
 		AE9407891CAE871C0084BCB8 /* TransitionPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */; };
 		AE94078A1CAE87860084BCB8 /* SystemPageAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageAnimator.swift */; };
+		AEC23FC01CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */; };
+		AEC23FC21CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */; };
 		AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
@@ -163,6 +165,8 @@
 		AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientStartPoint.swift; path = IBAnimatable/GradientStartPoint.swift; sourceTree = SOURCE_ROOT; };
 		AE8FBAA81C853C7A00EB8AEA /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionPageType.swift; sourceTree = "<group>"; };
+		AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenEdgePanInteractiveAnimator.swift; sourceTree = "<group>"; };
+		AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PercentDrivenInteractiveTransition.swift; sourceTree = "<group>"; };
 		AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureDirection.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -315,6 +319,8 @@
 			isa = PBXGroup;
 			children = (
 				AE4C53F11C883F80007C9EFA /* PanInteractiveAnimator.swift */,
+				AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */,
+				AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */,
 			);
 			name = "interactive animator";
 			sourceTree = "<group>";
@@ -615,6 +621,7 @@
 				AE6B01731C2A444900950BB2 /* ShadowDesignable.swift in Sources */,
 				AE6B01621C2A444000950BB2 /* AnimationType.swift in Sources */,
 				AE154B8C1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */,
+				AEC23FC21CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift in Sources */,
 				E27691F31CAFCD67004A725C /* SystemRotateAnimator.swift in Sources */,
 				AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE4C53F31C883F80007C9EFA /* PanInteractiveAnimator.swift in Sources */,
@@ -666,6 +673,7 @@
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
 				AE6B016E1C2A444900950BB2 /* NavigationBarDesginable.swift in Sources */,
+				AEC23FC01CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift in Sources */,
 				AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */,
 				AE6B01861C2A445100950BB2 /* DesignableNavigationBar.swift in Sources */,
 				AE677B9A1CADCF6700D62273 /* SystemRippleEffectAnimator.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		AE9407871CAE86DE0084BCB8 /* TransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6D430B1C98B658006E2F67 /* TransitionType.swift */; };
 		AE9407891CAE871C0084BCB8 /* TransitionPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */; };
 		AE94078A1CAE87860084BCB8 /* SystemPageAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageAnimator.swift */; };
+		AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
 		AED1A1051BFE9820001346FA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */; };
@@ -162,6 +163,7 @@
 		AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientStartPoint.swift; path = IBAnimatable/GradientStartPoint.swift; sourceTree = SOURCE_ROOT; };
 		AE8FBAA81C853C7A00EB8AEA /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionPageType.swift; sourceTree = "<group>"; };
+		AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureDirection.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		AED1A0FE1BFE9820001346FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 				AE81DB4D1C11DF00000AEB20 /* BlurEffectStyle.swift */,
 				AED97B851C1710A900D2B0B8 /* BorderSide.swift */,
 				E2472EA31C6F97F800A20E27 /* ColorType.swift */,
+				AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */,
 				AE8C53AF1C0F1C0400A775AF /* GradientStartPoint.swift */,
 				E2E28E6A1C6A6C30003F3852 /* GradientType.swift */,
 				AE4C53F41C8843AB007C9EFA /* InteractiveGestureType.swift */,
@@ -663,6 +666,7 @@
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
 				AE6B016E1C2A444900950BB2 /* NavigationBarDesginable.swift in Sources */,
+				AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */,
 				AE6B01861C2A445100950BB2 /* DesignableNavigationBar.swift in Sources */,
 				AE677B9A1CADCF6700D62273 /* SystemRippleEffectAnimator.swift in Sources */,
 				AEE552AB1C816233009CF623 /* TransitionFadeType.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		AE6B01881C2A445800950BB2 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3A1C1ECA4200B5289B /* UIViewControllerExtension.swift */; };
 		AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */; };
 		AE6C21061C842A0F00DB6892 /* TransitionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */; };
+		AE7C26111CB4F680002CF125 /* InteractiveAnimatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7C26101CB4F680002CF125 /* InteractiveAnimatorFactory.swift */; };
 		AE8964DB1C2CC0D100D3E9F0 /* RootWindowDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8964DA1C2CC0D100D3E9F0 /* RootWindowDesignable.swift */; };
 		AE8A4FFA1C856EEC00E9E368 /* TransitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8A4FF91C856EEC00E9E368 /* TransitionViewController.swift */; };
 		AE8FBAA91C853C7A00EB8AEA /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8FBAA81C853C7A00EB8AEA /* Functions.swift */; };
@@ -76,7 +77,7 @@
 		AE9407891CAE871C0084BCB8 /* TransitionPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */; };
 		AE94078A1CAE87860084BCB8 /* SystemPageAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageAnimator.swift */; };
 		AEC23FC01CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */; };
-		AEC23FC21CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */; };
+		AEC23FC21CB3DE0900E42D99 /* InteractiveAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FC11CB3DE0900E42D99 /* InteractiveAnimator.swift */; };
 		AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
@@ -157,6 +158,7 @@
 		AE6C66FF1BFBF93500134A35 /* IBAnimatableApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IBAnimatableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE6D430B1C98B658006E2F67 /* TransitionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionType.swift; sourceTree = "<group>"; };
 		AE74D6D61C166FB100718E0E /* SideImageDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideImageDesignable.swift; sourceTree = "<group>"; };
+		AE7C26101CB4F680002CF125 /* InteractiveAnimatorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractiveAnimatorFactory.swift; sourceTree = "<group>"; };
 		AE81DAED1C10F14C000AEB20 /* GradientDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GradientDesignable.swift; path = IBAnimatable/GradientDesignable.swift; sourceTree = SOURCE_ROOT; };
 		AE81DB4D1C11DF00000AEB20 /* BlurEffectStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BlurEffectStyle.swift; path = IBAnimatable/BlurEffectStyle.swift; sourceTree = SOURCE_ROOT; };
 		AE81DB4F1C12E060000AEB20 /* RotationDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RotationDesignable.swift; path = IBAnimatable/RotationDesignable.swift; sourceTree = SOURCE_ROOT; };
@@ -166,7 +168,7 @@
 		AE8FBAA81C853C7A00EB8AEA /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionPageType.swift; sourceTree = "<group>"; };
 		AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenEdgePanInteractiveAnimator.swift; sourceTree = "<group>"; };
-		AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PercentDrivenInteractiveTransition.swift; sourceTree = "<group>"; };
+		AEC23FC11CB3DE0900E42D99 /* InteractiveAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractiveAnimator.swift; sourceTree = "<group>"; };
 		AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureDirection.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -318,8 +320,8 @@
 		AE4C53F01C883E14007C9EFA /* interactive animator */ = {
 			isa = PBXGroup;
 			children = (
+				AEC23FC11CB3DE0900E42D99 /* InteractiveAnimator.swift */,
 				AE4C53F11C883F80007C9EFA /* PanInteractiveAnimator.swift */,
-				AEC23FC11CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift */,
 				AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */,
 			);
 			name = "interactive animator";
@@ -329,6 +331,7 @@
 			isa = PBXGroup;
 			children = (
 				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
+				AE7C26101CB4F680002CF125 /* InteractiveAnimatorFactory.swift */,
 				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
 				AE154B8D1C7D89CB0093C05B /* Presenter.swift */,
 				AEE552AF1C839EB7009CF623 /* PresenterManager.swift */,
@@ -621,7 +624,7 @@
 				AE6B01731C2A444900950BB2 /* ShadowDesignable.swift in Sources */,
 				AE6B01621C2A444000950BB2 /* AnimationType.swift in Sources */,
 				AE154B8C1C7D59EE0093C05B /* AnimatorFactory.swift in Sources */,
-				AEC23FC21CB3DE0900E42D99 /* PercentDrivenInteractiveTransition.swift in Sources */,
+				AEC23FC21CB3DE0900E42D99 /* InteractiveAnimator.swift in Sources */,
 				E27691F31CAFCD67004A725C /* SystemRotateAnimator.swift in Sources */,
 				AE154B291C7BB52E0093C05B /* Typealias.swift in Sources */,
 				AE4C53F31C883F80007C9EFA /* PanInteractiveAnimator.swift in Sources */,
@@ -686,6 +689,7 @@
 				AE6B017E1C2A445100950BB2 /* AnimatableImageView.swift in Sources */,
 				AE6B01761C2A444900950BB2 /* TableViewCellDesignable.swift in Sources */,
 				CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */,
+				AE7C26111CB4F680002CF125 /* InteractiveAnimatorFactory.swift in Sources */,
 				AE4C53F61C8843AB007C9EFA /* InteractiveGestureType.swift in Sources */,
 				CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */,
 				CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */,


### PR DESCRIPTION
In this PR
1. Refactor `InteractiveGestureType` to use more Swifty way. Remove `PanFromLeft`, `PanFromRight` and so on, and use `Pan(Left)` and `Pan(Right)` instead.
2. Create `InteractiveAnimator` abstract (kind of, but Swift doesn't have it) class to encapsulate all logic for `InteractiveAnimator` subclasses
3. Change the default transition duration to 0.75, it looks nicer for most of transition animations.
4. Add `ScreenEdgePanInteractiveAnimator` to support `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `ScreenEdgePan(Left)`, `ScreenEdgePan(Right)`, `ScreenEdgePan(Top)`, `ScreenEdgePan(Bottom)`, `ScreenEdgePan(Horizontal)` and `ScreenEdgePan(Vertical)` for `ScreenEdgePan` gesture transition controller.

It is very easy to add new `***InteractiveAnimator` like `PinchInteractiveAnimator` because most of logic is in `InteractiveAnimator` abstract class.

@tbaranes could you please have a look when you have time. I will add Pinch gesture to `ExplodeAnimator` in next PR, thanks.

Refer to #125
