### PR TITLE
UIVibrancyEffect designable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 None
 
 #### Enhancements
-None
+
+- Add `vibrancyBlurEffect` to `BlurDesignable`. Once specify the Vibrancy effect style, all subviews will apply this vibrancy effect [#245](https://github.com/JakeLin/IBAnimatable/pull/245)
 
 #### Bugfixes
 None

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -33,6 +33,7 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
 | blurEffectStyle | Optional&lt;String> | Support three different blur effects: `ExtraLight`, `Light` and `Dark`, also can be found in emum [`BlurEffectStyle `](https://github.com/JakeLin/IBAnimatable/blob/master/IBAnimatable/BlurEffectStyle.swift). The look of blur effect in Interface Builder is different from Simulator or device. |
+| vibrancyEffectStyle | Optional&lt;String> | Support three different blur effects: `ExtraLight`, `Light` and `Dark`, also can be found in emum [`BlurEffectStyle `](https://github.com/JakeLin/IBAnimatable/blob/master/IBAnimatable/BlurEffectStyle.swift). Once specify the Vibrancy effect style, all subviews will apply this vibrancy effect. |
 | blurOpacity | CGFloat | Opacity of the blur effect specified above. the default value is `CGFloat.NaN`, the value range is from 0.0 to 1.0. |
 
 

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -85,8 +85,17 @@ import UIKit
   }
   
   // MARK: - BlurDesignable
-  @IBInspectable public var blurEffectStyle: String?
-  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN
+  @IBInspectable public var blurEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
+  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
   
   // MARK: - TintDesignable
   @IBInspectable public var tintOpacity: CGFloat = CGFloat.NaN

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -91,6 +91,12 @@ import UIKit
     }
   }
 
