### PR TITLE
TextView placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 None
 
 #### Enhancements
-None
+- New designable properties for `UITextView`: placeholder text and color [#227](https://github.com/JakeLin/IBAnimatable/issues/227)
 
 #### Bugfixes
 None

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -102,7 +102,8 @@ It is used in `AnimatableTextField` to add padding on either or both sides.
 #### `PlaceholderDesignable`
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
-| placeholderColor | Optional&lt;UIColor> | placeholder text color in `AnimatableTextField`. |
+| placeholderColor | Optional&lt;UIColor> | placeholder text color in `AnimatableTextField` and `AnimatableTextView`. |
+| placeholderText | Optional&lt;String> | placeholder text in `AnimatableTextView`. |
 
 #### `RootWindowDesignable`
 | Property name | Data type | Description |

--- a/IBAnimatable/PlaceholderDesignable.swift
+++ b/IBAnimatable/PlaceholderDesignable.swift
@@ -10,12 +10,51 @@ public protocol PlaceholderDesignable {
    `color` within `::-webkit-input-placeholder`, `::-moz-placeholder` or `:-ms-input-placeholder`
    */
   var placeholderColor: UIColor? { get set }
+  var placeholderText: String? { get set }
 }
 
 public extension PlaceholderDesignable where Self: UITextField {
+
+  var placeholderText: String? { get { return "" } set {} }
+
   public func configPlaceholderColor() {
     if let unwrappedPlaceholderColor = placeholderColor {
       attributedPlaceholder = NSAttributedString(string: placeholder!, attributes: [NSForegroundColorAttributeName: unwrappedPlaceholderColor])
     }
   }
+}
+
+public extension PlaceholderDesignable where Self: UITextView {
+
+  public func configPlaceholderLabel(placeholderLabel: UILabel, inout placeholderLabelConstraints: [NSLayoutConstraint]) {
+    placeholderLabel.font = font
+    placeholderLabel.textColor = placeholderColor
+    placeholderLabel.textAlignment = textAlignment
+    placeholderLabel.text = placeholderText
+    placeholderLabel.numberOfLines = 0
+    placeholderLabel.backgroundColor = UIColor.clearColor()
+    placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(placeholderLabel)
+    updateConstraintsForPlaceholderLabel(placeholderLabel, placeholderLabelConstraints: &placeholderLabelConstraints)
+  }
+
+  public func updateConstraintsForPlaceholderLabel(placeholderLabel: UILabel, inout placeholderLabelConstraints: [NSLayoutConstraint]) {
+    var newConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-(\(textContainerInset.left + textContainer.lineFragmentPadding))-[placeholder]",
+                                                                        options: [], metrics: nil,
+                                                                        views: ["placeholder": placeholderLabel])
+    newConstraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-(\(textContainerInset.top))-[placeholder]",
+                                                                     options: [], metrics: nil,
+                                                                     views: ["placeholder": placeholderLabel])
+    newConstraints.append(NSLayoutConstraint(item: placeholderLabel,
+      attribute: .Width,
+      relatedBy: .Equal,
+      toItem: self,
+      attribute: .Width,
+      multiplier: 1.0,
+      constant: -(textContainerInset.left + textContainerInset.right + textContainer.lineFragmentPadding * 2.0)))
+    removeConstraints(placeholderLabelConstraints)
+    addConstraints(newConstraints)
+    placeholderLabelConstraints = newConstraints
+  }
+
 }

