### PR TITLE
Remove `top` and `bottom` directions for `Flip` transition animator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Refactor `direction` to `fromDirection` for system transition animators.  Refactor `TransitionFromDirection` to `TransitionDirection`. [#206](https://github.com/JakeLin/IBAnimatable/pull/206)
 - Refactor `Fade`, `FadeIn` and `FadeOut` to `Fade(direction: TransitionDirection)` in `TransitionAnimationType`. Use `Fade(In)` to replace `FadeIn` and use `Fade(Out) to replace `FadeOut`.[#209](https://github.com/JakeLin/IBAnimatable/pull/209)
 - Remove `PresentFadeInSegue`, `PresentFadeInWithDismissInteractionSegue`, `PresentFadeOutSegue` and `PresentFadeOutWithDismissInteractionSegue`, use  `PresentFadeSegue` and `PresentFadeWithDismissInteractionSegue` instead. [#209](https://github.com/JakeLin/IBAnimatable/pull/209)
+- Remove `degree` for `SystemRotate` since it only supports 90 degrees. 
 
 #### Enhancements
 
@@ -22,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - Add `NatGeoAnimator` to support NatGeo transition animation. It supports only a direction `NatGeo(direction)`, if no specified, the default values are `NatGeo(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add `Turn` to support Turn transition animation. It supports only a direction `Turn(direction)`, if no specified, the default values are `Turn(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add `CardsAnimator` to support Cards transition animation. It supports parameters `Cards(direction)`, if no specified, the default values are `Cards(Forward)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
-- Add `FlipAnimator` to support Flip transition animation. It supports parameters `Flip(direction)`, if no specified, the default values are `Flip(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
+- Add `FlipAnimator` to support Flip transition animation. It supports parameters `Flip(direction)`, if no specified, the default values are `Flip(Left)`. Currently only support `Flip(Left)` and `Flip(Right)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add `ContainerTransition` to manage transition animations between two UIViewController in a container
 - Add `AnimatableCollectionViewCell` [#167](https://github.com/JakeLin/IBAnimatable/pull/167)
 - Add `PinchInteractiveAnimator` to support `Pinch(Close)`, `Pinch(Open)` for `Pinch` gesture transition controller. [#125](https://github.com/JakeLin/IBAnimatable/issues/125)

--- a/IBAnimatable/FlipAnimator.swift
+++ b/IBAnimatable/FlipAnimator.swift
@@ -32,16 +32,6 @@ public class FlipAnimator: NSObject, AnimatedTransitioning {
       self.reverseAnimationType = .Flip(fromDirection: .Left)
       self.interactiveGestureType = .Pan(fromDirection: .Left)
       reverse = true
-    case .Top:
-      self.transitionAnimationType = .Flip(fromDirection: .Top)
-      self.reverseAnimationType = .Flip(fromDirection: .Bottom)
-      self.interactiveGestureType = .Pan(fromDirection: .Bottom)
-      reverse = false
-    case .Bottom:
-      self.transitionAnimationType = .Flip(fromDirection: .Bottom)
-      self.reverseAnimationType = .Flip(fromDirection: .Top)
-      self.interactiveGestureType = .Pan(fromDirection: .Top)
-      reverse = true
     default:
       self.transitionAnimationType = .Flip(fromDirection: .Left)
       self.reverseAnimationType = .Flip(fromDirection: .Right)

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -71,7 +71,7 @@ private extension TransitionTableViewController {
     transitionAnimationsHeaders.append("Cards")
     transitionAnimations.append(["Cards(Forward)", "Cards(Backward)"])
     transitionAnimationsHeaders.append("Flip")
-    transitionAnimations.append(transitionTypeWithDirections(forName: "Flip"))
+    transitionAnimations.append(["Flip(Left)", "Flip(Right)"])
     transitionAnimationsHeaders.append("Slide")
     transitionAnimations.append(["Slide(Left, fade)", "Slide(Right)", "Slide(Top, fade)", "Slide(Bottom)"])
     transitionAnimationsHeaders.append("Others")


### PR DESCRIPTION
Since there is a bug for `Flip(Top)` and `Flip(Bottom)`, remove those directions now. But `Flip(Left)` and `Flip(Right)` works fine.
