### PR TITLE
Support for container transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `AnimatableCollectionViewCell`
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)
- 
+
 #### Enhancements
 
 - Add `ScreenEdgePanInteractiveAnimator` to support `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `ScreenEdgePan(Left)`, `ScreenEdgePan(Right)`, `ScreenEdgePan(Top)`, `ScreenEdgePan(Bottom)`, `ScreenEdgePan(Horizontal)` and `ScreenEdgePan(Vertical)` for `ScreenEdgePan` gesture transition controller. [125](https://github.com/JakeLin/IBAnimatable/issues/125)
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Add `Turn` to support Turn transition animation. It supports only a direction `Turn(direction)`, if no specified, the default values are `Turn(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add `CardsAnimator` to support Cards transition animation. It supports parameters `Cards(direction)`, if no specified, the default values are `Cards(Forward)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add `FlipAnimator` to support Flip transition animation. It supports parameters `Flip(direction)`, if no specified, the default values are `Flip(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+- Add `ContainerTransition` to manage transition animations between two UIViewController in a container
 
 #### Bugfixes
 
@@ -60,26 +61,26 @@ All notable changes to this project will be documented in this file.
 
 - Fix the sided borders issue [#150](https://github.com/JakeLin/IBAnimatable/pull/150)
 - Fix the `FromTop` and `FromBottom` directions in system built-in animations [#156](https://github.com/JakeLin/IBAnimatable/pull/156)
- 
+
 ### [2.1](https://github.com/JakeLin/IBAnimatable/releases/tag/2.1)
 
 #### API breaking changes
 
-- Remove `MaskDesignable` public methods ([#101](https://github.com/JakeLin/IBAnimatable/issues/101)): 
+- Remove `MaskDesignable` public methods ([#101](https://github.com/JakeLin/IBAnimatable/issues/101)):
    	- Remove `maskCircle()`, use `view.maskType = String(MaskType.Circle)` instead
    	- Remove `maskStar(_:)`, use `view.maskType = "Star(6)"` instead
    	- Remove `maskPolygon()`, use `view.maskType = String(MaskType.Polygon)` instead
    	- Remove `maskTriangle()`, use `view.maskType = String(MaskType.Triangle)` instead
    	- Remove `maskWave(_:_:_:)`, use `view.maskType = "Wave(up, 16, 40)"` instead
 - Improve the options in `TransitionAnimationType` enum. ([#137](https://github.com/JakeLin/IBAnimatable/pull/137))
-   	- Remove `SystemCubeFromLeft`, use `SystemCube(Left)` 
-   	- Remove `SystemCubeFromRight`, use `SystemCube(Right)` 
-   	- Remove `SystemCubeFromTop`, use `SystemCube(Top)` 
-   	- Remove `SystemCubeFromBottom`, use `SystemCube(Bottom)` 
-   	- Remove `SystemFlipFromLeft`, use `SystemFlip(Left)` 
-   	- Remove `SystemFlipFromRight`, use `SystemFlip(Right)` 
-   	- Remove `SystemFlipFromTop`, use `SystemFlip(Top)` 
-   	- Remove `SystemFlipFromBottom`, use `SystemFlip(Bottom)` 
+   	- Remove `SystemCubeFromLeft`, use `SystemCube(Left)`
+   	- Remove `SystemCubeFromRight`, use `SystemCube(Right)`
+   	- Remove `SystemCubeFromTop`, use `SystemCube(Top)`
+   	- Remove `SystemCubeFromBottom`, use `SystemCube(Bottom)`
+   	- Remove `SystemFlipFromLeft`, use `SystemFlip(Left)`
+   	- Remove `SystemFlipFromRight`, use `SystemFlip(Right)`
+   	- Remove `SystemFlipFromTop`, use `SystemFlip(Top)`
+   	- Remove `SystemFlipFromBottom`, use `SystemFlip(Bottom)`
 
 #### Enhancements
 
@@ -114,7 +115,7 @@ All notable changes to this project will be documented in this file.
 - Add `PresentFadeSegue`, `PresentFadeInSegue` and `PresentFadeOutSegue` for Present transition with Fade animations
 - Add `PresentFadeWithDismissInteractionSegue`, `PresentFadeInWithDismissInteractionSegue` and `PresentFadeOutWithDismissInteractionSegue` for Present transition with Fade animations and getsture interactions.
 - Add `PanInteractiveAnimator` to handle Pan interaction for Dismiss and Pop
-- Demo App can experiment all transition animations (tap on "Forget Password" button to see) 
+- Demo App can experiment all transition animations (tap on "Forget Password" button to see)
 
 #### Bugfixes
 
@@ -150,7 +151,7 @@ All notable changes to this project will be documented in this file.
 
 - New animations: Rotate, RotateCCW [#51](https://github.com/JakeLin/IBAnimatable/issues/51)
 - New masks: Star, Triangle, Polygon, Wave
-- SidebarImage now support right images 
+- SidebarImage now support right images
 - Predefined gradients [#24](https://github.com/JakeLin/IBAnimatable/issues/24)
 - iOS8 support [#89](https://github.com/JakeLin/IBAnimatable/issues/89)
 

--- a/IBAnimatable/Container.swift
+++ b/IBAnimatable/Container.swift
@@ -1,0 +1,110 @@
+//
+//  Created by Tom Baranes on 06/05/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+
+class ContainerTransition: NSObject, UIViewControllerContextTransitioning {
+  
+  typealias ContainerTransitionCompletion = () -> Void
+  
+  // MARK: Properties
+  
+  var animationType: TransitionAnimationType?
+  var transitionDuration: Duration = defaultTransitionDuration
+  
+  // MARK: Private
+  
+  private let container: UIView?
+  private let parentViewController: UIViewController?
+  private var viewControllers: [String: UIViewController]? = nil
+  private var views: [String: UIView]? = nil
+  private let completion: ContainerTransitionCompletion?
+  
+  // MARK: Life cycle
+  
+  init(animationType: TransitionAnimationType,
+       container: UIView, parentViewController: UIViewController,
+       fromViewController: UIViewController?, toViewController: UIViewController,
+       completion: ContainerTransitionCompletion? = nil) {
+    
+    self.completion = completion
+    self.animationType = animationType
+    self.container = container
+    self.parentViewController = parentViewController
+    
+    container.translatesAutoresizingMaskIntoConstraints = false
+    toViewController.view.translatesAutoresizingMaskIntoConstraints = true
+    toViewController.view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+    toViewController.view.frame = container.bounds
+    
+    fromViewController?.willMoveToParentViewController(nil)
+    parentViewController.addChildViewController(toViewController)
+    
+    guard let unwrappedFromViewController = fromViewController else {
+      container.addSubview(toViewController.view)
+      toViewController.didMoveToParentViewController(parentViewController)
+      completion?()
+      return
+    }
+    
+    viewControllers = [UITransitionContextFromViewControllerKey: unwrappedFromViewController,
+                       UITransitionContextToViewControllerKey: toViewController]
+    views = [UITransitionContextFromViewKey: unwrappedFromViewController.view,
+             UITransitionContextToViewKey: toViewController.view]
+  }
+  
+  func animate() {
+    guard let unwrappedAnimationType = animationType else {
+      return
+    }
+    
+    parentViewController?.view.userInteractionEnabled = false
+    let animator = AnimatorFactory.generateAnimator(unwrappedAnimationType)
+    animator.animateTransition(self)
+  }
+}
+
+// MARK: - UIViewControllerContextTransitioning
+
+extension ContainerTransition {
+  
+  func containerView() -> UIView? {
+    return container
+  }
+  
+  func viewControllerForKey(key: String) -> UIViewController? {
+    return viewControllers?[key]
+  }
+  
+  func viewForKey(key: String) -> UIView? {
+    return views?[key]
+  }
+  
+  func transitionWasCancelled() -> Bool {
+    return false
+  }
+  
+  func completeTransition(didComplete: Bool) {
+    viewControllers?[UITransitionContextFromViewControllerKey]?.view.removeFromSuperview()
+    viewControllers?[UITransitionContextFromViewControllerKey]?.removeFromParentViewController()
+    viewControllers?[UITransitionContextToViewControllerKey]?.didMoveToParentViewController(parentViewController)
+    parentViewController?.view.userInteractionEnabled = true
+    completion?()
+  }
+  
+  
+  // MARK: Mandatory protocol
+  
+  func initialFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero }
+  func finalFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero}
+  func isAnimated() -> Bool { return false }
+  func isInteractive() -> Bool { return false }
+  func presentationStyle() -> UIModalPresentationStyle { return .None }
+  func targetTransform() -> CGAffineTransform { return CGAffineTransformIdentity }
+  func updateInteractiveTransition(percentComplete: CGFloat) {}
+  func finishInteractiveTransition() {}
+  func cancelInteractiveTransition() {}
+  
+}

--- a/IBAnimatable/ContainerTransition.swift
+++ b/IBAnimatable/ContainerTransition.swift
@@ -5,9 +5,9 @@
 
 import UIKit
 
-class ContainerTransition: NSObject, UIViewControllerContextTransitioning {
+public class ContainerTransition: NSObject {
   
-  typealias ContainerTransitionCompletion = () -> Void
+  public typealias ContainerTransitionCompletion = () -> Void
   
   // MARK: Properties
   
@@ -24,10 +24,10 @@ class ContainerTransition: NSObject, UIViewControllerContextTransitioning {
   
   // MARK: Life cycle
   
-  init(animationType: TransitionAnimationType,
-       container: UIView, parentViewController: UIViewController,
-       fromViewController: UIViewController?, toViewController: UIViewController,
-       completion: ContainerTransitionCompletion? = nil) {
+  public init(animationType: TransitionAnimationType,
+              container: UIView, parentViewController: UIViewController,
+              fromViewController: UIViewController?, toViewController: UIViewController,
+              completion: ContainerTransitionCompletion? = nil) {
     
     self.completion = completion
     self.animationType = animationType
@@ -55,7 +55,7 @@ class ContainerTransition: NSObject, UIViewControllerContextTransitioning {
              UITransitionContextToViewKey: toViewController.view]
   }
   
-  func animate() {
+  public func animate() {
     guard let unwrappedAnimationType = animationType else {
       return
     }
@@ -68,25 +68,25 @@ class ContainerTransition: NSObject, UIViewControllerContextTransitioning {
 
 // MARK: - UIViewControllerContextTransitioning
 
-extension ContainerTransition {
+extension ContainerTransition: UIViewControllerContextTransitioning {
   
-  func containerView() -> UIView? {
+  public func containerView() -> UIView? {
     return container
   }
   
-  func viewControllerForKey(key: String) -> UIViewController? {
+  public func viewControllerForKey(key: String) -> UIViewController? {
     return viewControllers?[key]
   }
   
-  func viewForKey(key: String) -> UIView? {
+  public func viewForKey(key: String) -> UIView? {
     return views?[key]
   }
   
-  func transitionWasCancelled() -> Bool {
+  public func transitionWasCancelled() -> Bool {
     return false
   }
   
-  func completeTransition(didComplete: Bool) {
+  public func completeTransition(didComplete: Bool) {
     viewControllers?[UITransitionContextFromViewControllerKey]?.view.removeFromSuperview()
     viewControllers?[UITransitionContextFromViewControllerKey]?.removeFromParentViewController()
     viewControllers?[UITransitionContextToViewControllerKey]?.didMoveToParentViewController(parentViewController)
@@ -97,14 +97,14 @@ extension ContainerTransition {
   
   // MARK: Mandatory protocol
   
-  func initialFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero }
-  func finalFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero}
-  func isAnimated() -> Bool { return false }
-  func isInteractive() -> Bool { return false }
-  func presentationStyle() -> UIModalPresentationStyle { return .None }
-  func targetTransform() -> CGAffineTransform { return CGAffineTransformIdentity }
-  func updateInteractiveTransition(percentComplete: CGFloat) {}
-  func finishInteractiveTransition() {}
-  func cancelInteractiveTransition() {}
+  public func initialFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero }
+  public func finalFrameForViewController(vc: UIViewController) -> CGRect { return CGRect.zero}
+  public func isAnimated() -> Bool { return false }
+  public func isInteractive() -> Bool { return false }
+  public func presentationStyle() -> UIModalPresentationStyle { return .None }
+  public func targetTransform() -> CGAffineTransform { return CGAffineTransformIdentity }
+  public func updateInteractiveTransition(percentComplete: CGFloat) {}
+  public func finishInteractiveTransition() {}
+  public func cancelInteractiveTransition() {}
   
 }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -30,11 +30,11 @@ public enum TransitionAnimationType {
   case SystemCameraIris(hollowState: TransitionHollowState)
   case SystemRotate(degree: TransitionRotateDegree)
     
-  var stringValue: String {
+  public var stringValue: String {
     return String(self)
   }
 
-  static func fromString(transitionType: String) -> TransitionAnimationType? {
+  public static func fromString(transitionType: String) -> TransitionAnimationType? {
     if transitionType.hasPrefix("SystemRippleEffect") {
       return .SystemRippleEffect
     } else if transitionType.hasPrefix("SystemSuckEffect") {
@@ -120,7 +120,7 @@ private extension TransitionAnimationType {
       return .NatGeo(direction: direction)
     } else if transitionType.hasPrefix("Turn") {
       return .Turn(direction: direction)
-        return .NatGeo(direction: direction)
+        return .Turn(direction: direction)
     } else if transitionType.hasPrefix("Cards") {
       return .Cards(direction: direction)
     } else if transitionType.hasPrefix("Flip") {

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		E222CDC81CC400FD00684CA0 /* PresentPortalSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E222CDC71CC400FD00684CA0 /* PresentPortalSegue.swift */; };
 		E222CDCA1CC4010800684CA0 /* PresentPortalWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E222CDC91CC4010800684CA0 /* PresentPortalWithDismissInteractionSegue.swift */; };
 		E2472EA51C6F97F800A20E27 /* ColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2472EA31C6F97F800A20E27 /* ColorType.swift */; };
+		E25EC6E71CDE034300743DB8 /* ContainerTransitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */; };
 		E26B3EDA1CCD4C1D00BFD0AB /* NatGeoAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */; };
 		E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */; };
 		E26B3EDE1CCD57BF00BFD0AB /* PresentNatGeoWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3EDD1CCD57BF00BFD0AB /* PresentNatGeoWithDismissInteractionSegue.swift */; };
@@ -118,7 +119,7 @@
 		E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */; };
 		E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */; };
 		E2A062B71CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */; };
-		E2BCCD381CDCA15D00431DA0 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BCCD371CDCA15D00431DA0 /* Container.swift */; };
+		E2BCCD381CDCA15D00431DA0 /* ContainerTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BCCD371CDCA15D00431DA0 /* ContainerTransition.swift */; };
 		E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
 		E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */; };
 		E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */; };
@@ -239,6 +240,7 @@
 		E23D08B71CA9336500440E7C /* SystemPageAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPageAnimator.swift; sourceTree = "<group>"; };
 		E2472EA31C6F97F800A20E27 /* ColorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorType.swift; sourceTree = "<group>"; };
 		E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatColorsTypeScript.swift; path = Scripts/FlatColorsTypeScript.swift; sourceTree = SOURCE_ROOT; };
+		E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransitionViewController.swift; sourceTree = "<group>"; };
 		E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NatGeoAnimator.swift; sourceTree = "<group>"; };
 		E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentNatGeoSegue.swift; sourceTree = "<group>"; };
 		E26B3EDD1CCD57BF00BFD0AB /* PresentNatGeoWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentNatGeoWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
@@ -256,7 +258,7 @@
 		E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplodeAnimator.swift; sourceTree = "<group>"; };
 		E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeSegue.swift; sourceTree = "<group>"; };
 		E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
-		E2BCCD371CDCA15D00431DA0 /* Container.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
+		E2BCCD371CDCA15D00431DA0 /* ContainerTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransition.swift; sourceTree = "<group>"; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
 		E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		E2E28E711C6A6E70003F3852 /* GradientsTypeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradientsTypeScript.swift; path = Scripts/GradientsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -400,7 +402,7 @@
 				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
 				AE7C26101CB4F680002CF125 /* InteractiveAnimatorFactory.swift */,
 				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
-				E2BCCD371CDCA15D00431DA0 /* Container.swift */,
+				E2BCCD371CDCA15D00431DA0 /* ContainerTransition.swift */,
 				AE154B8D1C7D89CB0093C05B /* Presenter.swift */,
 				AEE552AF1C839EB7009CF623 /* PresenterManager.swift */,
 			);
@@ -413,6 +415,7 @@
 				AE8FBAA81C853C7A00EB8AEA /* Functions.swift */,
 				AE6C21051C842A0F00DB6892 /* TransitionTableViewController.swift */,
 				AE8A4FF91C856EEC00E9E368 /* TransitionViewController.swift */,
+				E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */,
 			);
 			name = code;
 			sourceTree = "<group>";
@@ -687,7 +690,7 @@
 				E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
-				E2BCCD381CDCA15D00431DA0 /* Container.swift in Sources */,
+				E2BCCD381CDCA15D00431DA0 /* ContainerTransition.swift in Sources */,
 				AE6B01801C2A445100950BB2 /* AnimatableStackView.swift in Sources */,
 				AE6B01661C2A444000950BB2 /* MaskType.swift in Sources */,
 				E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */,
@@ -795,6 +798,7 @@
 				AE8A4FFA1C856EEC00E9E368 /* TransitionViewController.swift in Sources */,
 				AE6C21061C842A0F00DB6892 /* TransitionTableViewController.swift in Sources */,
 				AE8FBAA91C853C7A00EB8AEA /* Functions.swift in Sources */,
+				E25EC6E71CDE034300743DB8 /* ContainerTransitionViewController.swift in Sources */,
 				AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */; };
 		E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */; };
 		E2A062B71CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */; };
+		E2BCCD381CDCA15D00431DA0 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BCCD371CDCA15D00431DA0 /* Container.swift */; };
 		E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
 		E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */; };
 		E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */; };
@@ -255,6 +256,7 @@
 		E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplodeAnimator.swift; sourceTree = "<group>"; };
 		E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeSegue.swift; sourceTree = "<group>"; };
 		E2A062B61CB1A65600C54B40 /* PresentExplodeWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
+		E2BCCD371CDCA15D00431DA0 /* Container.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
 		E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		E2E28E711C6A6E70003F3852 /* GradientsTypeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradientsTypeScript.swift; path = Scripts/GradientsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -398,6 +400,7 @@
 				AE154B8A1C7D59EE0093C05B /* AnimatorFactory.swift */,
 				AE7C26101CB4F680002CF125 /* InteractiveAnimatorFactory.swift */,
 				CAB5692C91C9ECC8018DE83E /* Navigator.swift */,
+				E2BCCD371CDCA15D00431DA0 /* Container.swift */,
 				AE154B8D1C7D89CB0093C05B /* Presenter.swift */,
 				AEE552AF1C839EB7009CF623 /* PresenterManager.swift */,
 			);
@@ -684,6 +687,7 @@
 				E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				AE6B017F1C2A445100950BB2 /* AnimatableLabel.swift in Sources */,
+				E2BCCD381CDCA15D00431DA0 /* Container.swift in Sources */,
 				AE6B01801C2A445100950BB2 /* AnimatableStackView.swift in Sources */,
 				AE6B01661C2A444000950BB2 /* MaskType.swift in Sources */,
 				E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */,

--- a/IBAnimatableApp/Base.lproj/Main.storyboard
+++ b/IBAnimatableApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -4553,7 +4553,7 @@
         <image name="work-bg" width="375" height="179"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="7Cl-bu-Udh"/>
+        <segue reference="4ed-KQ-MWR"/>
         <segue reference="k6j-5T-Sy8"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tFh-B7-Fcy">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tFh-B7-Fcy">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -12,7 +12,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="NP4-Ex-cLZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mDV-Ii-W8m" style="IBUITableViewCellStyleDefault" id="gTl-GY-SNY">
                                 <rect key="frame" x="0.0" y="113.5" width="375" height="44"/>
@@ -30,9 +30,6 @@
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
-                                <connections>
-                                    <segue destination="6OX-wo-iCM" kind="show" id="JfO-bv-zah"/>
-                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <sections/>
@@ -53,11 +50,66 @@
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <connections>
+                        <segue destination="6FH-YS-0XK" kind="show" identifier="ContainerTransitionDemo" id="dFq-cj-e7N"/>
+                        <segue destination="6OX-wo-iCM" kind="show" identifier="TransitionDemo" id="NPn-W0-B39"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ShH-Bu-pJr" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="Zt3-2n-Jal" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="3205.5" y="-281.5"/>
+        </scene>
+        <!--Container Transition View Controller-->
+        <scene sceneID="vbg-7z-IGm">
+            <objects>
+                <viewController id="6FH-YS-0XK" customClass="ContainerTransitionViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="XGv-O1-ajl"/>
+                        <viewControllerLayoutGuide type="bottom" id="5gn-r1-haV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="DO7-iz-lhW">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tabBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="grZ-Yd-hek">
+                                <rect key="frame" x="0.0" y="574" width="375" height="49"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <items>
+                                    <tabBarItem systemItem="favorites" id="UDi-aS-ctJ"/>
+                                    <tabBarItem tag="1" systemItem="recents" id="OIa-lR-VVM"/>
+                                    <tabBarItem tag="2" systemItem="bookmarks" id="O9c-6e-mnI"/>
+                                    <tabBarItem tag="3" systemItem="more" id="72s-Ju-a6i"/>
+                                </items>
+                                <connections>
+                                    <outlet property="delegate" destination="6FH-YS-0XK" id="vhG-sd-ok2"/>
+                                </connections>
+                            </tabBar>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Owa-pq-ybG">
+                                <rect key="frame" x="0.0" y="64" width="375" height="510"/>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="grZ-Yd-hek" secondAttribute="trailing" id="IDK-Y6-c5M"/>
+                            <constraint firstItem="grZ-Yd-hek" firstAttribute="leading" secondItem="DO7-iz-lhW" secondAttribute="leading" id="Ksd-Yv-yuH"/>
+                            <constraint firstItem="5gn-r1-haV" firstAttribute="top" secondItem="grZ-Yd-hek" secondAttribute="bottom" id="gT0-le-26s"/>
+                            <constraint firstAttribute="trailing" secondItem="Owa-pq-ybG" secondAttribute="trailing" id="lv1-0C-7RX"/>
+                            <constraint firstItem="Owa-pq-ybG" firstAttribute="top" secondItem="XGv-O1-ajl" secondAttribute="bottom" id="nCB-N4-Yfs"/>
+                            <constraint firstItem="Owa-pq-ybG" firstAttribute="leading" secondItem="DO7-iz-lhW" secondAttribute="leading" id="rWe-eW-kVp"/>
+                            <constraint firstItem="grZ-Yd-hek" firstAttribute="top" secondItem="Owa-pq-ybG" secondAttribute="bottom" id="zIN-35-6dy"/>
+                        </constraints>
+                    </view>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <connections>
+                        <outlet property="containerView" destination="Owa-pq-ybG" id="tda-6t-S0N"/>
+                        <outlet property="tabBar" destination="grZ-Yd-hek" id="8P9-hQ-yGH"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="zML-id-2Cn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3205.5" y="521.5"/>
         </scene>
         <!--Transition View Controller-->
         <scene sceneID="j4X-Oe-hEs">

--- a/IBAnimatableApp/ContainerTransitionViewController.swift
+++ b/IBAnimatableApp/ContainerTransitionViewController.swift
@@ -1,0 +1,84 @@
+//
+//  Created by Tom Baranes on 07/05/16.
+//  Copyright © 2016 Jake Lin. All rights reserved.
+//
+
+import UIKit
+import IBAnimatable
+
+class ContainerTransitionViewController: UIViewController, UITabBarDelegate {
+
+  // MARK: Properties
+  
+  @IBOutlet var tabBar: UITabBar!
+  @IBOutlet var containerView: UIView!
+  
+  private var viewControllers = [AnimatableViewController]()
+  private var currentViewController: AnimatableViewController?
+  
+  // MARK: Life cycle
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    createChildViewControllers()
+    tabBar.selectedItem = tabBar.items?.first
+  }
+  
+}
+
+// MARK: - ChildViewController
+
+private extension ContainerTransitionViewController {
+  
+  func createChildViewControllers() {
+    var viewController = AnimatableViewController()
+    viewController.view.backgroundColor = UIColor.blueColor()
+    viewController.transitionAnimationType = "Explode"
+    viewControllers.append(viewController)
+   
+    viewController = AnimatableViewController()
+    viewController.view.backgroundColor = UIColor.greenColor()
+    viewController.transitionAnimationType = "Fold"
+    viewControllers.append(viewController)
+
+    viewController = AnimatableViewController()
+    viewController.view.backgroundColor = UIColor.yellowColor()
+    viewController.transitionAnimationType = "NatGeo"
+    viewControllers.append(viewController)
+    
+    viewController = AnimatableViewController()
+    viewController.view.backgroundColor = UIColor.redColor()
+    viewController.transitionAnimationType = "Portal"
+    viewControllers.append(viewController)
+    
+    cycleFromViewController(containerView, fromViewController: nil, toViewController: viewControllers[0])
+
+  }
+  
+  func cycleFromViewController(containerView: UIView, fromViewController: AnimatableViewController?, toViewController: AnimatableViewController) {
+    guard let animationType = TransitionAnimationType.fromString(toViewController.transitionAnimationType ?? "") else {
+      return
+    }
+    
+    let transitionContext = ContainerTransition(animationType: animationType,
+                                                container: containerView,
+                                                parentViewController: self,
+                                                fromViewController: fromViewController,
+                                                toViewController: toViewController) {
+      self.currentViewController = toViewController
+    }
+    transitionContext.animate()
+  }
+  
+}
+
+// MARK: - UITabBarDelegate
+
+extension ContainerTransitionViewController {
+
+  func tabBar(tabBar: UITabBar, didSelectItem item: UITabBarItem) {
+    let toViewController = viewControllers[item.tag]
+    cycleFromViewController(containerView, fromViewController: currentViewController, toViewController: toViewController)
+  }
+  
+}

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -40,6 +40,8 @@ class TransitionTableViewController: UITableViewController {
 private extension TransitionTableViewController {
   
   func generateTransitionTypeData() {
+    transitionAnimationsHeaders.append("ContainerTransition")
+    transitionAnimations.append(["TabBar example"])
     transitionAnimationsHeaders.append("Fade")
     transitionAnimations.append(["Fade", "FadeIn", "FadeOut"])
     transitionAnimationsHeaders.append("SystemCube")
@@ -102,5 +104,13 @@ extension TransitionTableViewController {
     cell.textLabel?.text = transitionAnimations[indexPath.section][indexPath.row]
     return cell
   }
-  
+ 
+  override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+//    tableView.deselectRowAtIndexPath(indexPath, animated: true)
+    if indexPath.section == 0 && indexPath.row == 0 {
+      performSegueWithIdentifier("ContainerTransitionDemo", sender: self)
+    } else {
+      performSegueWithIdentifier("TransitionDemo", sender: self)
+    }
+  }
 }


### PR DESCRIPTION
Related to #188 

This PR contains only one new class: `Container` (need to find a better name) allowing the usage of `IBAnimatable` animators to make transition between childViewController. The usage is really straightforward:

``` swift
let transitionContext = ContainerTransition(animationType: .Fold(direction: direction, params: []),
                                                    container: containerView,
                                                    parentViewController: self,
                                                    fromViewController: fromViewController,
                                                    toViewController: toViewController) {
      self.currentViewController = toViewController
}
transitionContext.animate()
```

More details:
- Doesn't support interactive gesture
- Doesn't support for interface builder
- If nil is passed as `fromViewController`, it will set the `toViewController` as default without animation
- Handle all the logic to transit from a view controller to a new one, with an animation
- Support every `TransitionAnimationType`

That feature doesn't really follow the main goal of `IBAnimatable` (a library for designers), but I'm sure it's worth it for every developers using it programatically.  What do you think?

If you are ok to merge it, I will update the CHANGELOG, README, and also add an example in the demo project.