--- a/IBAnimatable/PlaceholderDesignable.swift
+++ b/IBAnimatable/PlaceholderDesignable.swift
@@ -32,7 +32,7 @@ public extension PlaceholderDesignable where Self: UITextView {
     placeholderLabel.textAlignment = textAlignment
     placeholderLabel.text = placeholderText
     placeholderLabel.numberOfLines = 0
-    placeholderLabel.backgroundColor = UIColor.clearColor()
+    placeholderLabel.backgroundColor = .clearColor()
     placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
     addSubview(placeholderLabel)
     updateConstraintsForPlaceholderLabel(placeholderLabel, placeholderLabelConstraints: &placeholderLabelConstraints)

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -1,49 +1,153 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="kOh-A6-3kw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="dM8-H6-op1">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="Stp-Ru-Xcf">
+        <!--User Interface-->
+        <scene sceneID="QNm-Wq-94X">
             <objects>
-                <viewController id="kOh-A6-3kw" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="716-Xg-LDL"/>
-                        <viewControllerLayoutGuide type="bottom" id="hF4-rn-CGW"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="cfl-WP-9DD" customClass="AnimatableView" customModule="IBAnimatable">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                <tableViewController clearsSelectionOnViewWillAppear="NO" id="dM8-H6-op1" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="O3U-8W-uIX" customClass="AnimatableTableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Coming soon..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PdI-Qv-jkF" customClass="AnimatableLabel" customModule="IBAnimatable">
-                                <rect key="frame" x="242.5" y="289" width="115" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="animationType" value="Pop"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="delay">
-                                        <real key="value" value="0.5"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="PdI-Qv-jkF" firstAttribute="centerY" secondItem="cfl-WP-9DD" secondAttribute="centerY" id="Ses-Lk-QbE"/>
-                            <constraint firstItem="PdI-Qv-jkF" firstAttribute="centerX" secondItem="cfl-WP-9DD" secondAttribute="centerX" id="uuh-cf-0vV"/>
-                        </constraints>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="separatorColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="pZQ-Pf-P1v">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="Rs1-3k-ac9" style="IBUITableViewCellStyleDefault" id="oZn-rq-6jb" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="99" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oZn-rq-6jb" id="MMG-gu-DNX">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Rs1-3k-ac9">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="EH2-oa-QGQ" kind="show" id="D7h-jh-hfX"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
                                 <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dpB-ha-2P7" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                        <connections>
+                            <outlet property="dataSource" destination="dM8-H6-op1" id="WFk-xW-xWs"/>
+                            <outlet property="delegate" destination="dM8-H6-op1" id="Cdg-F4-VlK"/>
+                        </connections>
+                    </tableView>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="User Interface" id="aVa-6A-0G1">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="NS3-dB-5Oz">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="ei2-cc-Rrn" kind="unwind" unwindAction="unwindToViewController:" id="QMb-6N-yEX"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MBb-g1-I5O" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="ei2-cc-Rrn" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="496" y="382"/>
+            <point key="canvasLocation" x="4017.5" y="-281.5"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="bM8-83-R8P">
+            <objects>
+                <viewController id="EH2-oa-QGQ" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="zEj-wi-wS3"/>
+                        <viewControllerLayoutGuide type="bottom" id="seB-Sk-UJs"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="C9g-v0-m2p">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="This is a placeholder message" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gdH-rU-9qJ" customClass="AnimatableTextField" customModule="IBAnimatable">
+                                <rect key="frame" x="16" y="124" width="343" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="uNF-ID-qmn"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderColor">
+                                        <color key="value" red="0.51372549020000002" green="0.58431372550000005" blue="0.58431372550000005" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingLeft">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textField>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="P8s-Eb-llW" customClass="AnimatableTextView" customModule="IBAnimatable">
+                                <rect key="frame" x="16" y="204" width="343" height="199"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="199" id="4Xk-j9-BCO"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholderText" value="This is a placeholder message for AnimatableTextView"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderColor">
+                                        <color key="value" red="0.51372549020000002" green="0.58431372550000005" blue="0.58431372550000005" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="P8s-Eb-llW" firstAttribute="width" secondItem="gdH-rU-9qJ" secondAttribute="width" id="G9F-Iw-FtK"/>
+                            <constraint firstItem="gdH-rU-9qJ" firstAttribute="leading" secondItem="C9g-v0-m2p" secondAttribute="leadingMargin" id="bRn-51-5Ls"/>
+                            <constraint firstItem="gdH-rU-9qJ" firstAttribute="trailing" secondItem="C9g-v0-m2p" secondAttribute="trailingMargin" id="iRJ-rd-Nae"/>
+                            <constraint firstItem="P8s-Eb-llW" firstAttribute="top" secondItem="gdH-rU-9qJ" secondAttribute="bottom" constant="40" id="lGN-QK-Mqk"/>
+                            <constraint firstItem="gdH-rU-9qJ" firstAttribute="top" secondItem="zEj-wi-wS3" secondAttribute="bottom" constant="60" id="n53-ek-nMc"/>
+                            <constraint firstItem="P8s-Eb-llW" firstAttribute="centerX" secondItem="gdH-rU-9qJ" secondAttribute="centerX" id="oUS-0g-2B5"/>
+                        </constraints>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JdN-Fw-n4f" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4469.5" y="-281.5"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="back" width="21" height="21"/>
+    </resources>
 </document>


### PR DESCRIPTION
Close #181 
This PR is a first try to make `AnimatableTextView` conforms to `PlaceholderDesignable`. Current result:
- Designable placeholder text and color 
- Supports multilines
- The placeholder uses all the properties set in the textview: textAlignment, font... any of them are currently customisable for the placeholder.

I think `AnimatableTextView` has too much knowledge about the placeholder, I'd like to abstract more in `PlaceholderDesignable` but since it's fully related to the instance itself (override properties, notification...) I didn't find a working output. The main issue about this implementation is that makes a lot of work to conform `PlaceholderDesignable` from an `UITextView`.  Any suggestions welcomed! 

Otherwise, it's ready to go 👍 
