### PR TITLE
Improving app main screen

### DIFF
--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -200,7 +200,7 @@ With these methods, we can navigate back or dismiss current ViewController witho
 ### TransitionAnimatable protocol
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
-| transitionAnimationType | Optional&lt;String> | Supported transition animations. Tap on "Forgot Password" button to see all predefined transition animations, e.g. `Fade`, `SystemCube(Left)` and `SystemPageCurl(Bottom)`. The transition type starts with `System` can only use in Push/Pop transitions, not Present/Dismiss transitions. Note: For `SystemRotate` seems that only `SystemRotate(90)` is working. |
+| transitionAnimationType | Optional&lt;String> | Supported transition animations. Tap on "Playground" button to see all predefined transition animations, e.g. `Fade`, `SystemCube(Left)` and `SystemPageCurl(Bottom)`. The transition type starts with `System` can only use in Push/Pop transitions, not Present/Dismiss transitions. Note: For `SystemRotate` seems that only `SystemRotate(90)` is working. |
 | transitionDuration | Double | transition duration. The default value is defined in [`Constants`](../IBAnimatable/Constants.swift) (0.7 seconds) |
 | interactiveGestureType | Optional&lt;String> | interactive gesture type. used to specify the gesture to dismiss/pop current scence. All supported interactive gesture types are in [`InteractiveGestureType`](../IBAnimatable/InteractiveGestureType.swift) |
 

--- a/Documentation/Transitions.md
+++ b/Documentation/Transitions.md
@@ -25,7 +25,7 @@ Once we configure those properties, **ALL Transition** (please notice it is all,
 
 ![Transition - Present Transition](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/PresentTransition.gif)
 
-You can see the example in "TransitionsInInterfaceBuilder.storyboard" and play around different configurations. Then open the App and tap on "Forget Password" button, and tap on "transitions" cell to navigate to Transitions Scene. Tap on "IB" button to see the configurations you made in "TransitionsInInterfaceBuilder.storyboard".
+You can see the example in "TransitionsInInterfaceBuilder.storyboard" and play around different configurations. Then open the App and tap on "Playground" button, and tap on "transitions" cell to navigate to Transitions Scene. Tap on "IB" button to see the configurations you made in "TransitionsInInterfaceBuilder.storyboard".
 
 If you want to have separate animation effect for different **Present Transition**, see the section [Configuring Present transition in Interface Builder via Segue](#configuring-present-transition-in-interface-builder-via-segue).
 
@@ -63,7 +63,7 @@ You can see the example in "TransitionsInInterfaceBuilder.storyboard" and play a
 
 `IBAnimatable` provide a broad set of Transition Animators / Controllers. We can use them in Interface Builder as **Transition Animation** as described in [Configuring Present transition in Interface Builder](#configuring-present-transition-in-interface-builder) and [Configuring Push transition in Interface Builder](#configuring-push-transition-in-interface-builder), or programmatically in code. They are all standard Transition Animators / Controllers conform to `UIViewControllerAnimatedTransitioning`.
 
-You can see all supported Transition Animators in the demo App, open the App and tap on "Forget Password" button, then tap on "transitions" cell to see all transitions.
+You can see all supported Transition Animators in the demo App, open the App and tap on "Playground" button, then tap on "transitions" cell to see all transitions.
 
 ### FadeAnimator
 

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -88,7 +88,7 @@
 		AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED1A0FA1BFE9820001346FA /* AppDelegate.swift */; };
 		AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FB1BFE9820001346FA /* Assets.xcassets */; };
 		AED1A1051BFE9820001346FA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */; };
