### PR TITLE
Makes AnimatableNavigationController configurable after init

### DIFF
--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -8,22 +8,36 @@ import UIKit
 public class AnimatableNavigationController: UINavigationController, TransitionAnimatable {
   
   // MARK: - TransitionAnimatable
-  @IBInspectable public var transitionAnimationType: String?
-  @IBInspectable public var transitionDuration: Double = .NaN
-  @IBInspectable public var interactiveGestureType: String?
-
+  @IBInspectable public var transitionAnimationType: String? {
+    didSet {
+      configureNavigationControllerDelegate()
+    }
+  }
+  @IBInspectable public var transitionDuration: Double = .NaN {
+    didSet {
+      configureNavigationControllerDelegate()
+    }
+  }
+  @IBInspectable public var interactiveGestureType: String? {
+    didSet {
+      configureNavigationControllerDelegate()
+    }
+  }
+  
   // MARK: - Lifecylce
   public override func viewDidLoad() {
     super.viewDidLoad()
     configureNavigationControllerDelegate()
   }
-
+  
   // MARK: - Private
   // Must have a property to keep the reference alive because `UINavigationController.delegate` is `weak`
   private var navigator: Navigator?
-
+  
   private func configureNavigationControllerDelegate() {
     guard let transitionAnimationType = transitionAnimationType, animationType = TransitionAnimationType.fromString(transitionAnimationType) else {
+      navigator = nil
+      delegate = nil
       return
     }
     var duration = transitionDuration


### PR DESCRIPTION
The `Navigator` will be create again with the new parameters if we change the animation type, the duration, or the interactive gesture. That can be useful in case that we are using only one navigation controller but want to customise the animation.. between two push / pop. If the animation is set to nil, then the custom navigation is completely reset and back to the default behaviour.

It wasn't what I was looking at first, but I'm pretty sure that can be pretty useful in a lot of cases. I'm just wondering, if there any reason that we create custom segues for Present / Dismiss but not Push / pop?