+  @IBInspectable public var vibrancyEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
   @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
     didSet {
       configBlurEffectStyle()

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -155,8 +155,7 @@ import UIKit
   // MARK: - Private
   private func configInspectableProperties() {
     configAnimatableProperties()
-    configTintedColor()
-    configBlurEffectStyle()
+    configTintedColor()    
   }
   
   private func configAfterLayoutSubviews() {

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -156,8 +156,7 @@ import UIKit
   // MARK: - Private
   private func configInspectableProperties() {
     configAnimatableProperties()
-    configTintedColor()
-    configBlurEffectStyle()
+    configTintedColor()  
   }
 
   private func configAfterLayoutSubviews() {

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -8,146 +8,154 @@ import UIKit
 
 @IBDesignable public class AnimatableScrollView: UIScrollView, CornerDesignable, FillDesignable, BorderDesignable, RotationDesignable, ShadowDesignable, BlurDesignable, TintDesignable, GradientDesignable, MaskDesignable, Animatable {
 
-    // MARK: - CornerDesignable
-    @IBInspectable public var cornerRadius: CGFloat = CGFloat.NaN {
-        didSet {
-            configCornerRadius()
-        }
+  // MARK: - CornerDesignable
+  @IBInspectable public var cornerRadius: CGFloat = CGFloat.NaN {
+    didSet {
+      configCornerRadius()
     }
+  }
 
-    // MARK: - FillDesignable
-    @IBInspectable public var fillColor: UIColor? {
-        didSet {
-            configFillColor()
-        }
+  // MARK: - FillDesignable
+  @IBInspectable public var fillColor: UIColor? {
+    didSet {
+      configFillColor()
     }
+  }
 
-    @IBInspectable public var predefinedColor: String? {
-        didSet {
-            configFillColor()
-        }
+  @IBInspectable public var predefinedColor: String? {
+    didSet {
+      configFillColor()
     }
+  }
 
-    @IBInspectable public var opacity: CGFloat = CGFloat.NaN {
-        didSet {
-            configOpacity()
-        }
+  @IBInspectable public var opacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configOpacity()
     }
+  }
 
-    // MARK: - BorderDesignable
-    @IBInspectable public var borderColor: UIColor? {
-        didSet {
-            configBorder()
-        }
+  // MARK: - BorderDesignable
+  @IBInspectable public var borderColor: UIColor? {
+    didSet {
+      configBorder()
     }
+  }
 
-    @IBInspectable public var borderWidth: CGFloat = CGFloat.NaN {
-        didSet {
-            configBorder()
-        }
+  @IBInspectable public var borderWidth: CGFloat = CGFloat.NaN {
+    didSet {
+      configBorder()
     }
+  }
 
-    @IBInspectable public var borderSide: String? {
-        didSet {
-            configBorder()
-        }
+  @IBInspectable public var borderSide: String? {
+    didSet {
+      configBorder()
     }
+  }
 
-    // MARK: - RotationDesignable
-    @IBInspectable public var rotate: CGFloat = CGFloat.NaN {
-        didSet {
-            configRotate()
-        }
+  // MARK: - RotationDesignable
+  @IBInspectable public var rotate: CGFloat = CGFloat.NaN {
+    didSet {
+      configRotate()
     }
+  }
 
-    // MARK: - ShadowDesignable
-    @IBInspectable public var shadowColor: UIColor? {
-        didSet {
-            configShadowColor()
-        }
+  // MARK: - ShadowDesignable
+  @IBInspectable public var shadowColor: UIColor? {
+    didSet {
+      configShadowColor()
     }
+  }
 
-    @IBInspectable public var shadowRadius: CGFloat = CGFloat.NaN {
-        didSet {
-            configShadowRadius()
-        }
+  @IBInspectable public var shadowRadius: CGFloat = CGFloat.NaN {
+    didSet {
+      configShadowRadius()
     }
+  }
 
-    @IBInspectable public var shadowOpacity: CGFloat = CGFloat.NaN {
-        didSet {
-            configShadowOpacity()
-        }
+  @IBInspectable public var shadowOpacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configShadowOpacity()
     }
+  }
 
-    @IBInspectable public var shadowOffset: CGPoint = CGPoint(x: CGFloat.NaN, y: CGFloat.NaN) {
-        didSet {
-            configShadowOffset()
-        }
+  @IBInspectable public var shadowOffset: CGPoint = CGPoint(x: CGFloat.NaN, y: CGFloat.NaN) {
+    didSet {
+      configShadowOffset()
     }
+  }
 
-    // MARK: - BlurDesignable
-    @IBInspectable public var blurEffectStyle: String?
-    @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN
-
-    // MARK: - TintDesignable
-    @IBInspectable public var tintOpacity: CGFloat = CGFloat.NaN
-    @IBInspectable public var shadeOpacity: CGFloat = CGFloat.NaN
-    @IBInspectable public var toneColor: UIColor?
-    @IBInspectable public var toneOpacity: CGFloat = CGFloat.NaN
-
-    // MARK: - GradientDesignable
-    @IBInspectable public var startColor: UIColor?
-    @IBInspectable public var endColor: UIColor?
-    @IBInspectable public var predefinedGradient: String?
-    @IBInspectable public var startPoint: String?
-
-    // MARK: - MaskDesignable
-    @IBInspectable public var maskType: String? {
-        didSet {
-            configMask()
-            configBorder()
-        }
+  // MARK: - BlurDesignable
+  @IBInspectable public var blurEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
     }
+  }
+  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
 
-    // MARK: - Animatable
-    @IBInspectable public var animationType: String?
-    @IBInspectable public var autoRun: Bool = true
-    @IBInspectable public var duration: Double = Double.NaN
-    @IBInspectable public var delay: Double = Double.NaN
-    @IBInspectable public var damping: CGFloat = CGFloat.NaN
-    @IBInspectable public var velocity: CGFloat = CGFloat.NaN
-    @IBInspectable public var force: CGFloat = CGFloat.NaN
-    @IBInspectable public var repeatCount: Float = Float.NaN
-    @IBInspectable public var x: CGFloat = CGFloat.NaN
-    @IBInspectable public var y: CGFloat = CGFloat.NaN
+  // MARK: - TintDesignable
+  @IBInspectable public var tintOpacity: CGFloat = CGFloat.NaN
+  @IBInspectable public var shadeOpacity: CGFloat = CGFloat.NaN
+  @IBInspectable public var toneColor: UIColor?
+  @IBInspectable public var toneOpacity: CGFloat = CGFloat.NaN
 
-    // MARK: - Lifecycle
-    public override func prepareForInterfaceBuilder() {
-        super.prepareForInterfaceBuilder()
-        configInspectableProperties()
-    }
+  // MARK: - GradientDesignable
+  @IBInspectable public var startColor: UIColor?
+  @IBInspectable public var endColor: UIColor?
+  @IBInspectable public var predefinedGradient: String?
+  @IBInspectable public var startPoint: String?
 
-    public override func awakeFromNib() {
-        super.awakeFromNib()
-        configInspectableProperties()
+  // MARK: - MaskDesignable
+  @IBInspectable public var maskType: String? {
+    didSet {
+      configMask()
+      configBorder()
     }
+  }
 
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        configAfterLayoutSubviews()
-        autoRunAnimation()
-    }
-    
-    // MARK: - Private
-    private func configInspectableProperties() {
-        configAnimatableProperties()
-        configTintedColor()
-        configBlurEffectStyle()
-    }
-    
-    private func configAfterLayoutSubviews() {
-        configMask()
-        configBorder()
-        configGradient()
-    }
+  // MARK: - Animatable
+  @IBInspectable public var animationType: String?
+  @IBInspectable public var autoRun: Bool = true
+  @IBInspectable public var duration: Double = Double.NaN
+  @IBInspectable public var delay: Double = Double.NaN
+  @IBInspectable public var damping: CGFloat = CGFloat.NaN
+  @IBInspectable public var velocity: CGFloat = CGFloat.NaN
+  @IBInspectable public var force: CGFloat = CGFloat.NaN
+  @IBInspectable public var repeatCount: Float = Float.NaN
+  @IBInspectable public var x: CGFloat = CGFloat.NaN
+  @IBInspectable public var y: CGFloat = CGFloat.NaN
+
+  // MARK: - Lifecycle
+  public override func prepareForInterfaceBuilder() {
+    super.prepareForInterfaceBuilder()
+    configInspectableProperties()
+  }
+
+  public override func awakeFromNib() {
+    super.awakeFromNib()
+    configInspectableProperties()
+  }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    configAfterLayoutSubviews()
+    autoRunAnimation()
+  }
+
+  // MARK: - Private
+  private func configInspectableProperties() {
+    configAnimatableProperties()
+    configTintedColor()
+    configBlurEffectStyle()
+  }
+
+  private func configAfterLayoutSubviews() {
+    configMask()
+    configBorder()
+    configGradient()
+  }
 }

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -91,6 +91,13 @@ import UIKit
       configBlurEffectStyle()
     }
   }
+
+  @IBInspectable public var vibrancyEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
   @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
     didSet {
       configBlurEffectStyle()

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -87,8 +87,17 @@ import UIKit
   }
   
   // MARK: - BlurDesignable
-  @IBInspectable public var blurEffectStyle: String?
-  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN
+  @IBInspectable public var blurEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
+  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
   
   // MARK: - TintDesignable
   @IBInspectable public var tintOpacity: CGFloat = CGFloat.NaN

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -93,6 +93,12 @@ import UIKit
     }
   }
 
+  @IBInspectable public var vibrancyEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
   @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
     didSet {
       configBlurEffectStyle()

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -157,8 +157,7 @@ import UIKit
   // MARK: - Private
   private func configInspectableProperties() {
     configAnimatableProperties()
-    configTintedColor()
-    configBlurEffectStyle()
+    configTintedColor()    
   }
   
   private func configAfterLayoutSubviews() {

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -85,8 +85,17 @@ import UIKit
   }
   
   // MARK: - BlurDesignable
-  @IBInspectable public var blurEffectStyle: String?
-  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN
+  @IBInspectable public var blurEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
+  @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
   
   // MARK: - TintDesignable
   @IBInspectable public var tintOpacity: CGFloat = CGFloat.NaN

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -91,6 +91,12 @@ import UIKit
     }
   }
 
+  @IBInspectable public var vibrancyEffectStyle: String? {
+    didSet {
+      configBlurEffectStyle()
+    }
+  }
+
   @IBInspectable public var blurOpacity: CGFloat = CGFloat.NaN {
     didSet {
       configBlurEffectStyle()

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -155,8 +155,7 @@ import UIKit
   // MARK: - Private
   private func configInspectableProperties() {
     configAnimatableProperties()
-    configTintedColor()
-    configBlurEffectStyle()
+    configTintedColor()    
   }
   
   private func configAfterLayoutSubviews() {

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -29,9 +29,9 @@ public extension BlurDesignable where Self: UIView {
 
     let blurEffectView = createVisualEffectView(UIBlurEffect(style: style))
     if let unwrappedVibrancyStyle = vibrancyEffectStyle, vibrancyStyle = blurEffectStyle(from: unwrappedVibrancyStyle) {
-      let vibrancyEffectView = createVisualEffectView(UIVibrancyEffect(forBlurEffect: UIBlurEffect(style: vibrancyStyle)))
+      let vibrancyEffectView = createVisualEffectView(UIVibrancyEffect(forBlurEffect: UIBlurEffect(style: vibrancyStyle)))      
       subviews.forEach {
-        vibrancyEffectView.addSubview($0)
+        vibrancyEffectView.contentView.addSubview($0)
       }
       blurEffectView.contentView.addSubview(vibrancyEffectView)
     }

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -10,7 +10,7 @@ public protocol BlurDesignable {
    blur effect style: `ExtraLight`, `Light` or `Dark`
    */
   var blurEffectStyle: String? { get set }
-  
+  var vibrancyEffectStyle: String? { get set }
   var blurOpacity: CGFloat { get set }
 }
 
@@ -19,15 +19,43 @@ public extension BlurDesignable where Self: UIView {
    configBlurEffectStyle method, should be called in layoutSubviews() method
    */
   public func configBlurEffectStyle() {
-    guard let unwrappedBlurEffectStyle = blurEffectStyle else {
+    guard let unwrappedBlurEffectStyle = blurEffectStyle, style = blurEffectStyle(from: unwrappedBlurEffectStyle) else {
       return
     }
-    
+
+    let blurEffectView = createVisualEffectView(UIBlurEffect(style: style))
+    if let unwrappedVibrancyStyle = vibrancyEffectStyle, vibrancyStyle = blurEffectStyle(from: unwrappedVibrancyStyle) {
+      let vibrancyEffectView = createVisualEffectView(UIVibrancyEffect(forBlurEffect: UIBlurEffect(style: vibrancyStyle)))
+      vibrancyEffectView.addSubview(UIImageView(image: UIImage(named: "checked")))
+      blurEffectView.contentView.addSubview(vibrancyEffectView)
+    }
+    insertSubview(blurEffectView, atIndex: 0)
+  }
+
+  private func createVisualEffectView(effect: UIVisualEffect) -> UIVisualEffectView {
+    let visualEffectView = UIVisualEffectView(effect: effect)
+    visualEffectView.alpha = blurOpacity.isNaN ? 1.0 : blurOpacity
+    if layer.cornerRadius > 0 {
+      visualEffectView.layer.cornerRadius = layer.cornerRadius
+      visualEffectView.clipsToBounds = true
+    }
+
+    visualEffectView.frame = bounds
+    visualEffectView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+    return visualEffectView
+  }
+
+}
+
+
+private extension BlurDesignable {
+
+  func blurEffectStyle(from blurEffectStyle: String) -> UIBlurEffectStyle? {
     var style: UIBlurEffectStyle?
-    guard let blurEffectStyle = BlurEffectStyle(rawValue: unwrappedBlurEffectStyle) else {
-      return
+    guard let blurEffectStyle = BlurEffectStyle(rawValue: blurEffectStyle) else {
+      return nil
     }
-    
+
     switch blurEffectStyle {
     case .ExtraLight:
       style = .ExtraLight
@@ -36,17 +64,6 @@ public extension BlurDesignable where Self: UIView {
     case .Dark:
       style = .Dark
     }
-    
-    let blurEffect = UIBlurEffect(style: style!)
-    let blurEffectView = UIVisualEffectView(effect: blurEffect)
-    blurEffectView.frame = bounds
-    let opacity = blurOpacity.isNaN ? 1.0 : blurOpacity // Default is 1.0
-    blurEffectView.alpha = opacity
-    if layer.cornerRadius > 0 {
-      blurEffectView.layer.cornerRadius = layer.cornerRadius
-      blurEffectView.clipsToBounds = true
-    }
-    blurEffectView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-    insertSubview(blurEffectView, atIndex: 0)
+    return style
   }
 }

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -26,7 +26,9 @@ public extension BlurDesignable where Self: UIView {
     let blurEffectView = createVisualEffectView(UIBlurEffect(style: style))
     if let unwrappedVibrancyStyle = vibrancyEffectStyle, vibrancyStyle = blurEffectStyle(from: unwrappedVibrancyStyle) {
       let vibrancyEffectView = createVisualEffectView(UIVibrancyEffect(forBlurEffect: UIBlurEffect(style: vibrancyStyle)))
-      vibrancyEffectView.addSubview(UIImageView(image: UIImage(named: "checked")))
+      subviews.forEach {
+        vibrancyEffectView.addSubview($0)
+      }
       blurEffectView.contentView.addSubview(vibrancyEffectView)
     }
     insertSubview(blurEffectView, atIndex: 0)

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -10,6 +10,10 @@ public protocol BlurDesignable {
    blur effect style: `ExtraLight`, `Light` or `Dark`
    */
   var blurEffectStyle: String? { get set }
+
+  /**
+   Vibrancy effect style: `ExtraLight`, `Light` or `Dark`. Once specify the Vibrancy effect style, all subviews will apply this vibrancy effect.
+   */
   var vibrancyEffectStyle: String? { get set }
   var blurOpacity: CGFloat { get set }
 }


### PR DESCRIPTION
I started the implementation of vibrancy designable (close #243), up to now it's working well but I have one issue which deserve more thought. 

The vibrancy is applied to its subviews while the blur is applied to everything below it. While using in interface builder, the blur is working well since we don't have to think about which view is parent of who, but for the vibrancy we have to know who will be its subviews. Since we can't use two different views to differentiate the vibrancy and the blur (they are fully related and can't work independently), how to add the subviews which will have the vibrancy effect applied?

The only option I find until now is to consider that all the subviews of the `AnimatableView` will be removed and then added to the `vibrancyView` which means, all the subviews will have a vibrancy without exception. That could be a good solution, but I'm expecting incomprehension when using the feature.
That option can be a bit extended by considering adding an `applyVibrancy` boolean to each subviews, but I'm not really fan of this.

Beside that, it's working well:

<img width="285" alt="screen shot 2016-07-14 at 15 31 00" src="https://cloud.githubusercontent.com/assets/1402212/16841109/07c422c6-49d8-11e6-9c1b-5052448b0c10.png">

The left image has been added programatically to the vibrancyView whereas the right one is a classic subview.

@JakeLin @f1nality Any suggestions about this issue? 
@f1nality Is that what you were expecting or did you have another idea in mind?