-		AED1A1061BFE9820001346FA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FF1BFE9820001346FA /* Main.storyboard */; };
+		AED1A1061BFE9820001346FA /* DemoApp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AED1A0FF1BFE9820001346FA /* DemoApp.storyboard */; };
 		AED57AE51CE5C0CB00C359E3 /* TransitionPushedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED57AE41CE5C0CB00C359E3 /* TransitionPushedViewController.swift */; };
 		AEDB24D11CE9EC0F0086612C /* TransitionPresentedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDB24D01CE9EC0F0086612C /* TransitionPresentedViewController.swift */; };
 		AEDB24D31CE9EEB30086612C /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDB24D21CE9EEB30086612C /* UIViewControllerExtension.swift */; };
@@ -146,6 +146,7 @@
 		E2D33E551D3A5557006F2492 /* PresentationPresentedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D33E541D3A5557006F2492 /* PresentationPresentedViewController.swift */; };
 		E2D33E571D3A59B8006F2492 /* PresentationsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D33E561D3A59B8006F2492 /* PresentationsTableViewController.swift */; };
 		E2DAD63B1D5F5CC600333ABF /* DropDownAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DAD63A1D5F5CC600333ABF /* DropDownAnimator.swift */; };
+		E2DAD6311D5F141F00333ABF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2DAD6301D5F141F00333ABF /* Main.storyboard */; };
 		E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
 		E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */; };
 		E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */; };
@@ -230,7 +231,7 @@
 		AED1A0FA1BFE9820001346FA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = IBAnimatableApp/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		AED1A0FB1BFE9820001346FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = IBAnimatableApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		AED1A0FE1BFE9820001346FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		AED1A1001BFE9820001346FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
+		AED1A1001BFE9820001346FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = DemoApp.storyboard; sourceTree = "<group>"; };
 		AED1A1011BFE9820001346FA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = IBAnimatableApp/Info.plist; sourceTree = SOURCE_ROOT; };
 		AED1A1091BFE983A001346FA /* AnimatableButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnimatableButton.swift; path = IBAnimatable/AnimatableButton.swift; sourceTree = SOURCE_ROOT; };
 		AED1A10A1BFE983A001346FA /* Animatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Animatable.swift; path = IBAnimatable/Animatable.swift; sourceTree = SOURCE_ROOT; };
@@ -312,6 +313,7 @@
 		E2D33E541D3A5557006F2492 /* PresentationPresentedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationPresentedViewController.swift; sourceTree = "<group>"; };
 		E2D33E561D3A59B8006F2492 /* PresentationsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationsTableViewController.swift; sourceTree = "<group>"; };
 		E2DAD63A1D5F5CC600333ABF /* DropDownAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropDownAnimator.swift; sourceTree = "<group>"; };
+		E2DAD6301D5F141F00333ABF /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
 		E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		E2E28E711C6A6E70003F3852 /* GradientsTypeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradientsTypeScript.swift; path = Scripts/GradientsTypeScript.swift; sourceTree = SOURCE_ROOT; };
@@ -538,7 +540,8 @@
 				AED1A0FA1BFE9820001346FA /* AppDelegate.swift */,
 				AED1A0FB1BFE9820001346FA /* Assets.xcassets */,
 				AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */,
-				AED1A0FF1BFE9820001346FA /* Main.storyboard */,
+				E2DAD6301D5F141F00333ABF /* Main.storyboard */,
+				AED1A0FF1BFE9820001346FA /* DemoApp.storyboard */,
 				AE28D0551CDFF7D50043273C /* IBAnimatable Playground */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
 			);
@@ -774,7 +777,8 @@
 			files = (
 				AEC5F9CE1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard in Resources */,
 				E2D33E511D3A5418006F2492 /* Presentations.storyboard in Resources */,
-				AED1A1061BFE9820001346FA /* Main.storyboard in Resources */,
+				AED1A1061BFE9820001346FA /* DemoApp.storyboard in Resources */,
+				E2DAD6311D5F141F00333ABF /* Main.storyboard in Resources */,
 				AE1B9A641CE3EA590098D962 /* Interactions.storyboard in Resources */,
 				AED1A1041BFE9820001346FA /* Assets.xcassets in Resources */,
 				AED1A1051BFE9820001346FA /* LaunchScreen.storyboard in Resources */,
@@ -971,12 +975,12 @@
 			path = ../IBAnimatableApp/Base.lproj;
 			sourceTree = "<group>";
 		};
