### PR TITLE
Improve signatures for transition animators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### API breaking changes
 
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)
+- Refactor `direction` to `fromDirection` for system transition animators.  Refactor `TransitionFromDirection` to `TransitionDirection`. [#206](https://github.com/JakeLin/IBAnimatable/pull/206)
 
 #### Enhancements
 

--- a/IBAnimatable/CardsAnimator.swift
+++ b/IBAnimatable/CardsAnimator.swift
@@ -14,9 +14,9 @@ public class CardsAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
     self.fromDirection = fromDirection
     

--- a/IBAnimatable/CardsAnimator.swift
+++ b/IBAnimatable/CardsAnimator.swift
@@ -48,7 +48,7 @@ extension CardsAnimator: UIViewControllerAnimatedTransitioning {
     if fromDirection == .Forward {
       executeForwardAnimation(transitionContext, containerView: containerView, fromView: fromView, toView: toView)
     } else {
-      executeBackwardAnimations(transitionContext, containerView: containerView, fromView: fromView, toView: toView)
+      executeBackwardAnimation(transitionContext, containerView: containerView, fromView: fromView, toView: toView)
     }
   }
   
@@ -58,7 +58,7 @@ extension CardsAnimator: UIViewControllerAnimatedTransitioning {
 
 private extension CardsAnimator {
   
-  func executeForwardAnimation(transitionContext: UIViewControllerContextTransitioning, containerView: UIView, fromView: UIView, toView: UIView) {
+  func executeBackwardAnimation(transitionContext: UIViewControllerContextTransitioning, containerView: UIView, fromView: UIView, toView: UIView) {
     let frame = fromView.frame
     var offScreenFrame = frame
     offScreenFrame.origin.y = offScreenFrame.height
@@ -95,7 +95,7 @@ private extension CardsAnimator {
 
 private extension CardsAnimator {
   
-  func executeBackwardAnimations(transitionContext: UIViewControllerContextTransitioning, containerView: UIView, fromView: UIView, toView: UIView) {
+  func executeForwardAnimation(transitionContext: UIViewControllerContextTransitioning, containerView: UIView, fromView: UIView, toView: UIView) {
     let frame = fromView.frame
     toView.frame = frame
     let scale = CATransform3DIdentity

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -1,7 +1,4 @@
 //
-//  ExplodeAnimator.swift
-//  IBAnimatableApp
-//
 //  Created by Tom Baranes on 03/04/16.
 //  Copyright © 2016 Jake Lin. All rights reserved.
 //

--- a/IBAnimatable/FlipAnimator.swift
+++ b/IBAnimatable/FlipAnimator.swift
@@ -13,7 +13,7 @@ public class FlipAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - Private params
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
   // MARK: - Private fold transition
   private var transform: CATransform3D = CATransform3DIdentity
@@ -21,7 +21,7 @@ public class FlipAnimator: NSObject, AnimatedTransitioning {
   private var horizontal: Bool = false
   
   // MARK: - Life cycle
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     horizontal = fromDirection.isHorizontal

--- a/IBAnimatable/FlipAnimator.swift
+++ b/IBAnimatable/FlipAnimator.swift
@@ -28,23 +28,23 @@ public class FlipAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .Flip(direction: .Right)
-      self.reverseAnimationType = .Flip(direction: .Left)
+      self.transitionAnimationType = .Flip(fromDirection: .Right)
+      self.reverseAnimationType = .Flip(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
       reverse = true
     case .Top:
-      self.transitionAnimationType = .Flip(direction: .Top)
-      self.reverseAnimationType = .Flip(direction: .Bottom)
+      self.transitionAnimationType = .Flip(fromDirection: .Top)
+      self.reverseAnimationType = .Flip(fromDirection: .Bottom)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
       reverse = false
     case .Bottom:
-      self.transitionAnimationType = .Flip(direction: .Bottom)
-      self.reverseAnimationType = .Flip(direction: .Top)
+      self.transitionAnimationType = .Flip(fromDirection: .Bottom)
+      self.reverseAnimationType = .Flip(fromDirection: .Top)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
       reverse = true
     default:
-      self.transitionAnimationType = .Flip(direction: .Left)
-      self.reverseAnimationType = .Flip(direction: .Right)
+      self.transitionAnimationType = .Flip(fromDirection: .Left)
+      self.reverseAnimationType = .Flip(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
       reverse = false      
     }

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -13,7 +13,7 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - Private params
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   private var folds: Int = 2
   
   // MARK: - Private fold transition
@@ -30,7 +30,7 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
   }
   
   // MARK: - Life cycle
-  public init(fromDirection: TransitionFromDirection, params: [String], transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, params: [String], transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     horizontal = fromDirection.isHorizontal

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -42,23 +42,23 @@ public class FoldAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .Fold(direction: .Right, params: params)
-      self.reverseAnimationType = .Fold(direction: .Left, params: params)
+      self.transitionAnimationType = .Fold(fromDirection: .Right, params: params)
+      self.reverseAnimationType = .Fold(fromDirection: .Left, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
       reverse = true
     case .Top:
-      self.transitionAnimationType = .Fold(direction: .Top, params: params)
-      self.reverseAnimationType = .Fold(direction: .Bottom, params: params)
+      self.transitionAnimationType = .Fold(fromDirection: .Top, params: params)
+      self.reverseAnimationType = .Fold(fromDirection: .Bottom, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
       reverse = false
     case .Bottom:
-      self.transitionAnimationType = .Fold(direction: .Bottom, params: params)
-      self.reverseAnimationType = .Fold(direction: .Top, params: params)
+      self.transitionAnimationType = .Fold(fromDirection: .Bottom, params: params)
+      self.reverseAnimationType = .Fold(fromDirection: .Top, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
       reverse = true
     default:
-      self.transitionAnimationType = .Fold(direction: .Left, params: params)
-      self.reverseAnimationType = .Fold(direction: .Right, params: params)
+      self.transitionAnimationType = .Fold(fromDirection: .Left, params: params)
+      self.reverseAnimationType = .Fold(fromDirection: .Right, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
       reverse = false      
     }

--- a/IBAnimatable/NatGeoAnimator.swift
+++ b/IBAnimatable/NatGeoAnimator.swift
@@ -14,12 +14,12 @@ public class NatGeoAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   private let firstPartRatio: Double = 0.8
   
   // MARK: - Life cycle
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
     self.fromDirection = fromDirection
     

--- a/IBAnimatable/NatGeoAnimator.swift
+++ b/IBAnimatable/NatGeoAnimator.swift
@@ -25,11 +25,11 @@ public class NatGeoAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .NatGeo(direction: .Right)
-      self.reverseAnimationType = .NatGeo(direction: .Left)
+      self.transitionAnimationType = .NatGeo(toDirection: .Right)
+      self.reverseAnimationType = .NatGeo(toDirection: .Left)
     default:
-      self.transitionAnimationType = .NatGeo(direction: .Left)
-      self.reverseAnimationType = .NatGeo(direction: .Right)
+      self.transitionAnimationType = .NatGeo(toDirection: .Left)
+      self.reverseAnimationType = .NatGeo(toDirection: .Right)
     }
     
     super.init()

--- a/IBAnimatable/PortalAnimator.swift
+++ b/IBAnimatable/PortalAnimator.swift
@@ -14,10 +14,10 @@ public class PortalAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   private var zoomScale: CGFloat = 0.8
   
-  public init(fromDirection: TransitionFromDirection, params: [String], transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, params: [String], transitionDuration: Duration) {
     self.transitionDuration = transitionDuration
     self.fromDirection = fromDirection
     

--- a/IBAnimatable/PresentFlipSegue.swift
+++ b/IBAnimatable/PresentFlipSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFlipSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Flip(direction: .Left))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Flip(fromDirection: .Left))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFlipWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentFlipWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFlipWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Flip(direction: .Left), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Flip(fromDirection: .Left), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFoldSegue.swift
+++ b/IBAnimatable/PresentFoldSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFoldSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(direction: .Left, params: []))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(fromDirection: .Left, params: []))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentFoldWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentFoldWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(direction: .Left, params: []), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Fold(fromDirection: .Left, params: []), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentNatGeoSegue.swift
+++ b/IBAnimatable/PresentNatGeoSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentNatGeoSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.NatGeo(direction: .Left))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.NatGeo(toDirection: .Left))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentNatGeoWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentNatGeoWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentNatGeoWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.NatGeo(direction: .Left), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.NatGeo(toDirection: .Left), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentSlideSegue.swift
+++ b/IBAnimatable/PresentSlideSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentSlideSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Slide(direction: .Left, params: []))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Slide(toDirection: .Left, params: []))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentSlideWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentSlideWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentSlideWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Slide(direction: .Left, params: []), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Slide(toDirection: .Left, params: []), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentTurnSegue.swift
+++ b/IBAnimatable/PresentTurnSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentTurnSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Turn(direction: .Left))
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Turn(fromDirection: .Left))
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/PresentTurnWithDismissInteractionSegue.swift
+++ b/IBAnimatable/PresentTurnWithDismissInteractionSegue.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public class PresentTurnWithDismissInteractionSegue: UIStoryboardSegue {
   public override func perform() {
-    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Turn(direction: .Left), interactiveGestureType: .Default)
+    destinationViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(.Turn(fromDirection: .Left), interactiveGestureType: .Default)
     sourceViewController.presentViewController(destinationViewController, animated: true, completion: nil)
   }
 }

--- a/IBAnimatable/SlideAnimator.swift
+++ b/IBAnimatable/SlideAnimator.swift
@@ -26,23 +26,23 @@ public class SlideAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .Slide(direction: .Right, params: params)
-      self.reverseAnimationType = .Slide(direction: .Left, params: params)
+      self.transitionAnimationType = .Slide(toDirection: .Right, params: params)
+      self.reverseAnimationType = .Slide(toDirection: .Left, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
       reverse = true
     case .Top:
-      self.transitionAnimationType = .Slide(direction: .Top, params: params)
-      self.reverseAnimationType = .Slide(direction: .Bottom, params: params)
+      self.transitionAnimationType = .Slide(toDirection: .Top, params: params)
+      self.reverseAnimationType = .Slide(toDirection: .Bottom, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
       reverse = false
     case .Bottom:
-      self.transitionAnimationType = .Slide(direction: .Bottom, params: params)
-      self.reverseAnimationType = .Slide(direction: .Top, params: params)
+      self.transitionAnimationType = .Slide(toDirection: .Bottom, params: params)
+      self.reverseAnimationType = .Slide(toDirection: .Top, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
       reverse = true
     default:
-      self.transitionAnimationType = .Slide(direction: .Left, params: params)
-      self.reverseAnimationType = .Slide(direction: .Right, params: params)
+      self.transitionAnimationType = .Slide(toDirection: .Left, params: params)
+      self.reverseAnimationType = .Slide(toDirection: .Right, params: params)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
       reverse = false
     }

--- a/IBAnimatable/SlideAnimator.swift
+++ b/IBAnimatable/SlideAnimator.swift
@@ -13,12 +13,12 @@ public class SlideAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   private var horizontal = false
   private var reverse = false
   private var fade = false
   
-  public init(fromDirection: TransitionFromDirection, params: [String], transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, params: [String], transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     fade = params.contains("fade")

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -15,9 +15,9 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
 
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -50,6 +50,6 @@ extension SystemCubeAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.Cube, subtype: fromDirection.stringValue)
+    animateWithCATransition(transitionContext, type: SystemTransitionType.Cube, subtype: fromDirection.CATransitionSubtype)
   }
 }

--- a/IBAnimatable/SystemCubeAnimator.swift
+++ b/IBAnimatable/SystemCubeAnimator.swift
@@ -23,20 +23,20 @@ public class SystemCubeAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .SystemCube(direction: .Right)
-      self.reverseAnimationType = .SystemCube(direction: .Left)
+      self.transitionAnimationType = .SystemCube(fromDirection: .Right)
+      self.reverseAnimationType = .SystemCube(fromDirection: .Left)
       self.interactiveGestureType = .ScreenEdgePan(fromDirection: .Left)
     case .Top:
-      self.transitionAnimationType = .SystemCube(direction: .Top)
-      self.reverseAnimationType = .SystemCube(direction: .Bottom)
+      self.transitionAnimationType = .SystemCube(fromDirection: .Top)
+      self.reverseAnimationType = .SystemCube(fromDirection: .Bottom)
       self.interactiveGestureType = .ScreenEdgePan(fromDirection: .Bottom)
     case .Bottom:
-      self.transitionAnimationType = .SystemCube(direction: .Bottom)
-      self.reverseAnimationType = .SystemCube(direction: .Top)
+      self.transitionAnimationType = .SystemCube(fromDirection: .Bottom)
+      self.reverseAnimationType = .SystemCube(fromDirection: .Top)
       self.interactiveGestureType = .ScreenEdgePan(fromDirection: .Top)
     default:
-      self.transitionAnimationType = .SystemPush(direction: .Left)
-      self.reverseAnimationType = .SystemPush(direction: .Right)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Left)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
     }
     

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -52,6 +52,6 @@ extension SystemFlipAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.Flip, subtype: fromDirection.stringValue)
+    animateWithCATransition(transitionContext, type: SystemTransitionType.Flip, subtype: fromDirection.CATransitionSubtype)
   }
 }

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -16,10 +16,10 @@ public class SystemFlipAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
 
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   private var animationOption: UIViewAnimationOptions
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatable/SystemFlipAnimator.swift
+++ b/IBAnimatable/SystemFlipAnimator.swift
@@ -25,20 +25,20 @@ public class SystemFlipAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .SystemFlip(direction: .Right)
-      self.reverseAnimationType = .SystemFlip(direction: .Left)
+      self.transitionAnimationType = .SystemFlip(fromDirection: .Right)
+      self.reverseAnimationType = .SystemFlip(fromDirection: .Left)
       self.animationOption = .TransitionFlipFromRight
     case .Top:
