### PR TITLE
Fix a bug to support single side of border for AnimatableTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 
 - Use `weak` for the `viewController` in `InteractiveAnimator` to avoid retain cycle.
 - Fixed the right image of `SideImageDesignable` [#176](https://github.com/JakeLin/IBAnimatable/issues/176)
-
+- Fix a bug to support single side of border for AnimatableTextField [#179](https://github.com/JakeLin/IBAnimatable/issues/179)
 
 ### [2.2](https://github.com/JakeLin/IBAnimatable/releases/tag/2.2)
 

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -95,15 +95,15 @@ public extension BorderDesignable where Self: UIView {
 
 private extension BorderDesignable where Self: UIView {
   func commonConfigBorder() {
-    // Clear borders
-    layer.borderColor = nil
-    layer.borderWidth = 0
-    layer.sublayers?.filter  { $0.name == "borderSideLayer" || $0.name == "borderAllSides" }
-      .forEach { $0.removeFromSuperlayer() }
-    
     guard let unwrappedBorderColor = borderColor where borderWidth > 0 else {
       return
     }
+    
+    // Clear borders
+    layer.borderColor = nil
+    layer.borderWidth = 0
+    layer.sublayers?.filter { $0.name == "borderSideLayer" || $0.name == "borderAllSides" }
+      .forEach { $0.removeFromSuperlayer() }
     
     // if a layer mask is specified, only border the mask
     if let mask = layer.mask as? CAShapeLayer {
@@ -115,7 +115,6 @@ private extension BorderDesignable where Self: UIView {
       borderLayer.lineWidth = borderWidth
       borderLayer.frame = bounds
       layer.insertSublayer(borderLayer, atIndex: 0)
-      layer.borderWidth = 0
       return
     }
     
@@ -135,7 +134,7 @@ private extension BorderDesignable where Self: UIView {
     
     var lines:[(start: CGPoint, end: CGPoint)] = []
     if sides.contains(.Top) {
-      lines.append((start: CGPoint(x: 0, y: 0), end: CGPoint(x: bounds.size.width, y: 0)))
+      lines.append((start: .zero, end: CGPoint(x: bounds.size.width, y: 0)))
     }
     if sides.contains(.Right) {
       lines.append((start: CGPoint(x: bounds.size.width, y: 0), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
@@ -144,7 +143,7 @@ private extension BorderDesignable where Self: UIView {
       lines.append((start:CGPoint(x: 0, y: bounds.size.height), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
     }
     if sides.contains(.Left) {
-      lines.append((start: CGPoint(x: 0, y: 0), end: CGPoint(x: 0, y: bounds.size.height)))
+      lines.append((start: .zero, end: CGPoint(x: 0, y: bounds.size.height)))
     }
     
     for linePoints in lines {
@@ -158,6 +157,5 @@ private extension BorderDesignable where Self: UIView {
     border.lineWidth = borderWidth
     border.frame = bounds
     layer.insertSublayer(border, atIndex: 0)
-    layer.borderWidth = 0
   }
 }

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -79,14 +79,28 @@ struct BorderSides: OptionSetType {
   }
 }
 
+public extension BorderDesignable where Self: UITextField {
+  public func configBorder() {
+    // set the borderSytle to `.None` to support single side of border
+    borderStyle = .None
+    commonConfigBorder()
+  }
+}
+
 public extension BorderDesignable where Self: UIView {
   public func configBorder() {
+    commonConfigBorder()
+  }
+}
+
+private extension BorderDesignable where Self: UIView {
+  func commonConfigBorder() {
     // Clear borders
     layer.borderColor = nil
     layer.borderWidth = 0
     layer.sublayers?.filter  { $0.name == "borderSideLayer" || $0.name == "borderAllSides" }
-        .forEach { $0.removeFromSuperlayer() }      
-
+      .forEach { $0.removeFromSuperlayer() }
+    
     guard let unwrappedBorderColor = borderColor where borderWidth > 0 else {
       return
     }
@@ -146,5 +160,4 @@ public extension BorderDesignable where Self: UIView {
     layer.insertSublayer(border, atIndex: 0)
     layer.borderWidth = 0
   }
-  
 }


### PR DESCRIPTION
Should fix #179 

To fix this issue, we need to set `borderStyle = .None` for `UITextField`

Also, I try to fix a warning for `BorderDesignable` for `AnimatableStackView` - "CATransformLayer changing property borderColor in transform-only layer, will have no effect" in this PR.

Actually, `BorderDesignable` doesn't work for `AnimatableStackView`, I think this is a bug of `UIStackView` someone tweeted about it https://twitter.com/fra3il/status/654127926644899841 But we can wait for the comming WWDC to see whether Apple fix it.

@tbaranes can you have a look if you have time, thanks.