-		AED1A0FF1BFE9820001346FA /* Main.storyboard */ = {
+		AED1A0FF1BFE9820001346FA /* DemoApp.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				AED1A1001BFE9820001346FA /* Base */,
 			);
-			name = Main.storyboard;
+			name = DemoApp.storyboard;
 			path = ../IBAnimatableApp/Base.lproj;
 			sourceTree = "<group>";
 		};

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -482,9 +482,9 @@
 			isa = PBXGroup;
 			children = (
 				AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */,
+				AE0D309B1CE14A170093B578 /* Animations.storyboard */,
 				E2DAD6361D5F4B4A00333ABF /* UserInterface */,
 				E2DAD6371D5F4B6100333ABF /* Transitions / Presentations */,
-				AE0D309B1CE14A170093B578 /* Animations.storyboard */,
 			);
 			name = storyboards;
 			sourceTree = "<group>";

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -482,13 +482,9 @@
 			isa = PBXGroup;
 			children = (
 				AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */,
-				AE0D30991CE149150093B578 /* UserInterface.storyboard */,
-				AE87646B1D232F1D0044E0AB /* UserInterfaceMask.storyboard */,
+				E2DAD6361D5F4B4A00333ABF /* UserInterface */,
+				E2DAD6371D5F4B6100333ABF /* Transitions / Presentations */,
 				AE0D309B1CE14A170093B578 /* Animations.storyboard */,
-				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
-				AEC5F9CD1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard */,
-				E2D33E501D3A5418006F2492 /* Presentations.storyboard */,
-				AE1B9A631CE3EA590098D962 /* Interactions.storyboard */,
 			);
 			name = storyboards;
 			sourceTree = "<group>";
@@ -665,6 +661,26 @@
 				E2DAD63A1D5F5CC600333ABF /* DropDownAnimator.swift */,
 			);
 			name = "presentation animator";
