### PR TITLE
Upgrade Swift playground for Swift 3 and Xcode 8 beta 2

### DIFF
--- a/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
@@ -3,7 +3,7 @@
 //: ## Animation Properties
 
 import UIKit
-import XCPlayground
+import PlaygroundSupport
 import IBAnimatable
 
 //: Constants

--- a/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
@@ -6,28 +6,16 @@ import UIKit
 import PlaygroundSupport
 import IBAnimatable
 
-//: Constants
-let iPhoneWidth = 375
-let iPhoneHeight = 667
-let animatableViewWidth = 100
-let animatableViewX = (iPhoneWidth - animatableViewWidth) / 2
-let animatableViewY = (iPhoneHeight - animatableViewWidth) / 2
-
 //: Set up the iPhone View
-let iPhoneView = UIView(frame: CGRect(x: 0, y: 0, width: iPhoneWidth, height: iPhoneHeight))
-iPhoneView.backgroundColor = .whiteColor()
-XCPlaygroundPage.currentPage.liveView = iPhoneView
+let iPhoneView = PhoneView()
+PlaygroundPage.current.liveView = iPhoneView
 
 //: Set up the animatable View
-let view = AnimatableView(frame: CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth))
-view.configAnimatableProperties()
+let view = CircleView()
 iPhoneView.addSubview(view)
 
-view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = String(MaskType.Circle)
-
 //: animationType: all supported predefined animations can be found in `enum AnimationType`
-view.animationType = String(AnimationType.SqueezeInLeft)
+view.animationType = String(AnimationType.squeezeInLeft)
 
 //: duration: used to specify the duration of animation. Default value is 0.7
 view.duration = 0.8

--- a/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Chaining Animations.xcplaygroundpage/Contents.swift
@@ -3,37 +3,25 @@
 //: ## Chaining Animations
 
 import UIKit
-import XCPlayground
+import PlaygroundSupport
 import IBAnimatable
 
-//: Constants
-let iPhoneWidth = 375
-let iPhoneHeight = 667
-let animatableViewWidth = 100
-let animatableViewX = (iPhoneWidth - animatableViewWidth) / 2
-let animatableViewY = (iPhoneHeight - animatableViewWidth) / 2
-
 //: Set up the iPhone View
-let iPhoneView = UIView(frame: CGRect(x: 0, y: 0, width: iPhoneWidth, height: iPhoneHeight))
-iPhoneView.backgroundColor = .whiteColor()
-XCPlaygroundPage.currentPage.liveView = iPhoneView
+let iPhoneView = PhoneView()
+PlaygroundPage.current.liveView = iPhoneView
 
 //: Set up the animatable View
-let view = AnimatableView(frame: CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth))
-view.configAnimatableProperties()
+let view = CircleView()
 iPhoneView.addSubview(view)
 
-view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
-view.maskType = String(MaskType.Circle)
-
-//: Start another animation in completion closure
+////: Start another animation in completion closure
 view.squeezeInDown { view.pop { view.shake { view.squeeze { view.wobble { view.flipX { view.flash { view.flipY { view.fadeOutDown() } } } } } } } }
 
 //: To apply delay, we can specify the animationType and delay
-//view.animationType = String(AnimationType.Pop)
+//view.animationType = String(AnimationType.pop)
 //view.animate{
 //  view.delay = 0.3
-//  view.animationType = String(AnimationType.Shake)
+//  view.animationType = String(AnimationType.shake)
 //  view.animate()
 //}
 

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
@@ -7,7 +7,7 @@ import IBAnimatable
 let iPhoneView = PhoneView()
 PlaygroundPage.current.liveView = iPhoneView
 
-//////: Set up the animatable View
+//: Set up the animatable View
 let view = CircleView()
 iPhoneView.addSubview(view)
 

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
@@ -1,7 +1,7 @@
 //: ## Predefined Animations
 
 import UIKit
-import XCPlayground
+import PlaygroundSupport
 import IBAnimatable
 
 //: Constants
@@ -13,20 +13,22 @@ let animatableViewY = (iPhoneHeight - animatableViewWidth) / 2
 
 //: Set up the iPhone View
 let iPhoneView = UIView(frame: CGRect(x: 0, y: 0, width: iPhoneWidth, height: iPhoneHeight))
-iPhoneView.backgroundColor = .whiteColor()
-XCPlaygroundPage.currentPage.liveView = iPhoneView
+iPhoneView.backgroundColor = .white()
+PlaygroundPage.current.liveView = iPhoneView
 
-//: Set up the animatable View
+
+////: Set up the animatable View
 let view = AnimatableView(frame: CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth))
 view.configAnimatableProperties()
 iPhoneView.addSubview(view)
 