-      self.transitionAnimationType = .SystemFlip(direction: .Top)
-      self.reverseAnimationType = .SystemFlip(direction: .Bottom)
+      self.transitionAnimationType = .SystemFlip(fromDirection: .Top)
+      self.reverseAnimationType = .SystemFlip(fromDirection: .Bottom)
       self.animationOption = .TransitionFlipFromTop
     case .Bottom:
-      self.transitionAnimationType = .SystemFlip(direction: .Bottom)
-      self.reverseAnimationType = .SystemFlip(direction: .Top)
+      self.transitionAnimationType = .SystemFlip(fromDirection: .Bottom)
+      self.reverseAnimationType = .SystemFlip(fromDirection: .Top)
       self.animationOption = .TransitionFlipFromBottom
     default:
-      self.transitionAnimationType = .SystemFlip(direction: .Left)
-      self.reverseAnimationType = .SystemFlip(direction: .Right)
+      self.transitionAnimationType = .SystemFlip(fromDirection: .Left)
+      self.reverseAnimationType = .SystemFlip(fromDirection: .Right)
       self.animationOption = .TransitionFlipFromLeft
     }
     

--- a/IBAnimatable/SystemMoveInAnimator.swift
+++ b/IBAnimatable/SystemMoveInAnimator.swift
@@ -21,20 +21,20 @@ public class SystemMoveInAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .SystemMoveIn(direction: .Right)
-      self.reverseAnimationType = .SystemMoveIn(direction: .Left)
+      self.transitionAnimationType = .SystemMoveIn(fromDirection: .Right)
+      self.reverseAnimationType = .SystemMoveIn(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
     case .Top:
-      self.transitionAnimationType = .SystemMoveIn(direction: .Top)
-      self.reverseAnimationType = .SystemMoveIn(direction: .Bottom)
+      self.transitionAnimationType = .SystemMoveIn(fromDirection: .Top)
+      self.reverseAnimationType = .SystemMoveIn(fromDirection: .Bottom)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
     case .Bottom:
-      self.transitionAnimationType = .SystemMoveIn(direction: .Bottom)
-      self.reverseAnimationType = .SystemMoveIn(direction: .Top)
+      self.transitionAnimationType = .SystemMoveIn(fromDirection: .Bottom)
+      self.reverseAnimationType = .SystemMoveIn(fromDirection: .Top)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
     default:
-      self.transitionAnimationType = .SystemMoveIn(direction: .Left)
-      self.reverseAnimationType = .SystemMoveIn(direction: .Right)
+      self.transitionAnimationType = .SystemMoveIn(fromDirection: .Left)
+      self.reverseAnimationType = .SystemMoveIn(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
     }
     

--- a/IBAnimatable/SystemMoveInAnimator.swift
+++ b/IBAnimatable/SystemMoveInAnimator.swift
@@ -48,6 +48,6 @@ extension SystemMoveInAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.MoveIn, subtype: fromDirection.stringValue)
+    animateWithCATransition(transitionContext, type: SystemTransitionType.MoveIn, subtype: fromDirection.CATransitionSubtype)
   }
 }