+			sourceTree = "<group>";
+		};
+		E2DAD6361D5F4B4A00333ABF /* UserInterface */ = {
+			isa = PBXGroup;
+			children = (
+				AE0D30991CE149150093B578 /* UserInterface.storyboard */,
+				AE87646B1D232F1D0044E0AB /* UserInterfaceMask.storyboard */,
+			);
+			name = UserInterface;
+			sourceTree = "<group>";
+		};
+		E2DAD6371D5F4B6100333ABF /* Transitions / Presentations */ = {
+			isa = PBXGroup;
+			children = (
+				AE154B0E1C788A560093C05B /* Transitions.storyboard */,
+				AEC5F9CD1CF660A000F20354 /* TransitionsInInterfaceBuilder.storyboard */,
+				E2D33E501D3A5418006F2492 /* Presentations.storyboard */,
+				AE1B9A631CE3EA590098D962 /* Interactions.storyboard */,
+			);
+			name = "Transitions / Presentations";
 			sourceTree = "<group>";
 		};
 		E2E28E701C6A6E5E003F3852 /* scripts */ = {

--- a/IBAnimatableApp/Base.lproj/DemoApp.storyboard
+++ b/IBAnimatableApp/Base.lproj/DemoApp.storyboard
@@ -123,7 +123,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <segue destination="2i8-5x-idC" kind="show" id="pRb-pt-haD"/>
+                                    <segue destination="BEQ-85-4z1" kind="unwind" unwindAction="unwindToViewController:" id="U5r-kA-8Y9"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -155,6 +155,7 @@
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oMr-Kw-Kza" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="BEQ-85-4z1" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="3521.5" y="-255.5"/>
         </scene>
@@ -4498,14 +4499,6 @@
                 <exit id="Lmb-XJ-KRv" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="5567.5" y="1234.5"/>
-        </scene>
-        <!--Playground-->
-        <scene sceneID="IE3-a9-ajk">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Playground" id="2i8-5x-idC" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="JNa-0V-Cew" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3102.5" y="-255.5"/>
         </scene>
     </scenes>
     <resources>

--- a/IBAnimatableApp/Base.lproj/LaunchScreen.storyboard
+++ b/IBAnimatableApp/Base.lproj/LaunchScreen.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>

--- a/IBAnimatableApp/Base.lproj/Main.storyboard
+++ b/IBAnimatableApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7ne-VT-Tkk">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/IBAnimatableApp/Info.plist
+++ b/IBAnimatableApp/Info.plist
@@ -36,6 +36,8 @@
 	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/IBAnimatableApp/Main.storyboard
+++ b/IBAnimatableApp/Main.storyboard
@@ -27,7 +27,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome, enjoy the demo" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lAS-Ee-lhd">
-                                        <rect key="frame" x="76.5" y="126" width="167.5" height="17"/>
+                                        <rect key="frame" x="76" y="126" width="167.5" height="17"/>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -46,6 +46,7 @@
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yQ6-br-D2b" customClass="AnimatableButton" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="0.0" width="256" height="50"/>
+                                        <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="TNq-Lf-9FA"/>
                                         </constraints>
@@ -62,6 +63,9 @@
                                             <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                                 <real key="value" value="1"/>
                                             </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="1" green="1" blue="1" alpha="0.40000000000000002" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <segue destination="AV2-NQ-rHH" kind="presentation" id="0PJ-Nq-5Lw"/>
@@ -69,6 +73,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mnm-1A-4XS" customClass="AnimatableButton" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="80" width="256" height="50"/>
+                                        <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                         <state key="normal" title="Playground">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
@@ -81,6 +86,9 @@
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                                 <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="1" green="1" blue="1" alpha="0.40000000000000002" colorSpace="calibratedRGB"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
@@ -104,12 +112,13 @@
                             <constraint firstItem="C0f-jh-Uh1" firstAttribute="leading" secondItem="0Zb-ln-vCD" secondAttribute="leading" id="o4k-8g-KDt"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="T7e-mN-iFb"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uTA-82-CQ7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="124" y="373"/>
+            <point key="canvasLocation" x="936" y="373"/>
         </scene>
         <!--DemoApp-->
         <scene sceneID="Au8-z9-02c">
@@ -117,7 +126,7 @@
                 <viewControllerPlaceholder storyboardName="DemoApp" id="AV2-NQ-rHH" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aZu-nD-fPx" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="431.5" y="346"/>
+            <point key="canvasLocation" x="1243.5" y="346"/>
         </scene>
         <!--Playground-->
         <scene sceneID="DcI-pm-Tv7">
@@ -125,7 +134,7 @@
                 <viewControllerPlaceholder storyboardName="Playground" id="ZP4-Ul-hjM" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VdQ-FT-fKl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="436.5" y="400"/>
+            <point key="canvasLocation" x="1248.5" y="400"/>
         </scene>
     </scenes>
 </document>

--- a/IBAnimatableApp/Main.storyboard
+++ b/IBAnimatableApp/Main.storyboard
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="l6o-2n-J10">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="xkD-nc-dIU">
+            <objects>
+                <viewController id="l6o-2n-J10" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="aju-Gi-iM9"/>
+                        <viewControllerLayoutGuide type="bottom" id="x3c-Zj-41j"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="0Zb-ln-vCD">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C0f-jh-Uh1">
+                                <rect key="frame" x="0.0" y="20" width="320" height="199"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IBAnimatable" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2UR-Mx-FBU">
+                                        <rect key="frame" x="57" y="79" width="205" height="42"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome, enjoy the demo" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lAS-Ee-lhd">
+                                        <rect key="frame" x="76.5" y="126" width="167.5" height="17"/>
+                                        <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="2UR-Mx-FBU" firstAttribute="centerY" secondItem="C0f-jh-Uh1" secondAttribute="centerY" id="UDh-QG-XFz"/>
+                                    <constraint firstItem="lAS-Ee-lhd" firstAttribute="centerX" secondItem="C0f-jh-Uh1" secondAttribute="centerX" id="W02-gv-GtM"/>
+                                    <constraint firstItem="2UR-Mx-FBU" firstAttribute="centerX" secondItem="C0f-jh-Uh1" secondAttribute="centerX" id="evY-5q-eAS"/>
+                                    <constraint firstItem="lAS-Ee-lhd" firstAttribute="top" secondItem="2UR-Mx-FBU" secondAttribute="bottom" constant="5" id="sEX-AL-khy"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="nQF-gv-DgD">
+                                <rect key="frame" x="32" y="219" width="256" height="130"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yQ6-br-D2b" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="0.0" width="256" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="TNq-Lf-9FA"/>
+                                        </constraints>
+                                        <state key="normal" title="Demo application">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="6"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="AV2-NQ-rHH" kind="presentation" id="0PJ-Nq-5Lw"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mnm-1A-4XS" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="80" width="256" height="50"/>
+                                        <state key="normal" title="Playground">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="6"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="ZP4-Ul-hjM" kind="presentation" id="JRW-KN-WE1"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="yQ6-br-D2b" firstAttribute="height" secondItem="Mnm-1A-4XS" secondAttribute="height" id="q3D-yH-W02"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="nQF-gv-DgD" firstAttribute="centerX" secondItem="0Zb-ln-vCD" secondAttribute="centerX" id="2uv-BO-ccu"/>
+                            <constraint firstItem="nQF-gv-DgD" firstAttribute="top" secondItem="C0f-jh-Uh1" secondAttribute="bottom" id="7wH-Aa-ONP"/>
+                            <constraint firstAttribute="trailing" secondItem="C0f-jh-Uh1" secondAttribute="trailing" id="8AR-fq-TwP"/>
+                            <constraint firstItem="nQF-gv-DgD" firstAttribute="width" secondItem="0Zb-ln-vCD" secondAttribute="width" multiplier="0.8" id="D6X-0E-6cX"/>
+                            <constraint firstItem="nQF-gv-DgD" firstAttribute="centerY" secondItem="0Zb-ln-vCD" secondAttribute="centerY" id="OJi-9G-Mzs"/>
+                            <constraint firstItem="C0f-jh-Uh1" firstAttribute="top" secondItem="aju-Gi-iM9" secondAttribute="bottom" id="nhQ-Dl-5UW"/>
+                            <constraint firstItem="C0f-jh-Uh1" firstAttribute="leading" secondItem="0Zb-ln-vCD" secondAttribute="leading" id="o4k-8g-KDt"/>
+                        </constraints>
+                    </view>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uTA-82-CQ7" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="124" y="373"/>
+        </scene>
+        <!--DemoApp-->
+        <scene sceneID="Au8-z9-02c">
+            <objects>
+                <viewControllerPlaceholder storyboardName="DemoApp" id="AV2-NQ-rHH" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aZu-nD-fPx" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="431.5" y="346"/>
+        </scene>
+        <!--Playground-->
+        <scene sceneID="DcI-pm-Tv7">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Playground" id="ZP4-Ul-hjM" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VdQ-FT-fKl" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="436.5" y="400"/>
+        </scene>
+    </scenes>
+</document>

--- a/IBAnimatableApp/MaskViewController.swift
+++ b/IBAnimatableApp/MaskViewController.swift
@@ -15,6 +15,7 @@ class MaskViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    title = maskType
     maskedView.maskType = maskType
     maskedImageView.maskType = maskType
   }