-view.fillColor = UIColor(red: 0xba/0xff, green: 0x77/0xff, blue: 1, alpha: 1)
+view.fillColor = #colorLiteral(red: 0.7098039216, green: 0.4549019608, blue: 0.9607843137, alpha: 1)
 view.borderWidth = 2
-view.borderColor = .purpleColor()
-view.maskType = String(MaskType.Circle)
+view.borderColor = .purple()
+view.maskType = .circle
 
-// For moveTo or moveBy animation
+
+// For `moveTo` or `moveBy` animation
 view.x = -100
 view.y = 200
 
@@ -34,9 +36,6 @@ view.y = 200
 
 // Uncomment one line to play the animation
 
-//view.moveX()
-//view.moveY()
-//view.moveXY()
 //view.slideInLeft()
 //view.slideInRight()
 //view.slideInDown()
@@ -76,7 +75,7 @@ view.y = 200
 //view.zoomIn()
 //view.zoomOut()
 //view.shake()
-//view.pop()
+view.pop()
 //view.flipX()
 //view.flipY()
 //view.morph()
@@ -87,6 +86,6 @@ view.y = 200
 //view.rotate()
 //view.rotate(clockwise: false)
 //view.moveTo()
-view.moveBy()
+//view.moveBy()
 
 //: [Next](@next)

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/Contents.swift
@@ -4,29 +4,12 @@ import UIKit
 import PlaygroundSupport
 import IBAnimatable
 
-//: Constants
-let iPhoneWidth = 375
-let iPhoneHeight = 667
-let animatableViewWidth = 100
-let animatableViewX = (iPhoneWidth - animatableViewWidth) / 2
-let animatableViewY = (iPhoneHeight - animatableViewWidth) / 2
-
-//: Set up the iPhone View
-let iPhoneView = UIView(frame: CGRect(x: 0, y: 0, width: iPhoneWidth, height: iPhoneHeight))
-iPhoneView.backgroundColor = .white()
+let iPhoneView = PhoneView()
 PlaygroundPage.current.liveView = iPhoneView
 
-
-////: Set up the animatable View
-let view = AnimatableView(frame: CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth))
-view.configAnimatableProperties()
+//////: Set up the animatable View
+let view = CircleView()
 iPhoneView.addSubview(view)
-
-view.fillColor = #colorLiteral(red: 0.7098039216, green: 0.4549019608, blue: 0.9607843137, alpha: 1)
-view.borderWidth = 2
-view.borderColor = .purple()
-view.maskType = .circle
-
 
 // For `moveTo` or `moveBy` animation
 view.x = -100
@@ -74,8 +57,8 @@ view.y = 200
 //view.squeezeFadeOutUp()
 //view.zoomIn()
 //view.zoomOut()
-//view.shake()
-view.pop()
+view.shake()
+//view.pop()
 //view.flipX()
 //view.flipY()
 //view.morph()

--- a/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/timeline.xctimeline
+++ b/IBAnimatable.playground/Pages/Predefined Animations.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/IBAnimatable.playground/Sources/common.swift
+++ b/IBAnimatable.playground/Sources/common.swift
@@ -28,6 +28,7 @@ public class PhoneView: UIView {
   }
 }
 
+//: Circle View subclassed from `AnimatableView`
 public class CircleView: AnimatableView {
   public init() {
     let frame = CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth)

--- a/IBAnimatable.playground/Sources/common.swift
+++ b/IBAnimatable.playground/Sources/common.swift
@@ -1,0 +1,50 @@
+//: ## Common code
+
+import UIKit
+import IBAnimatable
+
+//: Constants
+public let iPhoneWidth = 375
+public let iPhoneHeight = 667
+public let animatableViewWidth = 100
+public let animatableViewX = (iPhoneWidth - animatableViewWidth) / 2
+public let animatableViewY = (iPhoneHeight - animatableViewWidth) / 2
+
+//: Phone View
+public class PhoneView: UIView {
+  public init() {
+    let frame = CGRect(x: 0, y: 0, width: iPhoneWidth, height: iPhoneHeight)
+    super.init(frame: frame)
+    backgroundColor = .white()
+    
+  }
+  
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+  }
+  
+  public required init(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+public class CircleView: AnimatableView {
+  public init() {
+    let frame = CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth)
+    super.init(frame: frame)
+    
+    configAnimatableProperties()
+    fillColor = #colorLiteral(red: 0.7098039216, green: 0.4549019608, blue: 0.9607843137, alpha: 1)
+    borderWidth = 2
+    borderColor = .purple()
+    maskType = .circle
+  }
+  
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+  }
+  
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}


### PR DESCRIPTION
In this PR, we upgrade Swift playground pages to support Swift 3 and Xcode 8. Also, use "common.swift" file to group some common logic.

Should close #240 

Related to #221 
