### PR TITLE
Add an example in demo app how to configure transition animation in storyboard only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Refactor `direction` to `fromDirection` for system transition animators.  Refactor `TransitionFromDirection` to `TransitionDirection`. [#206](https://github.com/JakeLin/IBAnimatable/pull/206)
 - Refactor `Fade`, `FadeIn` and `FadeOut` to `Fade(direction: TransitionDirection)` in `TransitionAnimationType`. Use `Fade(In)` to replace `FadeIn` and use `Fade(Out) to replace `FadeOut`.[#209](https://github.com/JakeLin/IBAnimatable/pull/209)
 - Remove `PresentFadeInSegue`, `PresentFadeInWithDismissInteractionSegue`, `PresentFadeOutSegue` and `PresentFadeOutWithDismissInteractionSegue`, use  `PresentFadeSegue` and `PresentFadeWithDismissInteractionSegue` instead. [#209](https://github.com/JakeLin/IBAnimatable/pull/209)
-- Remove `degree` for `SystemRotate` since it only supports 90 degrees. 
+- Remove `degree` for `SystemRotate` since it only supports 90 degrees. [#210](https://github.com/JakeLin/IBAnimatable/pull/210)
 
 #### Enhancements
 
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Add `SlideAnimator` to support Slide transition animation. It supports parameters `Slide(direction, fade)`, if no specified, the default values are `Flip(Left)`. [#155](https://github.com/JakeLin/IBAnimatable/issues/155)
 - Add IBAnimatable Playground to demonstrate transitions and interactions. [#204](https://github.com/JakeLin/IBAnimatable/pull/204)
 - Add `Parallelogram` mask. [#207 - Parallelogram Mask support in Maskdesignable](https://github.com/JakeLin/IBAnimatable/pull/207)
+- Add `popToRootViewController` segue for poping to root ViewController of the NavigationController. [#211](https://github.com/JakeLin/IBAnimatable/pull/211)
 
 #### Bugfixes
 

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -52,6 +52,10 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
     let snapshots = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     containerView.sendSubviewToBack(fromView)
     animateSnapshotsExplode(snapshots) {
+      if transitionContext.transitionWasCancelled() {
+        containerView.bringSubviewToFront(fromView)
+      }
+      
       transitionContext.completeTransition(!transitionContext.transitionWasCancelled())
     }
   }

--- a/IBAnimatable/UIViewControllerExtension.swift
+++ b/IBAnimatable/UIViewControllerExtension.swift
@@ -13,4 +13,9 @@ public extension UIViewController {
   @IBAction public func dismissCurrentViewController(sender: UIStoryboardSegue) {
     sender.sourceViewController.dismissViewControllerAnimated(true, completion: nil)
   }
+  
+  @IBAction public func popToRootViewController(sender: UIStoryboardSegue) {
+    sender.sourceViewController.navigationController?.popToRootViewControllerAnimated(true)
+  }
+  
 }

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		AE94078A1CAE87860084BCB8 /* SystemPageAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D08B71CA9336500440E7C /* SystemPageAnimator.swift */; };
 		AEC23FC01CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */; };
 		AEC23FC21CB3DE0900E42D99 /* InteractiveAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC23FC11CB3DE0900E42D99 /* InteractiveAnimator.swift */; };
+		AEC5F9CE1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEC5F9CD1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard */; };
 		AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */; };
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
@@ -200,6 +201,7 @@
 		AE9407881CAE871C0084BCB8 /* TransitionPageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionPageType.swift; sourceTree = "<group>"; };
 		AEC23FBF1CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenEdgePanInteractiveAnimator.swift; sourceTree = "<group>"; };
 		AEC23FC11CB3DE0900E42D99 /* InteractiveAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractiveAnimator.swift; sourceTree = "<group>"; };
+		AEC5F9CD1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TransitionsInInterfaceBuilder.storyboard; sourceTree = "<group>"; };
 		AEC9F60D1CB31DCB00C82D16 /* GestureDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureDirection.swift; sourceTree = "<group>"; };
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -433,6 +435,7 @@
 				AE0D30991CE149150093B578 /* UserInterface.storyboard */,
 				AE0D309B1CE14A170093B578 /* Animations.storyboard */,
 				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
+				AEC5F9CD1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard */,
 				AE1B9A631CE3EA590098D962 /* Interactions.storyboard */,
 			);
 			name = storyboards;
@@ -698,6 +701,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AEC5F9CE1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard in Resources */,
 				AED1A1061BFE9820001346FA /* Main.storyboard in Resources */,
 				AE1B9A641CE3EA590098D962 /* Interactions.storyboard in Resources */,
 				AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */,

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="oAB-Bz-TaE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="oAB-Bz-TaE">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -615,7 +615,7 @@
         <image name="back" width="21" height="21"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="DNB-vZ-0SS"/>
+        <segue reference="HbQ-Kq-gSf"/>
         <segue reference="DUR-wR-gOd"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -175,7 +175,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="FgP-UH-Os8">
-                                <rect key="frame" x="28" y="264" width="319" height="140"/>
+                                <rect key="frame" x="28" y="229" width="319" height="210"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nmd-hI-p2R" userLabel="Push button" customClass="AnimatableButton" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="0.0" width="319" height="60"/>
@@ -194,8 +194,22 @@
                                             <segue destination="Jr9-M0-K6n" kind="show" id="f4g-PY-43d"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgi-jr-aua" userLabel="Pop button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="70" width="319" height="60"/>
+                                        <state key="normal" title="Pop to root ViewController">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Eer-hg-kVs" kind="unwind" unwindAction="popToRootViewController:" id="fUh-p9-Gm0"/>
+                                        </connections>
+                                    </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap &quot;Back&quot; button on Navigation bar" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MOa-4w-tZy">
-                                        <rect key="frame" x="0.0" y="70" width="319" height="30"/>
+                                        <rect key="frame" x="0.0" y="140" width="319" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="PAh-aU-Ots"/>
                                         </constraints>
@@ -204,7 +218,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or use gesture to pop" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G4y-eg-gD1">
-                                        <rect key="frame" x="0.0" y="110" width="319" height="30"/>
+                                        <rect key="frame" x="0.0" y="180" width="319" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -213,7 +227,9 @@
                                 <constraints>
                                     <constraint firstItem="MOa-4w-tZy" firstAttribute="centerX" secondItem="FgP-UH-Os8" secondAttribute="centerX" id="KPV-8M-Cvb"/>
                                     <constraint firstItem="G4y-eg-gD1" firstAttribute="height" secondItem="MOa-4w-tZy" secondAttribute="height" id="pC6-TP-z6N"/>
+                                    <constraint firstItem="Sgi-jr-aua" firstAttribute="width" secondItem="FgP-UH-Os8" secondAttribute="width" id="x3P-7c-YQG"/>
                                     <constraint firstItem="G4y-eg-gD1" firstAttribute="centerX" secondItem="FgP-UH-Os8" secondAttribute="centerX" id="x5w-79-xX0"/>
+                                    <constraint firstItem="Sgi-jr-aua" firstAttribute="height" secondItem="Nmd-hI-p2R" secondAttribute="height" id="yDP-bi-Ey0"/>
                                     <constraint firstItem="Nmd-hI-p2R" firstAttribute="width" secondItem="FgP-UH-Os8" secondAttribute="width" id="zhD-z5-xNp"/>
                                 </constraints>
                             </stackView>
@@ -234,6 +250,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MwU-bg-SAk" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="Eer-hg-kVs" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="5379.5" y="-667.5"/>
         </scene>
@@ -284,7 +301,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="63B-zV-SiK">
-                                <rect key="frame" x="28" y="264" width="319" height="140"/>
+                                <rect key="frame" x="28" y="228.5" width="319" height="210"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DIT-M5-Efk" userLabel="Push button" customClass="AnimatableButton" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="0.0" width="319" height="60"/>
@@ -303,8 +320,22 @@
                                             <segue destination="jDB-Ur-y9F" kind="show" id="DUR-wR-gOd"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="anp-zN-poS" userLabel="Pop button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="70" width="319" height="60"/>
+                                        <state key="normal" title="Pop to root ViewController">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="WRQ-WI-sbz" kind="unwind" unwindAction="popToRootViewController:" id="vSV-Hj-dIJ"/>
+                                        </connections>
+                                    </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap &quot;Back&quot; button on Navigation bar" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1fn-Db-caB">
-                                        <rect key="frame" x="0.0" y="70" width="319" height="30"/>
+                                        <rect key="frame" x="0.0" y="140" width="319" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="8Ts-z6-31z"/>
                                         </constraints>
@@ -313,7 +344,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or use gesture to pop" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cmp-P2-WvF">
-                                        <rect key="frame" x="0.0" y="110" width="319" height="30"/>
+                                        <rect key="frame" x="0.0" y="180" width="319" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -322,6 +353,8 @@
                                 <constraints>
                                     <constraint firstItem="DIT-M5-Efk" firstAttribute="width" secondItem="63B-zV-SiK" secondAttribute="width" id="6qd-oU-ze6"/>
                                     <constraint firstItem="1fn-Db-caB" firstAttribute="centerX" secondItem="63B-zV-SiK" secondAttribute="centerX" id="McH-I6-Pii"/>
+                                    <constraint firstItem="anp-zN-poS" firstAttribute="width" secondItem="63B-zV-SiK" secondAttribute="width" id="TSt-c4-RvZ"/>
+                                    <constraint firstItem="anp-zN-poS" firstAttribute="height" secondItem="DIT-M5-Efk" secondAttribute="height" id="gkY-9D-mhy"/>
                                     <constraint firstItem="cmp-P2-WvF" firstAttribute="height" secondItem="1fn-Db-caB" secondAttribute="height" id="jdk-AW-Ytd"/>
                                     <constraint firstItem="cmp-P2-WvF" firstAttribute="centerX" secondItem="63B-zV-SiK" secondAttribute="centerX" id="oGH-0l-fqG"/>
                                 </constraints>
@@ -343,6 +376,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5Td-V3-Teq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="WRQ-WI-sbz" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="5846.5" y="-667.5"/>
         </scene>
@@ -582,6 +616,6 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="DNB-vZ-0SS"/>
-        <segue reference="ftd-QI-Jx6"/>
+        <segue reference="DUR-wR-gOd"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/Base.lproj/Transitions.storyboard
+++ b/IBAnimatableApp/Base.lproj/Transitions.storyboard
@@ -16,7 +16,7 @@
                         <color key="separatorColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mDV-Ii-W8m" style="IBUITableViewCellStyleDefault" id="gTl-GY-SNY" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                <rect key="frame" x="0.0" y="114" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="113.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gTl-GY-SNY" id="qhN-8T-xDf">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -59,6 +59,11 @@
                             <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <connections>
                                 <segue destination="MCs-iu-UVL" kind="unwind" unwindAction="unwindToViewController:" id="j1e-QU-kec"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="IB" id="2K1-iW-B9P">
+                            <connections>
+                                <segue destination="6pB-Ve-5ey" kind="show" id="NTk-JN-vNJ"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -231,6 +236,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MwU-bg-SAk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="5379.5" y="-667.5"/>
+        </scene>
+        <!--TransitionsInInterfaceBuilder-->
+        <scene sceneID="CHb-Zv-Krd">
+            <objects>
+                <viewControllerPlaceholder storyboardName="TransitionsInInterfaceBuilder" id="6pB-Ve-5ey" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pkR-2n-XUY" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4017.5" y="151"/>
         </scene>
         <!--Animatable Navigation Controller-->
         <scene sceneID="Ryf-4p-TtM">
@@ -568,7 +581,7 @@
         <image name="back" width="21" height="21"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="DNB-vZ-0SS"/>
         <segue reference="ftd-QI-Jx6"/>
-        <segue reference="HbQ-Kq-gSf"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
+++ b/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5ps-L0-bib">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--Animatable View Controller-->
+        <scene sceneID="BJX-DM-cf8">
+            <objects>
+                <viewController id="5ps-L0-bib" customClass="AnimatableViewController" customModule="IBAnimatable" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="FUu-LY-EvW"/>
+                        <viewControllerLayoutGuide type="bottom" id="fqI-NU-VqO"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="2oI-EM-VaK" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-Bg-cTz" userLabel="Present button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                <rect key="frame" x="28" y="304" width="319" height="60"/>
+                                <state key="normal" title="Tap to present">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="V73-ac-tTf" kind="presentation" id="VLZ-o2-Lwb"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Pan(Left)"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OYQ-Df-93j" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="56.5" y="360.5"/>
+        </scene>
+        <!--Animatable View Controller-->
+        <scene sceneID="fHv-DU-F1a">
+            <objects>
+                <viewController id="V73-ac-tTf" customClass="AnimatableViewController" customModule="IBAnimatable" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="FjE-Ul-6yx"/>
+                        <viewControllerLayoutGuide type="bottom" id="j8E-pz-cFy"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Goa-e7-hdb" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatAlizarin"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Pan(Left)"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7mP-MC-00R" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="866.5" y="360.5"/>
+        </scene>
+    </scenes>
+</document>

--- a/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
+++ b/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5ps-L0-bib">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="EUy-AH-IJE">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -14,11 +14,11 @@
                         <viewControllerLayoutGuide type="bottom" id="fqI-NU-VqO"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="2oI-EM-VaK" customClass="AnimatableView" customModule="IBAnimatable">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="EY3-a7-f4G">
-                                <rect key="frame" x="36" y="263.5" width="303" height="140"/>
+                                <rect key="frame" x="36" y="191" width="303" height="220"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-Bg-cTz" userLabel="Present button" customClass="AnimatableButton" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="0.0" width="303" height="60"/>
@@ -51,8 +51,23 @@
                                             <segue destination="QTk-dN-RSb" kind="custom" customClass="PresentPortalWithDismissInteractionSegue" customModule="IBAnimatable" id="ZP9-5j-fle"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z86-aB-NQh" userLabel="Push button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="160" width="303" height="60"/>
+                                        <state key="normal" title="Tap to push">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="9UN-aX-czY" kind="show" id="tjl-SI-JM7"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstItem="Z86-aB-NQh" firstAttribute="height" secondItem="IHf-qd-c7a" secondAttribute="height" id="8r5-z5-5hJ"/>
                                     <constraint firstItem="IHf-qd-c7a" firstAttribute="height" secondItem="dz1-Bg-cTz" secondAttribute="height" id="lvF-Kr-Zs7"/>
                                 </constraints>
                             </stackView>
@@ -67,6 +82,16 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
                         </userDefinedRuntimeAttributes>
                     </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" id="v0Z-TM-7Am">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="7St-dx-aSb">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="jsv-bL-ifc" kind="unwind" unwindAction="dismissCurrentViewController:" id="X88-Vw-df8"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
@@ -77,8 +102,9 @@
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OYQ-Df-93j" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="jsv-bL-ifc" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="56.5" y="360.5"/>
+            <point key="canvasLocation" x="868.5" y="360.5"/>
         </scene>
         <!--Animatable View Controller-->
         <scene sceneID="fHv-DU-F1a">
@@ -107,7 +133,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7mP-MC-00R" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="548.5" y="-111.5"/>
+            <point key="canvasLocation" x="1360.5" y="-111.5"/>
         </scene>
         <!--Animatable View Controller-->
         <scene sceneID="75E-Ho-Bzj">
@@ -136,7 +162,60 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="AVJ-39-VNw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="548.5" y="658.5"/>
+            <point key="canvasLocation" x="1360.5" y="658.5"/>
+        </scene>
+        <!--Animatable View Controller-->
+        <scene sceneID="b7J-wZ-jdv">
+            <objects>
+                <viewController id="9UN-aX-czY" customClass="AnimatableViewController" customModule="IBAnimatable" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="FIQ-hE-LUD"/>
+                        <viewControllerLayoutGuide type="bottom" id="R36-fO-rbG"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Eye-3m-W9E" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatOrange"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Pan(Left)"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0Uy-GK-TiJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="868.5" y="1128.5"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="WCI-9v-Ho1">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="EUy-AH-IJE" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="pzy-Op-s2k" customClass="DesignableNavigationBar" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="barTintColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="solidColor" value="YES"/>
+                        </userDefinedRuntimeAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="5ps-L0-bib" kind="relationship" relationship="rootViewController" id="k1Y-a3-5dC"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="c4r-AY-Keq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="400.5" y="360.5"/>
         </scene>
     </scenes>
 </document>

--- a/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
+++ b/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
@@ -91,7 +91,7 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
@@ -193,10 +193,10 @@
             </objects>
             <point key="canvasLocation" x="868.5" y="1128.5"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Animatable Navigation Controller-->
         <scene sceneID="WCI-9v-Ho1">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="EUy-AH-IJE" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="EUy-AH-IJE" customClass="AnimatableNavigationController" customModule="IBAnimatable" sceneMemberID="viewController">
                     <toolbarItems/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="pzy-Op-s2k" customClass="DesignableNavigationBar" customModule="IBAnimatable">
@@ -209,6 +209,13 @@
                         </userDefinedRuntimeAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="SystemCube(Right)"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Default"/>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="5ps-L0-bib" kind="relationship" relationship="rootViewController" id="k1Y-a3-5dC"/>
                     </connections>

--- a/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
+++ b/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
@@ -76,7 +76,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7mP-MC-00R" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="866.5" y="360.5"/>
+            <point key="canvasLocation" x="560.5" y="360.5"/>
         </scene>
     </scenes>
 </document>

--- a/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
+++ b/IBAnimatableApp/TransitionsInInterfaceBuilder.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5ps-L0-bib">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Animatable View Controller-->
@@ -16,22 +17,52 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-Bg-cTz" userLabel="Present button" customClass="AnimatableButton" customModule="IBAnimatable">
-                                <rect key="frame" x="28" y="304" width="319" height="60"/>
-                                <state key="normal" title="Tap to present">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <segue destination="V73-ac-tTf" kind="presentation" id="VLZ-o2-Lwb"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="EY3-a7-f4G">
+                                <rect key="frame" x="36" y="263.5" width="303" height="140"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-Bg-cTz" userLabel="Present button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="0.0" width="303" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="d2C-XQ-aOL"/>
+                                        </constraints>
+                                        <state key="normal" title="Tap to present">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="V73-ac-tTf" kind="presentation" id="VLZ-o2-Lwb"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IHf-qd-c7a" userLabel="Present button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="80" width="303" height="60"/>
+                                        <state key="normal" title="Tap to present via sugue">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="QTk-dN-RSb" kind="custom" customClass="PresentPortalWithDismissInteractionSegue" customModule="IBAnimatable" id="ZP9-5j-fle"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="IHf-qd-c7a" firstAttribute="height" secondItem="dz1-Bg-cTz" secondAttribute="height" id="lvF-Kr-Zs7"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="EY3-a7-f4G" firstAttribute="centerY" secondItem="2oI-EM-VaK" secondAttribute="centerY" id="3hG-H8-8du"/>
+                            <constraint firstItem="EY3-a7-f4G" firstAttribute="leading" secondItem="2oI-EM-VaK" secondAttribute="leadingMargin" constant="20" id="nUv-ay-xKb"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="EY3-a7-f4G" secondAttribute="trailing" constant="20" id="ukc-uX-oZy"/>
+                        </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatGreenSea"/>
                         </userDefinedRuntimeAttributes>
@@ -69,14 +100,43 @@
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
                         <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
-                            <real key="value" value="5"/>
+                            <real key="value" value="1"/>
                         </userDefinedRuntimeAttribute>
                         <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Pan(Left)"/>
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7mP-MC-00R" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="560.5" y="360.5"/>
+            <point key="canvasLocation" x="548.5" y="-111.5"/>
+        </scene>
+        <!--Animatable View Controller-->
+        <scene sceneID="75E-Ho-Bzj">
+            <objects>
+                <viewController id="QTk-dN-RSb" customClass="AnimatableViewController" customModule="IBAnimatable" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="qc2-eR-ZQn"/>
+                        <viewControllerLayoutGuide type="bottom" id="7ZZ-1f-rBM"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Tke-p6-rQ1" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedColor" value="FlatPeterRiver"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="transitionAnimationType" value="Explode"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="transitionDuration">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="string" keyPath="interactiveGestureType" value="Pan(Left)"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="AVJ-39-VNw" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="548.5" y="658.5"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
In this PR, we have made some following changes:
- Add an example in demo app: How to configure transition animation in storyboard only
- Add `popToRootViewController`segue to support pop to root ViewController via Exist Segue.
- Fix a bug: when uses gesture to dismiss with `ExplodeAnimator`, the view state is broken.

Now we have lots of demo for transition animations. Next one is documentation. 👻