--- a/IBAnimatableApp/Playground.storyboard
+++ b/IBAnimatableApp/Playground.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="FqL-96-clY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="FqL-96-clY">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -211,7 +211,7 @@
                 <viewControllerPlaceholder storyboardName="UserInterface" id="VGT-SK-HRG" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dpn-Wz-hk3" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6307" y="-331"/>
+            <point key="canvasLocation" x="6308" y="-360"/>
         </scene>
         <!--Animations-->
         <scene sceneID="IlU-Wj-CPN">
@@ -219,7 +219,7 @@
                 <viewControllerPlaceholder storyboardName="Animations" id="YMk-Jn-KUW" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eLW-Ww-QM4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6299.5" y="-279"/>
+            <point key="canvasLocation" x="6300.5" y="-308"/>
         </scene>
         <!--Transitions-->
         <scene sceneID="rFV-yH-sSh">
@@ -227,7 +227,7 @@
                 <viewControllerPlaceholder storyboardName="Transitions" id="Yrg-NP-dYZ" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PSX-rh-CnY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6299" y="-228"/>
+            <point key="canvasLocation" x="6300" y="-257"/>
         </scene>
         <!--Interactions-->
         <scene sceneID="LKK-ky-A7J">
@@ -235,7 +235,7 @@
                 <viewControllerPlaceholder storyboardName="Interactions" id="rei-S7-RFR" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RB5-Hg-lBY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6301.5" y="-140"/>