--- a/IBAnimatable/SystemMoveInAnimator.swift
+++ b/IBAnimatable/SystemMoveInAnimator.swift
@@ -13,9 +13,9 @@ public class SystemMoveInAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatable/SystemPushAnimator.swift
+++ b/IBAnimatable/SystemPushAnimator.swift
@@ -24,20 +24,20 @@ public class SystemPushAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .SystemPush(direction: .Right)
-      self.reverseAnimationType = .SystemPush(direction: .Left)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Right)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
     case .Top:
-      self.transitionAnimationType = .SystemPush(direction: .Top)
-      self.reverseAnimationType = .SystemPush(direction: .Bottom)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Top)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Bottom)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
     case .Bottom:
-      self.transitionAnimationType = .SystemPush(direction: .Bottom)
-      self.reverseAnimationType = .SystemPush(direction: .Top)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Bottom)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Top)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
     default:
-      self.transitionAnimationType = .SystemPush(direction: .Left)
-      self.reverseAnimationType = .SystemPush(direction: .Right)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Left)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
     }
     

--- a/IBAnimatable/SystemPushAnimator.swift
+++ b/IBAnimatable/SystemPushAnimator.swift
@@ -16,9 +16,9 @@ public class SystemPushAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatable/SystemPushAnimator.swift
+++ b/IBAnimatable/SystemPushAnimator.swift
@@ -51,6 +51,6 @@ extension SystemPushAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.Push, subtype: fromDirection.stringValue)
+    animateWithCATransition(transitionContext, type: SystemTransitionType.Push, subtype: fromDirection.CATransitionSubtype)
   }
 }

