### PR TITLE
Fold transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)
 
 - Add `ExplodeAnimator` to support Explode transition animation. It supports parameters `Explode(xFactor, minAngle, maxAngle)`, if no specified, the default values are `Explode(10, -10, 10)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
-- Add `FoldAnimator` to support Fold transition animation. It supports parameters `Explode(nbFolds)`, if no specified, the default values are `Fold(2)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+- Add `FoldAnimator` to support Fold transition animation. It supports parameters `Explode(direction, nbFolds)`, if no specified, the default values are `Fold(Left, 2)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
  
 #### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ All notable changes to this project will be documented in this file.
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)
 
 - Add `ExplodeAnimator` to support Explode transition animation. It supports parameters `Explode(xFactor, minAngle, maxAngle)`, if no specified, the default values are `Explode(10, -10, 10)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
-- Add `FoldAnimator` to support Fold transition animation. It supports parameters `Explode(direction, nbFolds)`, if no specified, the default values are `Fold(Left, 2)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
  
 #### Enhancements
 
 - Add `ScreenEdgePanInteractiveAnimator` to support `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `ScreenEdgePan(Left)`, `ScreenEdgePan(Right)`, `ScreenEdgePan(Top)`, `ScreenEdgePan(Bottom)`, `ScreenEdgePan(Horizontal)` and `ScreenEdgePan(Vertical)` for `ScreenEdgePan` gesture transition controller. [125](https://github.com/JakeLin/IBAnimatable/issues/125)
 - Support multiple sides for border [#168](https://github.com/JakeLin/IBAnimatable/pull/168)
+- Add `FoldAnimator` to support Fold transition animation. It supports parameters `Explode(direction, nbFolds)`, if no specified, the default values are `Fold(Left, 2)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+
 
 #### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)
 
-- Add `ExplodeAnimator` to support Explode transition animation. It supports parmaters `Explode(xFactor, minAngle, maxAngle)`, if no specified, the default values are Explode(10, -10, 10). [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+- Add `ExplodeAnimator` to support Explode transition animation. It supports parameters `Explode(xFactor, minAngle, maxAngle)`, if no specified, the default values are `Explode(10, -10, 10)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+- Add `FoldAnimator` to support Fold transition animation. It supports parameters `Explode(nbFolds)`, if no specified, the default values are `Fold(2)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
  
 #### Enhancements
 

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -24,8 +24,8 @@ struct AnimatorFactory {
       return SystemSuckEffectAnimator(transitionDuration: transitionDuration)
     case .SystemRippleEffect:
       return SystemRippleEffectAnimator(transitionDuration: transitionDuration)
-    case .Fold:
-      return FoldAnimator(transitionDuration: transitionDuration)
+    case .Fold(let params):
+      return FoldAnimator(params: params, transitionDuration: transitionDuration)
     case .Explode(let params):
       return ExplodeAnimator(params: params, transitionDuration: transitionDuration)
     case .SystemCube(let direction):

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -25,10 +25,9 @@ struct AnimatorFactory {
     case .SystemRippleEffect:
       return SystemRippleEffectAnimator(transitionDuration: transitionDuration)
     case let .Explode(params):
-    case .Fold(let params):
-      return FoldAnimator(params: params, transitionDuration: transitionDuration)
-    case .Explode(let params):
       return ExplodeAnimator(params: params, transitionDuration: transitionDuration)
+    case let .Fold(direction, params):
+      return FoldAnimator(fromDirection: direction, params: params, transitionDuration: transitionDuration)
     case let .SystemCube(direction):
       return SystemCubeAnimator(fromDirection: direction, transitionDuration: transitionDuration)
     case let .SystemFlip(direction):

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -24,6 +24,8 @@ struct AnimatorFactory {
       return SystemSuckEffectAnimator(transitionDuration: transitionDuration)
     case .SystemRippleEffect:
       return SystemRippleEffectAnimator(transitionDuration: transitionDuration)
+    case .Fold:
+      return FoldAnimator(transitionDuration: transitionDuration)
     case .Explode(let params):
       return ExplodeAnimator(params: params, transitionDuration: transitionDuration)
     case .SystemCube(let direction):

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -20,19 +20,19 @@ public class ExplodeAnimator: NSObject, AnimatedTransitioning {
   private var minAngle: CGFloat = -10.0
   private var maxAngle: CGFloat = 10.0
   
-  init(params: String, transitionDuration: Duration) {
+  init(params: [String], transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
     self.transitionAnimationType = .Explode(params: params)
     self.reverseAnimationType = .Explode(params: params)
     
-    let params = params.componentsSeparatedByString(",")
-    if  let unwrappedXFactor = Double(params[0]),
-            unwrappedMinAngle = Double(params[1]),
-            unwrappedMaxAngle = Double(params[2])
-      where params.count == 3 {
+    if params.count == 3 {
+      if let unwrappedXFactor = Double(params[0]),
+             unwrappedMinAngle = Double(params[1]),
+             unwrappedMaxAngle = Double(params[2]) {
         self.xFactor = CGFloat(unwrappedXFactor)
         self.minAngle = CGFloat(unwrappedMinAngle)
         self.maxAngle = CGFloat(unwrappedMaxAngle)
+      }
     }
     super.init()
   }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -12,9 +12,11 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   public var reverseAnimationType: TransitionAnimationType?
   public var interactiveGestureType: InteractiveGestureType? = .Default
   
-  // MARK: - Private
+  // MARK: - Private params
   private var reverse: Bool = false
   private var folds: Int = 2
+  
+  // MARK: - Private fold transition
   
   private var transform: CATransform3D = CATransform3DIdentity
   private var size: CGSize = CGSize.zero
@@ -22,10 +24,15 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   
   // MARK: - Life cycle
   
-  init(transitionDuration: Duration) {
+  init(params: String, transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
-    self.transitionAnimationType = .Fold
-    self.reverseAnimationType = .Fold
+    self.transitionAnimationType = .Fold(params: params)
+    self.reverseAnimationType = .Fold(params: params)
+    
+    let params = params.componentsSeparatedByString(",")
+    if let unwrappedFolds = Int(params[0]) where params.count == 1 {
+      self.folds = unwrappedFolds
+    }
     super.init()
   }
 }
@@ -93,18 +100,17 @@ private extension FoldAnimator {
     return [toViewFolds, fromViewFolds]
   }
   
-  func createSnapshot(fromView view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView{
+  func createSnapshot(fromView view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView {
     let containerView = view.superview
     var snapshotView: UIView
+    let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldWidth, height: size.height)
     if !afterUpdates {
-      let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldWidth, height: size.height)
       snapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
     } else {
       snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: foldWidth, height: size.height))
       snapshotView.backgroundColor = view.backgroundColor;
-      let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldWidth, height: size.height)
-      let snapshotView2 = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
-      snapshotView.addSubview(snapshotView2)
+      let subSnapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
+      snapshotView.addSubview(subSnapshotView)
     }
     
     let snapshotWithShadowView = addShadow(toView: snapshotView, reverse: left)
@@ -171,7 +177,6 @@ private extension FoldAnimator {
       }
       
       completion()
-
     })
   }
   

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -13,6 +13,7 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType? = .Default
   
   // MARK: - Private params
+  private var fromDirection: TransitionFromDirection
   private var reverse: Bool = false
   private var folds: Int = 2
   
@@ -22,15 +23,15 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   private var foldWidth: CGFloat = 0.0
   
   // MARK: - Life cycle
-  init(params: String, transitionDuration: Duration) {
+  init(fromDirection: TransitionFromDirection, params: [String], transitionDuration: Duration) {
+    self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
-    self.transitionAnimationType = .Fold(params: params)
-    self.reverseAnimationType = .Fold(params: params)
-    
-    let params = params.componentsSeparatedByString(",")
-    if let unwrappedFolds = Int(params[0]) where params.count == 1 {
-      self.folds = unwrappedFolds
-    }
+    self.transitionAnimationType = .Fold(direction: fromDirection, params: params)
+    self.reverseAnimationType = .Fold(direction: fromDirection, params: params)
+        
+//    if let unwrappedFolds = Int(params[0]) where params.count == 1 {
+//      self.folds = unwrappedFolds
+//    }
     super.init()
   }
 }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -1,0 +1,178 @@
+//
+//  Created by Tom Baranes on 09/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class FoldAnimator: NSObject, AnimatedTransitioning {
+  // MARK: - AnimatorProtocol
+  public var transitionAnimationType: TransitionAnimationType
+  public var transitionDuration: Duration = defaultTransitionDuration
+  public var reverseAnimationType: TransitionAnimationType?
+  public var interactiveGestureType: InteractiveGestureType? = .Default
+  
+  // MARK: - Private
+  private var reverse: Bool = false
+  private var folds: Int = 2
+  
+  private var transform: CATransform3D = CATransform3DIdentity
+  private var size: CGSize = CGSize.zero
+  private var foldWidth: CGFloat = 0.0
+  
+  // MARK: - Life cycle
+  
+  init(transitionDuration: Duration) {
+    self.transitionDuration = transitionDuration
+    self.transitionAnimationType = .Fold
+    self.reverseAnimationType = .Fold
+    super.init()
+  }
+}
+
+extension FoldAnimator: UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    return retrieveTransitionDuration(transitionContext)
+  }
+  
+  public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+    let (tempfromView, tempToView, tempContainerView) = retrieveViews(transitionContext)
+    guard let fromView = tempfromView, toView = tempToView, containerView = tempContainerView else {
+      transitionContext.completeTransition(true)
+      return
+    }
+    
+    toView.frame = CGRectOffset(toView.frame, toView.frame.size.width, 0)
+    containerView.addSubview(toView)
+    
+    transform.m34 = -0.005
+    containerView.layer.sublayerTransform = transform
+    
+    size = toView.frame.size
+    foldWidth = size.width * 0.5 / CGFloat(folds)
+
+    let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
+    animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1]) {
+      toView.frame = containerView.bounds;
+      fromView.frame = containerView.bounds;
+      transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+    }
+  }
+  
+}
+
+// MARK: - Setup fold transition
+
+private extension FoldAnimator {
+  
+  func createSnapshots(toView toView: UIView, fromView: UIView, containerView: UIView) -> [[UIView]] {
+    var fromViewFolds = [UIView]()
+    var toViewFolds = [UIView]()
+    for i in 0..<folds {
+      let offset = CGFloat(i) * foldWidth * 2
+      let leftFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset, left: true)
+      leftFromViewFold.layer.position = CGPoint(x: offset, y: size.height / 2)
+      fromViewFolds.append(leftFromViewFold)
+      leftFromViewFold.subviews[1].alpha = 0.0
+
+      let rightFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset + foldWidth, left: false)
+      rightFromViewFold.layer.position = CGPoint(x: offset + foldWidth * 2, y: size.height / 2);
+      fromViewFolds.append(rightFromViewFold)
+      rightFromViewFold.subviews[1].alpha = 0.0
+
+      let leftToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset, left: true)
+      leftToViewFold.layer.position = CGPointMake(self.reverse ? size.width : 0.0, size.height / 2)
+      leftToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(M_PI_2), 0.0, 1.0, 0.0)
+      toViewFolds.append(leftToViewFold)
+
+      let rightToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset + foldWidth, left: false)
+      rightToViewFold.layer.position = CGPointMake(self.reverse ? size.width : 0.0, size.height / 2)
+      rightToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(-M_PI_2), 0.0, 1.0, 0.0)
+      toViewFolds.append(rightToViewFold)
+    }
+    return [toViewFolds, fromViewFolds]
+  }
+  
+  func createSnapshot(fromView view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView{
+    let containerView = view.superview
+    var snapshotView: UIView
+    if !afterUpdates {
+      let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldWidth, height: size.height)
+      snapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
+    } else {
+      snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: foldWidth, height: size.height))
+      snapshotView.backgroundColor = view.backgroundColor;
+      let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldWidth, height: size.height)
+      let snapshotView2 = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
+      snapshotView.addSubview(snapshotView2)
+    }
+    
+    let snapshotWithShadowView = addShadow(toView: snapshotView, reverse: left)
+    containerView?.addSubview(snapshotWithShadowView)
+    snapshotWithShadowView.layer.anchorPoint = CGPoint(x: left ? 0.0 : 1.0, y: 0.5)
+    return snapshotWithShadowView
+  }
+  
+  func addShadow(toView view: UIView, reverse: Bool) -> UIView {
+    let viewWithShadow = UIView(frame: view.frame)
+    let shadowView = UIView(frame: viewWithShadow.bounds)
+    let gradient = CAGradientLayer()
+    gradient.frame = shadowView.bounds
+    gradient.colors = [UIColor(white: 0.0, alpha: 0.0).CGColor, UIColor(white: 0.0, alpha: 1.0).CGColor]
+    gradient.startPoint = CGPoint(x: reverse ? 0.0 : 1.0, y: reverse ? 0.2 : 0.0)
+    gradient.endPoint = CGPoint(x: reverse ? 1.0 : 0.0, y: reverse ? 0.0 : 1.0)
+    shadowView.layer.insertSublayer(gradient, atIndex: 1)
+    
+    view.frame = view.bounds
+    viewWithShadow.addSubview(view)
+    viewWithShadow.addSubview(shadowView)
+    return viewWithShadow
+  }
+
+}
+
+// MARK: - Animates
+
+private extension FoldAnimator {
+
+  func animateFoldTransition(fromView view: UIView, toViewFolds: [UIView], fromViewFolds: [UIView], completion: AnimatableCompletion) {
+    view.frame = CGRectOffset(view.frame, view.frame.width, 0)
+    UIView.animateWithDuration(transitionDuration, animations: {
+      for i in 0..<self.folds {
+        let offset = CGFloat(i) * self.foldWidth * 2
+        let leftFromView = fromViewFolds[i * 2]
+        leftFromView.layer.position = CGPoint(x: self.reverse ? 0.0 : self.size.width, y: self.size.height / 2)
+        leftFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(M_PI_2), 0.0, 1.0, 0)
+        leftFromView.subviews[1].alpha = 1.0
+        
+        let rightFromView = fromViewFolds[i * 2 + 1]
+        rightFromView.layer.position = CGPoint(x: self.reverse ? 0.0 : self.size.width, y: self.size.height / 2)
+        rightFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(-M_PI_2), 0.0, 1.0, 0)
+        rightFromView.subviews[1].alpha = 1.0
+        
+        let leftToView = toViewFolds[i * 2]
+        leftToView.layer.position = CGPoint(x: offset, y: self.size.height / 2)
+        leftToView.layer.transform = CATransform3DIdentity
+        leftToView.subviews[1].alpha = 0.0
+
+        let rightToView = toViewFolds[i * 2 + 1]
+        rightToView.layer.position = CGPoint(x: offset + self.foldWidth * 2, y: self.size.height / 2)
+        rightToView.layer.transform = CATransform3DIdentity
+        rightToView.subviews[1].alpha = 0.0
+      }
+    },
+    completion: { _ in
+      toViewFolds.forEach {
+        $0.removeFromSuperview()
+      }
+
+      fromViewFolds.forEach {
+        $0.removeFromSuperview()
+      }
+      
+      completion()
+
+    })
+  }
+  
+}

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -84,7 +84,7 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
     containerView.layer.sublayerTransform = transform
     
     size = toView.frame.size
-    foldSize = (horizontal ? size.width : size.height) * 0.5 / CGFloat(folds)
+    foldSize = width() * 0.5 / CGFloat(folds)
 
     let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1]) {
@@ -106,23 +106,29 @@ private extension FoldAnimator {
     for i in 0..<folds {
       let offset = CGFloat(i) * foldSize * 2
       let leftFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset, left: true)
-      leftFromViewFold.layer.position = CGPoint(x: offset, y: size.height / 2)
+      var axesValues = valuesForAxe(offset, reverseValue: height() / 2)
+      leftFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       fromViewFolds.append(leftFromViewFold)
       leftFromViewFold.subviews[1].alpha = 0.0
 
       let rightFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset + foldSize, left: false)
-      rightFromViewFold.layer.position = CGPoint(x: offset + foldSize * 2, y: size.height / 2);
+      axesValues = valuesForAxe(offset + foldSize * 2, reverseValue: height() / 2)
+      rightFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1);
       fromViewFolds.append(rightFromViewFold)
       rightFromViewFold.subviews[1].alpha = 0.0
 
       let leftToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset, left: true)
-      leftToViewFold.layer.position = CGPointMake(self.reverse ? size.width : 0.0, size.height / 2)
-      leftToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(M_PI_2), 0.0, 1.0, 0.0)
+      axesValues = valuesForAxe(self.reverse ? width() : 0.0, reverseValue: height() / 2)
+      leftToViewFold.layer.position = CGPointMake(axesValues.0, axesValues.1)
+      axesValues = valuesForAxe(0.0, reverseValue: 1.0)
+      leftToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(M_PI_2), axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(leftToViewFold)
 
       let rightToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset + foldSize, left: false)
-      rightToViewFold.layer.position = CGPointMake(self.reverse ? size.width : 0.0, size.height / 2)
-      rightToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(-M_PI_2), 0.0, 1.0, 0.0)
+      axesValues = valuesForAxe(self.reverse ? width() : 0.0, reverseValue: height() / 2)
+      rightToViewFold.layer.position = CGPointMake(axesValues.0, axesValues.1)
+      axesValues = valuesForAxe(0.0, reverseValue: 1.0)
+      rightToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(-M_PI_2), axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(rightToViewFold)
     }
     return [toViewFolds, fromViewFolds]
@@ -131,11 +137,14 @@ private extension FoldAnimator {
   func createSnapshot(fromView view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView {
     let containerView = view.superview
     var snapshotView: UIView
-    let snapshotRegion = CGRect(x: offset, y: 0.0, width: foldSize, height: size.height)
+    var axesValues = valuesForAxe(offset, reverseValue: 0.0)
+    var axesValues2 = valuesForAxe(foldSize, reverseValue: height())
+    let snapshotRegion = CGRect(x: axesValues.0, y: axesValues.1, width: axesValues2.0, height: axesValues2.1)
     if !afterUpdates {
       snapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
     } else {
-      snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: foldSize, height: size.height))
+      axesValues = valuesForAxe(foldSize, reverseValue: height())
+      snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: axesValues.0, height: axesValues.1))
       snapshotView.backgroundColor = view.backgroundColor;
       let subSnapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
       snapshotView.addSubview(subSnapshotView)
@@ -143,7 +152,8 @@ private extension FoldAnimator {
     
     let snapshotWithShadowView = addShadow(toView: snapshotView, reverse: left)
     containerView?.addSubview(snapshotWithShadowView)
-    snapshotWithShadowView.layer.anchorPoint = CGPoint(x: left ? 0.0 : 1.0, y: 0.5)
+    axesValues = valuesForAxe(left ? 0.0 : 1.0, reverseValue: 0.5)
+    snapshotWithShadowView.layer.anchorPoint = CGPoint(x: axesValues.0, y: axesValues.1)
     return snapshotWithShadowView
   }
   
@@ -154,11 +164,15 @@ private extension FoldAnimator {
     gradient.frame = shadowView.bounds
     gradient.colors = [UIColor(white: 0.0, alpha: 0.0).CGColor, UIColor(white: 0.0, alpha: 1.0).CGColor]
     if horizontal {
-      gradient.startPoint = CGPoint(x: reverse ? 0.0 : 1.0, y: reverse ? 0.2 : 0.0)
-      gradient.endPoint = CGPoint(x: reverse ? 1.0 : 0.0, y: reverse ? 0.0 : 1.0)
+      var axesValues = valuesForAxe(reverse ? 0.0 : 1.0, reverseValue: reverse ? 0.2 : 0.0)
+      gradient.startPoint = CGPoint(x: axesValues.0, y: axesValues.1)
+      axesValues = valuesForAxe(reverse ? 1.0 : 0.0, reverseValue: reverse ? 0.0 : 1.0)
+      gradient.endPoint = CGPoint(x: axesValues.0, y: axesValues.1)
     } else {
-      gradient.startPoint = CGPoint(x: reverse ? 0.2 : 0.0, y: reverse ? 0.0 : 1.0)
-      gradient.endPoint = CGPoint(x: reverse ? 0.0 : 1.0, y: reverse ? 1.0 : 0.0)
+      var axesValues = valuesForAxe(reverse ? 0.2 : 0.0, reverseValue: reverse ? 0.0 : 1.0)
+      gradient.startPoint = CGPoint(x: axesValues.0, y: axesValues.1)
+      axesValues = valuesForAxe(reverse ? 0.0 : 1.0, reverseValue: reverse ? 1.0 : 0.0)
+      gradient.endPoint = CGPoint(x: axesValues.0, y: axesValues.1)
     }
     shadowView.layer.insertSublayer(gradient, atIndex: 1)
     
@@ -180,22 +194,28 @@ private extension FoldAnimator {
       for i in 0..<self.folds {
         let offset = CGFloat(i) * self.foldSize * 2
         let leftFromView = fromViewFolds[i * 2]
-        leftFromView.layer.position = CGPoint(x: self.reverse ? 0.0 : self.size.width, y: self.size.height / 2)
-        leftFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(M_PI_2), 0.0, 1.0, 0)
+        var axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width(), reverseValue: self.height() / 2)
+        leftFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
+        axesValues = self.valuesForAxe(0.0, reverseValue: 1.0)
+        leftFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(M_PI_2), axesValues.0, axesValues.1, 0)
         leftFromView.subviews[1].alpha = 1.0
         
         let rightFromView = fromViewFolds[i * 2 + 1]
-        rightFromView.layer.position = CGPoint(x: self.reverse ? 0.0 : self.size.width, y: self.size.height / 2)
-        rightFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(-M_PI_2), 0.0, 1.0, 0)
+        axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width(), reverseValue: self.height() / 2)
+        rightFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
+        axesValues = self.valuesForAxe(0.0, reverseValue: 1.0)
+        rightFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(-M_PI_2), axesValues.0, axesValues.1, 0)
         rightFromView.subviews[1].alpha = 1.0
         
         let leftToView = toViewFolds[i * 2]
-        leftToView.layer.position = CGPoint(x: offset, y: self.size.height / 2)
+        axesValues = self.valuesForAxe(offset, reverseValue: self.height() / 2)
+        leftToView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         leftToView.layer.transform = CATransform3DIdentity
         leftToView.subviews[1].alpha = 0.0
 
         let rightToView = toViewFolds[i * 2 + 1]
-        rightToView.layer.position = CGPoint(x: offset + self.foldSize * 2, y: self.size.height / 2)
+        axesValues = self.valuesForAxe(offset + self.foldSize * 2, reverseValue: self.height() / 2)
+        rightToView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         rightToView.layer.transform = CATransform3DIdentity
         rightToView.subviews[1].alpha = 0.0
       }
@@ -211,6 +231,24 @@ private extension FoldAnimator {
       
       completion()
     })
+  }
+  
+}
+
+// MARK: - Helpers
+
+private extension FoldAnimator {
+  
+  func valuesForAxe(initialValue: CGFloat, reverseValue: CGFloat) -> (CGFloat, CGFloat) {
+    return horizontal ? (initialValue, reverseValue) : (reverseValue, initialValue)
+  }
+  
+  func width() -> CGFloat {
+    return horizontal ? size.width : size.height
+  }
+  
+  func height() -> CGFloat {
+    return horizontal ? size.height : size.width
   }
   
 }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -22,6 +22,12 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   private var horizontal: Bool = false
   private var size: CGSize = CGSize.zero
   private var foldSize: CGFloat = 0.0
+  private var width: CGFloat {
+      return horizontal ? size.width : size.height
+  }
+  private var height: CGFloat {
+    return horizontal ? size.height : size.width
+  }
   
   // MARK: - Life cycle
   init(fromDirection: TransitionFromDirection, params: [String], transitionDuration: Duration) {
@@ -84,7 +90,7 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
     containerView.layer.sublayerTransform = transform
     
     size = toView.frame.size
-    foldSize = width() * 0.5 / CGFloat(folds)
+    foldSize = width * 0.5 / CGFloat(folds)
 
     let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1]) {
@@ -106,26 +112,26 @@ private extension FoldAnimator {
     for i in 0..<folds {
       let offset = CGFloat(i) * foldSize * 2
       let leftFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset, left: true)
-      var axesValues = valuesForAxe(offset, reverseValue: height() / 2)
+      var axesValues = valuesForAxe(offset, reverseValue: height / 2)
       leftFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       fromViewFolds.append(leftFromViewFold)
       leftFromViewFold.subviews[1].alpha = 0.0
 
       let rightFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset + foldSize, left: false)
-      axesValues = valuesForAxe(offset + foldSize * 2, reverseValue: height() / 2)
+      axesValues = valuesForAxe(offset + foldSize * 2, reverseValue: height / 2)
       rightFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1);
       fromViewFolds.append(rightFromViewFold)
       rightFromViewFold.subviews[1].alpha = 0.0
 
       let leftToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset, left: true)
-      axesValues = valuesForAxe(self.reverse ? width() : 0.0, reverseValue: height() / 2)
+      axesValues = valuesForAxe(self.reverse ? width : 0.0, reverseValue: height / 2)
       leftToViewFold.layer.position = CGPointMake(axesValues.0, axesValues.1)
       axesValues = valuesForAxe(0.0, reverseValue: 1.0)
       leftToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(M_PI_2), axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(leftToViewFold)
 
       let rightToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset + foldSize, left: false)
-      axesValues = valuesForAxe(self.reverse ? width() : 0.0, reverseValue: height() / 2)
+      axesValues = valuesForAxe(self.reverse ? width : 0.0, reverseValue: height / 2)
       rightToViewFold.layer.position = CGPointMake(axesValues.0, axesValues.1)
       axesValues = valuesForAxe(0.0, reverseValue: 1.0)
       rightToViewFold.layer.transform = CATransform3DMakeRotation(CGFloat(-M_PI_2), axesValues.0, axesValues.1, 0.0)
@@ -138,12 +144,12 @@ private extension FoldAnimator {
     let containerView = view.superview
     var snapshotView: UIView
     var axesValues = valuesForAxe(offset, reverseValue: 0.0)
-    var axesValues2 = valuesForAxe(foldSize, reverseValue: height())
+    var axesValues2 = valuesForAxe(foldSize, reverseValue: height)
     let snapshotRegion = CGRect(x: axesValues.0, y: axesValues.1, width: axesValues2.0, height: axesValues2.1)
     if !afterUpdates {
       snapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
     } else {
-      axesValues = valuesForAxe(foldSize, reverseValue: height())
+      axesValues = valuesForAxe(foldSize, reverseValue: height)
       snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: axesValues.0, height: axesValues.1))
       snapshotView.backgroundColor = view.backgroundColor;
       let subSnapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
@@ -194,27 +200,27 @@ private extension FoldAnimator {
       for i in 0..<self.folds {
         let offset = CGFloat(i) * self.foldSize * 2
         let leftFromView = fromViewFolds[i * 2]
-        var axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width(), reverseValue: self.height() / 2)
+        var axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width, reverseValue: self.height / 2)
         leftFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         axesValues = self.valuesForAxe(0.0, reverseValue: 1.0)
         leftFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(M_PI_2), axesValues.0, axesValues.1, 0)
         leftFromView.subviews[1].alpha = 1.0
         
         let rightFromView = fromViewFolds[i * 2 + 1]
-        axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width(), reverseValue: self.height() / 2)
+        axesValues = self.valuesForAxe(self.reverse ? 0.0 : self.width, reverseValue: self.height / 2)
         rightFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         axesValues = self.valuesForAxe(0.0, reverseValue: 1.0)
         rightFromView.layer.transform = CATransform3DRotate(self.transform, CGFloat(-M_PI_2), axesValues.0, axesValues.1, 0)
         rightFromView.subviews[1].alpha = 1.0
         
         let leftToView = toViewFolds[i * 2]
-        axesValues = self.valuesForAxe(offset, reverseValue: self.height() / 2)
+        axesValues = self.valuesForAxe(offset, reverseValue: self.height / 2)
         leftToView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         leftToView.layer.transform = CATransform3DIdentity
         leftToView.subviews[1].alpha = 0.0
 
         let rightToView = toViewFolds[i * 2 + 1]
-        axesValues = self.valuesForAxe(offset + self.foldSize * 2, reverseValue: self.height() / 2)
+        axesValues = self.valuesForAxe(offset + self.foldSize * 2, reverseValue: self.height / 2)
         rightToView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         rightToView.layer.transform = CATransform3DIdentity
         rightToView.subviews[1].alpha = 0.0
@@ -241,14 +247,6 @@ private extension FoldAnimator {
   
   func valuesForAxe(initialValue: CGFloat, reverseValue: CGFloat) -> (CGFloat, CGFloat) {
     return horizontal ? (initialValue, reverseValue) : (reverseValue, initialValue)
-  }
-  
-  func width() -> CGFloat {
-    return horizontal ? size.width : size.height
-  }
-  
-  func height() -> CGFloat {
-    return horizontal ? size.height : size.width
   }
   
 }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -17,13 +17,11 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   private var folds: Int = 2
   
   // MARK: - Private fold transition
-  
   private var transform: CATransform3D = CATransform3DIdentity
   private var size: CGSize = CGSize.zero
   private var foldWidth: CGFloat = 0.0
   
   // MARK: - Life cycle
-  
   init(params: String, transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
     self.transitionAnimationType = .Fold(params: params)

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -28,10 +28,34 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
     self.transitionDuration = transitionDuration
     self.transitionAnimationType = .Fold(direction: fromDirection, params: params)
     self.reverseAnimationType = .Fold(direction: fromDirection, params: params)
-        
-//    if let unwrappedFolds = Int(params[0]) where params.count == 1 {
-//      self.folds = unwrappedFolds
-//    }
+    
+    if let firstParam = params.first,
+           unwrappedFolds = Int(firstParam) {
+        self.folds = unwrappedFolds
+    }
+    
+    switch fromDirection {
+    case .Left:
+      self.transitionAnimationType = .Fold(direction: .Left, params: params)
+      self.reverseAnimationType = .Fold(direction: .Right, params: params)
+      self.interactiveGestureType = .Pan(direction: .Right)
+      reverse = false
+    case .Right:
+      self.transitionAnimationType = .Fold(direction: .Right, params: params)
+      self.reverseAnimationType = .Fold(direction: .Left, params: params)
+      self.interactiveGestureType = .Pan(direction: .Left)
+      reverse = true
+    case .Top:
+      self.transitionAnimationType = .Fold(direction: .Top, params: params)
+      self.reverseAnimationType = .Fold(direction: .Bottom, params: params)
+      self.interactiveGestureType = .Pan(direction: .Bottom)
+      reverse = false
+    case .Bottom:
+      self.transitionAnimationType = .Fold(direction: .Bottom, params: params)
+      self.reverseAnimationType = .Fold(direction: .Top, params: params)
+      self.interactiveGestureType = .Pan(direction: .Top)
+      reverse = true
+    }
     super.init()
   }
 }

--- a/IBAnimatable/PresentExplodeSegue.swift
+++ b/IBAnimatable/PresentExplodeSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentExplodeSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: ""))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: []))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -1,7 +1,4 @@
 //
-//  File.swift
-//  IBAnimatableApp
-//
 //  Created by Tom Baranes on 03/04/16.
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //

--- a/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentExplodeWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentExplodeWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: ""), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Explode(params: []), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFoldSegue.swift
+++ b/IBAnimatable/PresentFoldSegue.swift
@@ -1,0 +1,13 @@
+//
+//  Created by Tom Baranes on 09/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentFoldSegue: UIStoryboardSegue {
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(params: ""))
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentFoldSegue.swift
+++ b/IBAnimatable/PresentFoldSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFoldSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(params: ""))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(direction: .Left, params: []))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFoldWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(params: ""), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(direction: .Left, params: []), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
@@ -1,0 +1,13 @@
+//
+//  Created by Tom Baranes on 09/04/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+public class PresentFoldWithDismissInteractionSegue: UIStoryboardSegue {
+  public override func perform() {
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(params: ""), interactiveGestureType: .Default)
+    sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -12,6 +12,7 @@ public enum TransitionAnimationType {
   case Fade             // ToView fades in and FromeView fades out
   case FadeIn           // ToView fades in
   case FadeOut          // FromView Fades out
+  case Fold
   case SystemSuckEffect
   case SystemRippleEffect
   case Explode(params: String)
@@ -33,6 +34,8 @@ public enum TransitionAnimationType {
       return .SystemRippleEffect
     } else if transitionType.hasPrefix("SystemSuckEffect") {
         return .SystemSuckEffect
+    } else if transitionType.hasPrefix("Fold") {
+      return .Fold
     } else if transitionType.hasPrefix("Explode") {
       return .Explode(params: params(forTransitionType: transitionType))
     } else if transitionType.hasPrefix("Fade") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -12,9 +12,9 @@ public enum TransitionAnimationType {
   case Fade             // ToView fades in and FromeView fades out
   case FadeIn           // ToView fades in
   case FadeOut          // FromView Fades out
-  case Fold
   case SystemSuckEffect
   case SystemRippleEffect
+  case Fold(params: String)
   case Explode(params: String)
   case SystemCube(direction: TransitionFromDirection)
   case SystemFlip(direction: TransitionFromDirection)
@@ -35,7 +35,7 @@ public enum TransitionAnimationType {
     } else if transitionType.hasPrefix("SystemSuckEffect") {
         return .SystemSuckEffect
     } else if transitionType.hasPrefix("Fold") {
-      return .Fold
+      return .Fold(params: params(forTransitionType: transitionType))
     } else if transitionType.hasPrefix("Explode") {
       return .Explode(params: params(forTransitionType: transitionType))
     } else if transitionType.hasPrefix("Fade") {

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
 		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
+		E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20078A01CB8FB94002B2C16 /* FoldAnimator.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E27691E91CAFC72C004A725C /* SystemMoveInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */; };
 		E27691EB1CAFC91A004A725C /* SystemPushAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */; };
@@ -205,6 +206,7 @@
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
+		E20078A01CB8FB94002B2C16 /* FoldAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoldAnimator.swift; sourceTree = "<group>"; };
 		E20E91121CAC374200625094 /* SystemRippleEffectAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRippleEffectAnimator.swift; sourceTree = "<group>"; };
 		E20E911B1CAC421E00625094 /* TransitionHollowState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionHollowState.swift; sourceTree = "<group>"; };
 		E20E911D1CAC432400625094 /* SystemCameraIrisAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCameraIrisAnimator.swift; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 				E20E91211CAC465A00625094 /* SystemSuckEffectAnimator.swift */,
 				E20E911D1CAC432400625094 /* SystemCameraIrisAnimator.swift */,
 				E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */,
+				E20078A01CB8FB94002B2C16 /* FoldAnimator.swift */,
 			);
 			name = "transition animator";
 			sourceTree = "<group>";
@@ -623,6 +626,7 @@
 				AEE552B11C839EB7009CF623 /* PresenterManager.swift in Sources */,
 				AED5F6921C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */,
 				AE6B01721C2A444900950BB2 /* RotationDesignable.swift in Sources */,
+				E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
 				AE6B01801C2A445100950BB2 /* AnimatableStackView.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
 		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20078A01CB8FB94002B2C16 /* FoldAnimator.swift */; };
+		E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20078A21CB912E1002B2C16 /* PresentFoldSegue.swift */; };
+		E20078A51CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20078A41CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
 		E27691E91CAFC72C004A725C /* SystemMoveInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */; };
 		E27691EB1CAFC91A004A725C /* SystemPushAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */; };
@@ -207,6 +209,8 @@
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D7E765671C4C8961008C3116 /* IBAnimatable.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = IBAnimatable.playground; sourceTree = "<group>"; };
 		E20078A01CB8FB94002B2C16 /* FoldAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoldAnimator.swift; sourceTree = "<group>"; };
+		E20078A21CB912E1002B2C16 /* PresentFoldSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFoldSegue.swift; sourceTree = "<group>"; };
+		E20078A41CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFoldWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
 		E20E91121CAC374200625094 /* SystemRippleEffectAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRippleEffectAnimator.swift; sourceTree = "<group>"; };
 		E20E911B1CAC421E00625094 /* TransitionHollowState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionHollowState.swift; sourceTree = "<group>"; };
 		E20E911D1CAC432400625094 /* SystemCameraIrisAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCameraIrisAnimator.swift; sourceTree = "<group>"; };
@@ -268,6 +272,8 @@
 				AE0635FA1C9837E9003F9815 /* PresentFadeOutWithDismissInteractionSegue.swift */,
 				E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */,
 				E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */,
+				E20078A21CB912E1002B2C16 /* PresentFoldSegue.swift */,
+				E20078A41CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift */,
 			);
 			name = segue;
 			sourceTree = "<group>";
@@ -627,6 +633,7 @@
 				AED5F6921C83E9B60052E57B /* PresentFadeInSegue.swift in Sources */,
 				AE6B01721C2A444900950BB2 /* RotationDesignable.swift in Sources */,
 				E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */,
+				E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
 				AE6B01801C2A445100950BB2 /* AnimatableStackView.swift in Sources */,
@@ -645,6 +652,7 @@
 				E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */,
 				AE6B016D1C2A444900950BB2 /* GradientDesignable.swift in Sources */,
 				AE677B9B1CADCFA800D62273 /* TransitionHollowState.swift in Sources */,
+				E20078A51CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift in Sources */,
 				E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */,
 				AE65CF931C96E35600A723F8 /* PresentFadeWithDismissInteractionSegue.swift in Sources */,
 				AE677B981CADCF5900D62273 /* SystemSuckEffectAnimator.swift in Sources */,

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -59,7 +59,7 @@ private extension TransitionTableViewController {
     transitionAnimationsHeaders.append("Rotate")
     transitionAnimations.append(["SystemRotate(90)", "SystemRotate(90ccw)", "SystemRotate(180)", "SystemRotate(180ccw)"])
     transitionAnimationsHeaders.append("Others")
-    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode(10,-10,10)"])
+    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode(10,-10,10)", "Fold"])
 
   }
   

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -58,8 +58,10 @@ private extension TransitionTableViewController {
     transitionAnimations.append(["SystemCameraIris", "SystemCameraIris(HollowOpen)", "SystemCameraIris(HollowClose)"])
     transitionAnimationsHeaders.append("Rotate")
     transitionAnimations.append(["SystemRotate(90)", "SystemRotate(90ccw)", "SystemRotate(180)", "SystemRotate(180ccw)"])
+    transitionAnimationsHeaders.append("Fold")
+    transitionAnimations.append(transitionTypeWithDirections(forName: "Fold"))
     transitionAnimationsHeaders.append("Others")
-    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode(10,-10,10)", "Fold"])
+    transitionAnimations.append(["SystemRippleEffect", "SystemSuckEffect", "Explode(10,-10,10)"])
 
   }
   


### PR DESCRIPTION
Here is the next one: Fold transition, related to #155 

That PR implements the `Fold` transition, it's working as expected, and can be customise with using params: `Fold(nbFolds)` which will change the number of pan during the transition, default is 2.

Missing:
- Reverse: I didn't find a way to detect if the transition is a push or a pop. Did you implement a system for that? The navigation is currently in hard coding (a private property set to true)
- Direction: not sure if that's needed, but after some tests I think it could be nice to setup the direction. Moreover, it could be used to solve the reverse issue if there no existing code to detect the that. 

The main code won't move (at least, if we dont implement the direction which is way more complex 😆) that much, so if you have any feedback, let me know 👐 

/!\ This PR is not finished yet, don't merge it /!\