+            <point key="canvasLocation" x="6302.5" y="-156"/>
         </scene>
         <!--Presentations-->
         <scene sceneID="JYL-TY-QR4">
@@ -243,7 +243,7 @@
                 <viewControllerPlaceholder storyboardName="Presentations" id="tXh-nS-4b7" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Sb-x6-cQw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6307.5" y="-184"/>
+            <point key="canvasLocation" x="6308.5" y="-206"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="VjR-mb-m73">

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="dM8-H6-op1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="dM8-H6-op1">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -9,16 +9,16 @@
         <scene sceneID="QNm-Wq-94X">
             <objects>
                 <tableViewController clearsSelectionOnViewWillAppear="NO" id="dM8-H6-op1" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="O3U-8W-uIX" customClass="AnimatableTableView" customModule="IBAnimatable">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="O3U-8W-uIX" customClass="AnimatableTableView" customModule="IBAnimatable">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="separatorColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <sections>
                             <tableViewSection id="pZQ-Pf-P1v">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="Rs1-3k-ac9" style="IBUITableViewCellStyleDefault" id="oZn-rq-6jb" userLabel="uiCell" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="99" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="Rs1-3k-ac9" style="IBUITableViewCellStyleDefault" id="oZn-rq-6jb" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="64" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oZn-rq-6jb" id="MMG-gu-DNX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -43,8 +43,8 @@
                                             <segue destination="EH2-oa-QGQ" kind="show" id="D7h-jh-hfX"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="gM0-9A-UM6" style="IBUITableViewCellStyleDefault" id="cVI-On-FQ4" userLabel="uiCell" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="143" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="gM0-9A-UM6" style="IBUITableViewCellStyleDefault" id="cVI-On-FQ4" userLabel="Mask" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="108" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cVI-On-FQ4" id="Q2V-hQ-Jdi">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -100,10 +100,10 @@
             </objects>
             <point key="canvasLocation" x="4017.5" y="-281.5"/>
         </scene>
-        <!--View Controller-->
+        <!--Placeholder-->
         <scene sceneID="bM8-83-R8P">
             <objects>
-                <viewController id="EH2-oa-QGQ" sceneMemberID="viewController">
+                <viewController title="Placeholder" id="EH2-oa-QGQ" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="zEj-wi-wS3"/>
                         <viewControllerLayoutGuide type="bottom" id="seB-Sk-UJs"/>
@@ -166,11 +166,22 @@
                             <constraint firstItem="P8s-Eb-llW" firstAttribute="centerX" secondItem="gdH-rU-9qJ" secondAttribute="centerX" id="oUS-0g-2B5"/>
                         </constraints>
                     </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Placeholder" id="T5D-Hg-abW">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="a0M-Fg-4uy">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="gJl-3C-ZLK" kind="unwind" unwindAction="unwindToViewController:" id="oHi-oM-JGZ"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JdN-Fw-n4f" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="gJl-3C-ZLK" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4465.5" y="-281.5"/>