--- a/IBAnimatable/SystemRevealAnimator.swift
+++ b/IBAnimatable/SystemRevealAnimator.swift
@@ -48,6 +48,6 @@ extension SystemRevealAnimator: UIViewControllerAnimatedTransitioning {
   }
   
   public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-    animateWithCATransition(transitionContext, type: SystemTransitionType.Reveal, subtype: fromDirection.stringValue)
+    animateWithCATransition(transitionContext, type: SystemTransitionType.Reveal, subtype: fromDirection.CATransitionSubtype)
   }
 }

--- a/IBAnimatable/SystemRevealAnimator.swift
+++ b/IBAnimatable/SystemRevealAnimator.swift
@@ -21,20 +21,20 @@ public class SystemRevealAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .SystemReveal(direction: .Right)
-      self.reverseAnimationType = .SystemReveal(direction: .Left)
+      self.transitionAnimationType = .SystemReveal(fromDirection: .Right)
+      self.reverseAnimationType = .SystemReveal(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
     case .Top:
-      self.transitionAnimationType = .SystemReveal(direction: .Top)
-      self.reverseAnimationType = .SystemReveal(direction: .Bottom)
+      self.transitionAnimationType = .SystemReveal(fromDirection: .Top)
+      self.reverseAnimationType = .SystemReveal(fromDirection: .Bottom)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
     case .Bottom:
-      self.transitionAnimationType = .SystemReveal(direction: .Bottom)
-      self.reverseAnimationType = .SystemReveal(direction: .Top)
+      self.transitionAnimationType = .SystemReveal(fromDirection: .Bottom)
+      self.reverseAnimationType = .SystemReveal(fromDirection: .Top)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
     default:
-      self.transitionAnimationType = .SystemPush(direction: .Left)
-      self.reverseAnimationType = .SystemPush(direction: .Right)
+      self.transitionAnimationType = .SystemPush(fromDirection: .Left)
+      self.reverseAnimationType = .SystemPush(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
     }
     

--- a/IBAnimatable/SystemRevealAnimator.swift
+++ b/IBAnimatable/SystemRevealAnimator.swift
@@ -13,9 +13,9 @@ public class SystemRevealAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType?
   
   // MARK: - private
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -15,7 +15,7 @@ public enum TransitionAnimationType {
   case SystemSuckEffect
   case SystemRippleEffect
   case Explode(params: [String])
-  case Fold(direction: TransitionDirection, params: [String])
+  case Fold(fromDirection: TransitionDirection, params: [String])
   case Portal(direction: TransitionDirection, params: [String])
   case Slide(direction: TransitionDirection, params: [String])
   case NatGeo(direction: TransitionDirection)
@@ -134,7 +134,7 @@ private extension TransitionAnimationType {
     var params = params
     params.removeFirst()
     if transitionType.hasPrefix("Fold") {
-      return .Fold(direction: direction, params: params)
+      return .Fold(fromDirection: direction, params: params)
     } else if transitionType.hasPrefix("Portal") {
       return .Portal(direction: direction, params: params)
     } else if transitionType.hasPrefix("Slide") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -21,7 +21,7 @@ public enum TransitionAnimationType {
   case NatGeo(toDirection: TransitionDirection)
   case Turn(fromDirection: TransitionDirection)
   case Cards(direction: TransitionDirection)
-  case Flip(direction: TransitionDirection)
+  case Flip(fromDirection: TransitionDirection)
   case SystemCube(fromDirection: TransitionDirection)
   case SystemFlip(fromDirection: TransitionDirection)
   case SystemMoveIn(fromDirection: TransitionDirection)
@@ -124,7 +124,7 @@ private extension TransitionAnimationType {
     } else if transitionType.hasPrefix("Cards") {
       return .Cards(direction: direction)
     } else if transitionType.hasPrefix("Flip") {
-      return .Flip(direction: direction)
+      return .Flip(fromDirection: direction)
     } else {
       return fromStringWithDirectionAndParams(transitionType, direction: direction, params: transitionParams)
     }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -15,18 +15,18 @@ public enum TransitionAnimationType {
   case SystemSuckEffect
   case SystemRippleEffect
   case Explode(params: [String])
-  case Fold(direction: TransitionFromDirection, params: [String])
-  case Portal(direction: TransitionFromDirection, params: [String])
-  case Slide(direction: TransitionFromDirection, params: [String])
-  case NatGeo(direction: TransitionFromDirection)
-  case Turn(direction: TransitionFromDirection)
-  case Cards(direction: TransitionFromDirection)
-  case Flip(direction: TransitionFromDirection)
-  case SystemCube(fromDirection: TransitionFromDirection)
-  case SystemFlip(fromDirection: TransitionFromDirection)
-  case SystemMoveIn(fromDirection: TransitionFromDirection)
-  case SystemPush(fromDirection: TransitionFromDirection)
-  case SystemReveal(fromDirection: TransitionFromDirection)
+  case Fold(direction: TransitionDirection, params: [String])
+  case Portal(direction: TransitionDirection, params: [String])
+  case Slide(direction: TransitionDirection, params: [String])
+  case NatGeo(direction: TransitionDirection)
+  case Turn(direction: TransitionDirection)
+  case Cards(direction: TransitionDirection)
+  case Flip(direction: TransitionDirection)
+  case SystemCube(fromDirection: TransitionDirection)
+  case SystemFlip(fromDirection: TransitionDirection)
+  case SystemMoveIn(fromDirection: TransitionDirection)
+  case SystemPush(fromDirection: TransitionDirection)
+  case SystemReveal(fromDirection: TransitionDirection)
   case SystemPage(type: TransitionPageType)
   case SystemCameraIris(hollowState: TransitionHollowState)
   case SystemRotate(degree: TransitionRotateDegree)
@@ -130,7 +130,7 @@ private extension TransitionAnimationType {
     }
   }
   
-  static func fromStringWithDirectionAndParams(transitionType: String, direction: TransitionFromDirection, params: [String]) -> TransitionAnimationType? {
+  static func fromStringWithDirectionAndParams(transitionType: String, direction: TransitionDirection, params: [String]) -> TransitionAnimationType? {
     var params = params
     params.removeFirst()
     if transitionType.hasPrefix("Fold") {
@@ -158,7 +158,7 @@ private extension TransitionAnimationType {
     return transitionType.componentsSeparatedByString(",")
   }
   
-  static func transitionDirection(forParams params: [String]) -> TransitionFromDirection? {
+  static func transitionDirection(forParams params: [String]) -> TransitionDirection? {
     if params.contains("left") {
       return .Left
     } else if params.contains("right") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -19,7 +19,7 @@ public enum TransitionAnimationType {
   case Portal(direction: TransitionDirection, params: [String])
   case Slide(direction: TransitionDirection, params: [String])
   case NatGeo(toDirection: TransitionDirection)
-  case Turn(direction: TransitionDirection)
+  case Turn(fromDirection: TransitionDirection)
   case Cards(direction: TransitionDirection)
   case Flip(direction: TransitionDirection)
   case SystemCube(fromDirection: TransitionDirection)
@@ -120,7 +120,7 @@ private extension TransitionAnimationType {
     } else if transitionType.hasPrefix("NatGeo") {
       return .NatGeo(toDirection: direction)
     } else if transitionType.hasPrefix("Turn") {
-      return .Turn(direction: direction)      
+      return .Turn(fromDirection: direction)      
     } else if transitionType.hasPrefix("Cards") {
       return .Cards(direction: direction)
     } else if transitionType.hasPrefix("Flip") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -18,7 +18,7 @@ public enum TransitionAnimationType {
   case Fold(fromDirection: TransitionDirection, params: [String])
   case Portal(direction: TransitionDirection, params: [String])
   case Slide(direction: TransitionDirection, params: [String])
-  case NatGeo(direction: TransitionDirection)
+  case NatGeo(toDirection: TransitionDirection)
   case Turn(direction: TransitionDirection)
   case Cards(direction: TransitionDirection)
   case Flip(direction: TransitionDirection)
@@ -118,7 +118,7 @@ private extension TransitionAnimationType {
     } else if transitionType.hasPrefix("SystemReveal") {
       return .SystemReveal(fromDirection: direction)
     } else if transitionType.hasPrefix("NatGeo") {
-      return .NatGeo(direction: direction)
+      return .NatGeo(toDirection: direction)
     } else if transitionType.hasPrefix("Turn") {
       return .Turn(direction: direction)      
     } else if transitionType.hasPrefix("Cards") {

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -17,7 +17,7 @@ public enum TransitionAnimationType {
   case Explode(params: [String])
   case Fold(fromDirection: TransitionDirection, params: [String])
   case Portal(direction: TransitionDirection, params: [String])
-  case Slide(direction: TransitionDirection, params: [String])
+  case Slide(toDirection: TransitionDirection, params: [String])
   case NatGeo(toDirection: TransitionDirection)
   case Turn(fromDirection: TransitionDirection)
   case Cards(direction: TransitionDirection)
@@ -138,7 +138,7 @@ private extension TransitionAnimationType {
     } else if transitionType.hasPrefix("Portal") {
       return .Portal(direction: direction, params: params)
     } else if transitionType.hasPrefix("Slide") {
-      return .Slide(direction: direction, params: params)
+      return .Slide(toDirection: direction, params: params)
     }
     return nil
   }

--- a/IBAnimatable/TransitionAnimationType.swift
+++ b/IBAnimatable/TransitionAnimationType.swift
@@ -22,11 +22,11 @@ public enum TransitionAnimationType {
   case Turn(direction: TransitionFromDirection)
   case Cards(direction: TransitionFromDirection)
   case Flip(direction: TransitionFromDirection)
-  case SystemCube(direction: TransitionFromDirection)
-  case SystemFlip(direction: TransitionFromDirection)
-  case SystemMoveIn(direction: TransitionFromDirection)
-  case SystemPush(direction: TransitionFromDirection)
-  case SystemReveal(direction: TransitionFromDirection)
+  case SystemCube(fromDirection: TransitionFromDirection)
+  case SystemFlip(fromDirection: TransitionFromDirection)
+  case SystemMoveIn(fromDirection: TransitionFromDirection)
+  case SystemPush(fromDirection: TransitionFromDirection)
+  case SystemReveal(fromDirection: TransitionFromDirection)
   case SystemPage(type: TransitionPageType)
   case SystemCameraIris(hollowState: TransitionHollowState)
   case SystemRotate(degree: TransitionRotateDegree)
@@ -108,15 +108,15 @@ private extension TransitionAnimationType {
     let transitionParams = params(forTransitionType: transitionType)
     let direction = transitionDirection(forParams: transitionParams) ?? .Left
     if transitionType.hasPrefix("SystemCube") {
-      return .SystemCube(direction: direction)
+      return .SystemCube(fromDirection: direction)
     } else if transitionType.hasPrefix("SystemFlip") {
-      return .SystemFlip(direction: direction)
+      return .SystemFlip(fromDirection: direction)
     } else if transitionType.hasPrefix("SystemMoveIn") {
-      return .SystemMoveIn(direction: direction)
+      return .SystemMoveIn(fromDirection: direction)
     } else if transitionType.hasPrefix("SystemPush") {
-      return .SystemPush(direction: direction)
+      return .SystemPush(fromDirection: direction)
     } else if transitionType.hasPrefix("SystemReveal") {
-      return .SystemReveal(direction: direction)
+      return .SystemReveal(fromDirection: direction)
     } else if transitionType.hasPrefix("NatGeo") {
       return .NatGeo(direction: direction)
     } else if transitionType.hasPrefix("Turn") {

--- a/IBAnimatable/TransitionFromDirection.swift
+++ b/IBAnimatable/TransitionFromDirection.swift
@@ -5,16 +5,17 @@
 import UIKit
 
 /**
-TransitionFromDirection: convert from direction to CATransition Subtype used in `CATransition`
+TransitionDirection: used to specify the direction for the transition
 */
-public enum TransitionFromDirection {
+public enum TransitionDirection {
   case Left
   case Right
   case Top
   case Bottom
   case Forward
   case Backward
-  
+
+  // Convert from direction to CATransition Subtype used in `CATransition`
   var stringValue: String {
     switch self {
     case .Left:

--- a/IBAnimatable/TransitionFromDirection.swift
+++ b/IBAnimatable/TransitionFromDirection.swift
@@ -16,7 +16,7 @@ public enum TransitionDirection {
   case Backward
 
   // Convert from direction to CATransition Subtype used in `CATransition`
-  var stringValue: String {
+  var CATransitionSubtype: String {
     switch self {
     case .Left:
       return kCATransitionFromLeft

--- a/IBAnimatable/TurnAnimator.swift
+++ b/IBAnimatable/TurnAnimator.swift
@@ -26,23 +26,23 @@ public class TurnAnimator: NSObject, AnimatedTransitioning {
     
     switch fromDirection {
     case .Right:
-      self.transitionAnimationType = .Turn(direction: .Right)
-      self.reverseAnimationType = .Turn(direction: .Left)
+      self.transitionAnimationType = .Turn(fromDirection: .Right)
+      self.reverseAnimationType = .Turn(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
       reverse = true
     case .Top:
-      self.transitionAnimationType = .Turn(direction: .Top)
-      self.reverseAnimationType = .Turn(direction: .Bottom)
+      self.transitionAnimationType = .Turn(fromDirection: .Top)
+      self.reverseAnimationType = .Turn(fromDirection: .Bottom)
       self.interactiveGestureType = .Pan(fromDirection: .Bottom)
       reverse = false
     case .Bottom:
-      self.transitionAnimationType = .Turn(direction: .Bottom)
-      self.reverseAnimationType = .Turn(direction: .Top)
+      self.transitionAnimationType = .Turn(fromDirection: .Bottom)
+      self.reverseAnimationType = .Turn(fromDirection: .Top)
       self.interactiveGestureType = .Pan(fromDirection: .Top)
       reverse = true
     default:
-      self.transitionAnimationType = .Turn(direction: .Left)
-      self.reverseAnimationType = .Turn(direction: .Right)
+      self.transitionAnimationType = .Turn(fromDirection: .Left)
+      self.reverseAnimationType = .Turn(fromDirection: .Right)
       self.interactiveGestureType = .Pan(fromDirection: .Right)
       reverse = false      
     }

--- a/IBAnimatable/TurnAnimator.swift
+++ b/IBAnimatable/TurnAnimator.swift
@@ -13,14 +13,14 @@ public class TurnAnimator: NSObject, AnimatedTransitioning {
   public var interactiveGestureType: InteractiveGestureType? = .Pan(fromDirection: .Horizontal)
   
   // MARK: - Private params
-  private var fromDirection: TransitionFromDirection
+  private var fromDirection: TransitionDirection
   
   // MARK: - Private fold transition
   private var transform: CATransform3D = CATransform3DIdentity
   private var reverse: Bool = false
   
   // MARK: - Life cycle
-  public init(fromDirection: TransitionFromDirection, transitionDuration: Duration) {
+  public init(fromDirection: TransitionDirection, transitionDuration: Duration) {
     self.fromDirection = fromDirection
     self.transitionDuration = transitionDuration
     

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -71,7 +71,7 @@ private extension TransitionTableViewController {
     transitionAnimationsHeaders.append("Turn")
     transitionAnimations.append(transitionTypeWithDirections(forName: "Turn"))
     transitionAnimationsHeaders.append("Cards")
-    transitionAnimations.append(transitionTypeWithDirections(forName: "Cards"))
+    transitionAnimations.append(["Cards(Forward)", "Cards(Backward)"])
     transitionAnimationsHeaders.append("Flip")
     transitionAnimations.append(transitionTypeWithDirections(forName: "Flip"))
     transitionAnimationsHeaders.append("Slide")


### PR DESCRIPTION
- Refactor `direction` to `fromDirection` for system transition animators because all system built-in transitions use `from` direction.
- Refactor `direction` to `formDirection` for `TransitionAnimationType.Fold`. (New animator for 2.3, no breaking changes)
- Refactor `direction` to `toDirection` for `TransitionAnimationType.NatGeo`. (New animator for 2.3, no breaking changes)
- Refactor `direction` to `fromDirection` for `TransitionAnimationType.Turn`. (New animator for 2.3, no breaking changes)
- Fix the direction for `CardAnimator`.
- Refactor `direction` to `fromDirection` for `TransitionAnimationType.Flip`. (New animator for 2.3, no breaking changes)
- Refactor `direction` to `toDirection` for `TransitionAnimationType.Slide`. (New animator for 2.3, no breaking changes)

@tbaranes please have a look when you have time, thanks.
