### PR TITLE
Fix a bug for fold animator with pan gesture when dismiss

### DIFF
--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -138,7 +138,7 @@ public extension BorderDesignable where Self: UIView {
       borderPath.addLineToPoint(linePoints.end)
     }
     
-    border.path = borderPath.CGPath;
+    border.path = borderPath.CGPath
     border.fillColor = UIColor.clearColor().CGColor
     border.strokeColor = unwrappedBorderColor.CGColor
     border.lineWidth = borderWidth

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -93,11 +93,18 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
     foldSize = width * 0.5 / CGFloat(folds)
 
     let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
-    animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1]) {
-      toView.frame = containerView.bounds
-      fromView.frame = containerView.bounds
+    animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1], completion: {
+      if !transitionContext.transitionWasCancelled() {
+        toView.frame = containerView.bounds
+        fromView.frame = containerView.bounds
+      }
+      else {
+        fromView.frame = containerView.bounds
+      }
+      
       transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
-    }
+      }
+    )
   }
   
 }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -10,7 +10,7 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   public var transitionAnimationType: TransitionAnimationType
   public var transitionDuration: Duration = defaultTransitionDuration
   public var reverseAnimationType: TransitionAnimationType?
-  public var interactiveGestureType: InteractiveGestureType? = .Default
+  public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - Private params
   private var fromDirection: TransitionFromDirection
@@ -94,8 +94,8 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
 
     let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1]) {
-      toView.frame = containerView.bounds;
-      fromView.frame = containerView.bounds;
+      toView.frame = containerView.bounds
+      fromView.frame = containerView.bounds
       transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
     }
   }
@@ -119,7 +119,7 @@ private extension FoldAnimator {
 
       let rightFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset + foldSize, left: false)
       axesValues = valuesForAxe(offset + foldSize * 2, reverseValue: height / 2)
-      rightFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1);
+      rightFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       fromViewFolds.append(rightFromViewFold)
       rightFromViewFold.subviews[1].alpha = 0.0
 
@@ -151,7 +151,7 @@ private extension FoldAnimator {
     } else {
       axesValues = valuesForAxe(foldSize, reverseValue: height)
       snapshotView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: axesValues.0, height: axesValues.1))
-      snapshotView.backgroundColor = view.backgroundColor;
+      snapshotView.backgroundColor = view.backgroundColor
       let subSnapshotView = view.resizableSnapshotViewFromRect(snapshotRegion, afterScreenUpdates: afterUpdates, withCapInsets: UIEdgeInsetsZero)
       snapshotView.addSubview(subSnapshotView)
     }

--- a/IBAnimatable/PortalAnimator.swift
+++ b/IBAnimatable/PortalAnimator.swift
@@ -108,13 +108,13 @@ private extension PortalAnimator {
   
   func executeBackwardAnimations(transitionContext: UIViewControllerContextTransitioning, containerView containerView: UIView, fromView: UIView, toView: UIView) {
     containerView.addSubview(fromView)
-    toView.frame = CGRectOffset(toView.frame, toView.frame.width, 0);
+    toView.frame = CGRectOffset(toView.frame, toView.frame.width, 0)
     containerView.addSubview(toView)
 
     let leftSnapshotRegion = CGRect(x: 0, y: 0, width: toView.frame.width / 2, height: toView.bounds.height)
     let leftHandView = toView.resizableSnapshotViewFromRect(leftSnapshotRegion, afterScreenUpdates: true, withCapInsets: UIEdgeInsetsZero)
     leftHandView.frame = leftSnapshotRegion
-    leftHandView.frame = CGRectOffset(leftHandView.frame, -leftHandView.frame.width, 0);
+    leftHandView.frame = CGRectOffset(leftHandView.frame, -leftHandView.frame.width, 0)
     containerView.addSubview(leftHandView)
 
     let rightSnapshotRegion = CGRect(x: toView.frame.width / 2, y: 0, width: toView.frame.width / 2, height: fromView.frame.height)
@@ -127,16 +127,17 @@ private extension PortalAnimator {
       leftHandView.frame = CGRectOffset(leftHandView.frame, leftHandView.frame.size.width, 0)
       rightHandView.frame = CGRectOffset(rightHandView.frame, -rightHandView.frame.size.width, 0)
       let scale = CATransform3DIdentity
-      fromView.layer.transform = CATransform3DScale(scale, self.zoomScale, self.zoomScale, 1);
+      fromView.layer.transform = CATransform3DScale(scale, self.zoomScale, self.zoomScale, 1)
     }, completion: { _ in
-        if transitionContext.transitionWasCancelled() {
-          self.removeOtherViews(fromView)
-        } else {
-          self.removeOtherViews(toView)
-          toView.frame = containerView.bounds
-          fromView.layer.transform = CATransform3DIdentity
-        }
-        transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
+      
+      if transitionContext.transitionWasCancelled() {
+        self.removeOtherViews(fromView)
+      } else {
+        self.removeOtherViews(toView)
+        toView.frame = containerView.bounds
+        fromView.layer.transform = CATransform3DIdentity
+      }
+      transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
     })
   }
   


### PR DESCRIPTION
Fix a bug for fold animator with pan gesture when dismiss the ViewController, it is a bug in https://github.com/ColinEberhardt/VCTransitionsLibrary as well, will do a PR to them to fix it.

It was OK for popping a ViewController, but not for dismissing a ViewController, the transition state was broken.

The fix is in 
https://github.com/JakeLin/IBAnimatable/compare/bugfix/fold-animator-with-pan-gesture-when-dismiss?expand=1#diff-e3c0877d13bebebec521d0689eb955f7R97

Also fixed some minal code style issues.

@tbaranes can you have a look at this? thanks.