+            <point key="canvasLocation" x="4513.5" y="-281.5"/>
         </scene>
         <!--UserInterfaceMask-->
         <scene sceneID="jMl-6T-PN8">
@@ -178,7 +189,7 @@
                 <viewControllerPlaceholder storyboardName="UserInterfaceMask" id="KX0-ct-vLn" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5o5-kn-ytD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4352" y="147"/>
+            <point key="canvasLocation" x="4400" y="165"/>
         </scene>
     </scenes>
     <resources>

--- a/IBAnimatableApp/UserInterfaceMask.storyboard
+++ b/IBAnimatableApp/UserInterfaceMask.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="il8-4c-qod">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="il8-4c-qod">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -8,14 +8,14 @@
         <scene sceneID="YmD-eu-ZsA">
             <objects>
                 <tableViewController clearsSelectionOnViewWillAppear="NO" id="il8-4c-qod" customClass="UserInterfaceMaskTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="4OC-bH-cUu" customClass="AnimatableTableView" customModule="IBAnimatable">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="4OC-bH-cUu" customClass="AnimatableTableView" customModule="IBAnimatable">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="separatorColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="QQh-LE-jen" style="IBUITableViewCellStyleDefault" id="3dh-WJ-c8D" userLabel="maskCell" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                <rect key="frame" x="0.0" y="113.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="92" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3dh-WJ-c8D" id="U1w-DA-jBA">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -53,12 +53,21 @@
                         </connections>
                     </tableView>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="Mask" id="SRi-uY-fPM"/>
+                    <navigationItem key="navigationItem" title="Mask" id="SRi-uY-fPM">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="bha-iD-yZj">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="dNI-CK-76B" kind="unwind" unwindAction="unwindToViewController:" id="xYe-Ps-i32"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="m8H-TX-FmW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="dNI-CK-76B" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="4465.5" y="459.5"/>
         </scene>
@@ -112,5 +121,6 @@
     </scenes>
     <resources>
         <image name="auto-bg" width="375" height="179"/>
+        <image name="back" width="21" height="21"/>
     </resources>
 </document>

--- a/IBAnimatableApp/UserInterfaceMask.storyboard
+++ b/IBAnimatableApp/UserInterfaceMask.storyboard
@@ -108,6 +108,14 @@
                             <constraint firstItem="rm0-49-clX" firstAttribute="top" secondItem="SbM-du-jBs" secondAttribute="bottom" constant="60" id="xgn-Oy-AS3"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="r4q-8J-vDr">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="KOq-2I-xvZ">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="ecL-Ec-tjn" kind="unwind" unwindAction="unwindToViewController:" id="ReZ-Gj-zsn"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
                     <connections>
                         <outlet property="maskedImageView" destination="rm0-49-clX" id="gXT-sO-eBY"/>
@@ -115,6 +123,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="on5-5B-kLq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="ecL-Ec-tjn" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="4920.5" y="459.5"/>
         </scene>


### PR DESCRIPTION
Since we add the (awesome) playground page in the demo app, I was frustrating by the access point.  Also, I think the playground part is too hard to find if you don't read the docs. This PR is a try to improve it:
- New main screen: when launching the app, instead of getting in the demo, we will get a dispatch one: choose between "Demo app" or "Playground". The "forget password" is used to go back into the main screen. The interface can be improved (animations, colors, images...), but it's a start & proof of concept. 

![simulator screen shot 13 aug 2016 10 54 39](https://cloud.githubusercontent.com/assets/1402212/17642414/d845edec-6145-11e6-8a5b-72e6215e765e.png)

I also add few other improvements:
- Uniformize back buttons in the "Placeholder" and "Mask" demo
- Uniformize UITableView separator line in the "User interface" and "Mask" demo
- Set mask selected as title in `MaskViewController`
