### PR TITLE
Feature/ Improve Border Sides

### DIFF
--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -46,11 +46,18 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+   public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
+  
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }
+  
 
   // MARK: - ShadowDesignable
   @IBInspectable public var shadowColor: UIColor? {

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -71,7 +71,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -65,12 +65,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - ShadowDesignable
   @IBInspectable public var shadowColor: UIColor? {
     didSet {

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - TableViewCellDesignable
   @IBInspectable public var removeSeparatorMargins: Bool = false
   

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - RotationDesignable
   @IBInspectable public var rotate: CGFloat = CGFloat.nan {
     didSet {

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
-
+  
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }
   // MARK: - Animatable
 public var animationType: AnimationType = .none
 @IBInspectable  var _animationType: String? {

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -47,12 +47,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - RotationDesignable
   @IBInspectable public var rotate: CGFloat = CGFloat.nan {
     didSet {

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -53,7 +53,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -26,7 +26,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -20,12 +20,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - RotationDesignable
   @IBInspectable public var rotate: CGFloat = CGFloat.nan {
     didSet {

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -54,7 +54,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -48,12 +48,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - RotationDesignable
   @IBInspectable public var rotate: CGFloat = CGFloat.nan {
     didSet {

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -39,12 +39,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - GradientDesignable
   @IBInspectable public var startColor: UIColor?
   @IBInspectable public var endColor: UIColor?

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -45,7 +45,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -39,12 +39,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - TableViewCellDesignable
   @IBInspectable public var removeSeparatorMargins: Bool = false
   

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -45,7 +45,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - ShadowDesignable
   @IBInspectable public var shadowColor: UIColor? {
     didSet {

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
-
+  
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }
   // MARK: - PlaceholderDesignable
   @IBInspectable public var placeholderText: String? {
     didSet {

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -46,12 +46,17 @@ import UIKit
     }
   }
   
-  @IBInspectable public var borderSide: String? {
+  public var borderSides: BorderSides  = .AllSides {
     didSet {
       configBorder()
     }
   }
   
+  @IBInspectable public var _borderSides: String? {
+    didSet {
+      borderSides = BorderSides(rawValue: _borderSides)
+    }
+  }  
   // MARK: - RotationDesignable
   @IBInspectable public var rotate: CGFloat = CGFloat.nan {
     didSet {

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -52,7 +52,7 @@ import UIKit
     }
   }
   
-  @IBInspectable public var _borderSides: String? {
+  @IBInspectable var _borderSides: String? {
     didSet {
       borderSides = BorderSides(rawValue: _borderSides)
     }

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -19,64 +19,8 @@ public protocol BorderDesignable {
   /**
    border side: Top, Right, Bottom or Left, if not specified, all border sides will display,
    */
-  var borderSide: String? { get set }
+  var borderSides: BorderSides { get set }
   
-}
-
-struct BorderSides: OptionSet {
-  let rawValue: Int
-  
-  static let Unknown = BorderSides(rawValue: 0)
-  
-  static let top = BorderSides(rawValue: 1)
-  static let right = BorderSides(rawValue: 1 << 1)
-  static let bottom = BorderSides(rawValue: 1 << 2)
-  static let left = BorderSides(rawValue: 1 << 3)
-  
-  static let AllSides: BorderSides = [.top, .right, .bottom, .left]
-  
-  init(rawValue: Int) {
-    self.rawValue = rawValue
-  }
-  
-  init(rawValue: String?) {
-    guard let rawValue = rawValue else {
-      self = .AllSides
-      return
-    }
-    
-    guard !rawValue.isEmpty else {
-      self = .AllSides
-      return
-    }
-    
-    let sideElements = rawValue.characters.split(separator: ",")
-      .map(String.init)
-      .map { BorderSide(rawValue: $0.trimmingCharacters(in: CharacterSet.whitespaces)) }
-      .map { BorderSides(side: $0) }
-    
-    guard !sideElements.contains(.Unknown) else {
-      self = .AllSides
-      return
-    }
-    
-    self = BorderSides(sideElements)
-    
-  }
-  
-  init(side: BorderSide?) {
-    guard let side = side else { 
-      self = .Unknown 
-      return 
-    }
-    
-    switch side {
-    case .top: self = .top
-    case .right: self = .right
-    case .bottom: self = .bottom
-    case .left: self = .left
-    }
-  }
 }
 
 public extension BorderDesignable where Self: UITextField {
@@ -118,9 +62,9 @@ private extension BorderDesignable where Self: UIView {
       return
     }
     
-    let sides = BorderSides(rawValue: borderSide)
+    //let sides = BorderSides(rawValue: BorderSides)
     
-    if sides == .AllSides {
+    if borderSides == .AllSides {
       layer.borderColor = unwrappedBorderColor.cgColor
       layer.borderWidth = borderWidth
       return
@@ -133,16 +77,16 @@ private extension BorderDesignable where Self: UIView {
     let borderPath = UIBezierPath()
     
     var lines: [(start: CGPoint, end: CGPoint)] = []
-    if sides.contains(.top) {
+    if borderSides.contains(.top) {
       lines.append((start: .zero, end: CGPoint(x: bounds.size.width, y: 0)))
     }
-    if sides.contains(.right) {
+    if borderSides.contains(.right) {
       lines.append((start: CGPoint(x: bounds.size.width, y: 0), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
     }
-    if sides.contains(.bottom) {
+    if borderSides.contains(.bottom) {
       lines.append((start: CGPoint(x: 0, y: bounds.size.height), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
     }
-    if sides.contains(.left) {
+    if borderSides.contains(.left) {
       lines.append((start: .zero, end: CGPoint(x: 0, y: bounds.size.height)))
     }
     

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -75,19 +75,19 @@ private extension BorderDesignable where Self: UIView {
     border.name = "borderSideLayer"
     
     let borderPath = UIBezierPath()
-    
+    let shift = borderWidth / 2
     var lines: [(start: CGPoint, end: CGPoint)] = []
     if borderSides.contains(.top) {
-      lines.append((start: .zero, end: CGPoint(x: bounds.size.width, y: 0)))
+      lines.append((start: CGPoint(x: 0, y: shift), end: CGPoint(x: bounds.size.width, y: shift)))
     }
     if borderSides.contains(.right) {
-      lines.append((start: CGPoint(x: bounds.size.width, y: 0), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
+      lines.append((start: CGPoint(x: bounds.size.width - shift, y: 0), end: CGPoint(x: bounds.size.width - shift, y: bounds.size.height)))
     }
     if borderSides.contains(.bottom) {
-      lines.append((start: CGPoint(x: 0, y: bounds.size.height), end: CGPoint(x: bounds.size.width, y: bounds.size.height)))
+      lines.append((start: CGPoint(x: 0, y: bounds.size.height - shift), end: CGPoint(x: bounds.size.width, y: bounds.size.height - shift)))
     }
     if borderSides.contains(.left) {
-      lines.append((start: .zero, end: CGPoint(x: 0, y: bounds.size.height)))
+      lines.append((start: CGPoint(x: shift, y: 0), end: CGPoint(x: shift, y: bounds.size.height)))
     }
     
     for linePoints in lines {

--- a/IBAnimatable/BorderSide.swift
+++ b/IBAnimatable/BorderSide.swift
@@ -11,3 +11,55 @@ public enum BorderSide: String {
   case bottom
   case left
 }
+
+
+public struct BorderSides: OptionSet {
+  public let rawValue: Int
+  
+  public static let unknown = BorderSides(rawValue: 0)
+  
+  public static let top = BorderSides(rawValue: 1)
+  public static let right = BorderSides(rawValue: 1 << 1)
+  public static let bottom = BorderSides(rawValue: 1 << 2)
+  public static let left = BorderSides(rawValue: 1 << 3)
+  
+  public static let AllSides: BorderSides = [.top, .right, .bottom, .left]
+  
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+  
+  init(rawValue: String?) {
+    guard let rawValue = rawValue, !rawValue.isEmpty else {
+      self = .AllSides
+      return
+    }
+    let sideElements = rawValue.lowercased().characters.split(separator: ",")
+      .map(String.init)
+      .map { BorderSide(rawValue: $0.trimmingCharacters(in: CharacterSet.whitespaces)) }
+      .map { BorderSides(side: $0) }
+    
+    guard !sideElements.contains(.unknown) else {
+      self = .AllSides
+      return
+    }
+    
+    self = BorderSides(sideElements)
+    
+  }
+  
+  init(side: BorderSide?) {
+    guard let side = side else {
+      self = .unknown
+      return
+    }
+    
+    switch side {
+    case .top: self = .top
+    case .right: self = .right
+    case .bottom: self = .bottom
+    case .left: self = .left
+    }
+  }
+}
+                    

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		732485D71D4902510068FD93 /* ParamType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732485D61D4902510068FD93 /* ParamType.swift */; };
 		733323031D56BCF200B88F6E /* UserInterfaceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733323021D56BCF200B88F6E /* UserInterfaceTableViewController.swift */; };
 		734DAFF31D493EB6007E830B /* BlurEffectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734DAFF21D493EB6007E830B /* BlurEffectViewController.swift */; };
+		73A99B671D5FC8650079C7EC /* BorderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A99B661D5FC8650079C7EC /* BorderViewController.swift */; };
 		73B7D8861D233FB700DD3F43 /* IBEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B7D8851D233FB700DD3F43 /* IBEnum.swift */; };
 		73BDE6EC1D5654ED00D19EAE /* GradientViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BDE6EB1D5654ED00D19EAE /* GradientViewController.swift */; };
 		73CF12281D4828EE0025404E /* SystemTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56645FCD11BEC66200818 /* SystemTransitionType.swift */; };
@@ -163,6 +164,7 @@
 		732485D61D4902510068FD93 /* ParamType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParamType.swift; sourceTree = "<group>"; };
 		733323021D56BCF200B88F6E /* UserInterfaceTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInterfaceTableViewController.swift; sourceTree = "<group>"; };
 		734DAFF21D493EB6007E830B /* BlurEffectViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurEffectViewController.swift; sourceTree = "<group>"; };
+		73A99B661D5FC8650079C7EC /* BorderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderViewController.swift; sourceTree = "<group>"; };
 		73B7D8851D233FB700DD3F43 /* IBEnum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IBEnum.swift; sourceTree = "<group>"; };
 		73BDE6EB1D5654ED00D19EAE /* GradientViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientViewController.swift; sourceTree = "<group>"; };
 		73ED71F71D34CA4700755C9B /* AnimationsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationsViewController.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 				734DAFF21D493EB6007E830B /* BlurEffectViewController.swift */,
 				73BDE6EB1D5654ED00D19EAE /* GradientViewController.swift */,
 				733323021D56BCF200B88F6E /* UserInterfaceTableViewController.swift */,
+				73A99B661D5FC8650079C7EC /* BorderViewController.swift */,
 			);
 			name = code;
 			sourceTree = "<group>";
@@ -885,6 +888,7 @@
 			files = (
 				733323031D56BCF200B88F6E /* UserInterfaceTableViewController.swift in Sources */,
 				AE1B9A661CE3EB100098D962 /* InteractionTableViewController.swift in Sources */,
+				73A99B671D5FC8650079C7EC /* BorderViewController.swift in Sources */,
 				AE8764701D2332F60044E0AB /* MaskViewController.swift in Sources */,
 				73BDE6EC1D5654ED00D19EAE /* GradientViewController.swift in Sources */,
 				AE8A4FFA1C856EEC00E9E368 /* TransitionViewController.swift in Sources */,

--- a/IBAnimatableApp/BorderViewController.swift
+++ b/IBAnimatableApp/BorderViewController.swift
@@ -1,0 +1,44 @@
+//
+//  BorderViewController.swift
+//  IBAnimatableApp
+//
+//  Created by jason akakpo on 13/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+import IBAnimatable
+
+class BorderViewController: UIViewController {
+
+  @IBOutlet weak var viewToBorder: AnimatableView!
+  @IBOutlet weak var topCheckBox: AnimatableCheckBox!
+  @IBOutlet weak var botCheckBox: AnimatableCheckBox!
+  @IBOutlet weak var leftCheckBox: AnimatableCheckBox!
+  @IBOutlet weak var rightCheckBox: AnimatableCheckBox!
+  
+
+  @IBAction func boxChecked(_ sender: AnimatableCheckBox) {
+    let border: BorderSides
+    switch sender {
+    case topCheckBox:
+      border = .top
+    case botCheckBox:
+      border = .bottom
+    case leftCheckBox:
+      border = .left
+    case rightCheckBox:
+      border = .right
+    default:
+      return
+    }
+    if sender.checked {
+      viewToBorder.borderSides.insert(border)
+    } else {
+      viewToBorder.borderSides.remove(border)
+    }
+    
+  }
+  
+
+}

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11185.3" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dM8-H6-op1">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11151.4"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -23,7 +24,7 @@
                                         <rect key="frame" x="0.0" y="99" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oZn-rq-6jb" id="MMG-gu-DNX">
-                                            <frame key="frameInset" width="375" height="44"/>
+                                            <frame key="frameInset" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Rs1-3k-ac9">
@@ -49,7 +50,7 @@
                                         <rect key="frame" x="0.0" y="143" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cVI-On-FQ4" id="Q2V-hQ-Jdi">
-                                            <frame key="frameInset" width="375" height="44"/>
+                                            <frame key="frameInset" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Mask" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gM0-9A-UM6">
@@ -75,7 +76,7 @@
                                         <rect key="frame" x="0.0" y="187" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Rlw-9O-B7b" id="2fY-RT-49u">
-                                            <frame key="frameInset" width="375" height="44"/>
+                                            <frame key="frameInset" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Blur effect" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dwn-Ja-n4y">
@@ -101,7 +102,7 @@
                                         <rect key="frame" x="0.0" y="231" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AkO-ey-85U" id="PXI-Fe-iHY">
-                                            <frame key="frameInset" width="375" height="44"/>
+                                            <frame key="frameInset" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Predefined gradients" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="t5m-Ei-nOr">
@@ -127,7 +128,7 @@
                                         <rect key="frame" x="0.0" y="275" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0w5-J3-37R" id="G1s-we-dSo">
-                                            <frame key="frameInset" width="375" height="44"/>
+                                            <frame key="frameInset" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Gradients" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="i9c-8y-AYA">
@@ -147,6 +148,32 @@
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <segue destination="YvY-Pr-4LY" kind="show" identifier="gradients" id="JfQ-7P-WNG"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="Vxg-g9-73G" style="IBUITableViewCellStyleDefault" id="cmI-Lb-6Pc" userLabel="uiCell" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="319" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cmI-Lb-6Pc" id="Gs2-Zn-JkG">
+                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Border Sides" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Vxg-g9-73G">
+                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="yzd-wU-DRz" kind="show" id="gnx-mE-kud"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -343,7 +370,187 @@ Opacity</string>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FX3-ux-6qf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4826" y="500"/>
+            <point key="canvasLocation" x="4570" y="591"/>
+        </scene>
+        <!--Border View Controller-->
+        <scene sceneID="8Aq-1E-j6W">
+            <objects>
+                <viewController id="yzd-wU-DRz" customClass="BorderViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="6rF-a8-fWx"/>
+                        <viewControllerLayoutGuide type="bottom" id="pNt-lR-6Yk"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="RXa-AH-gCS">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eb4-7r-Usj">
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XfI-vs-Klt" userLabel="Content">
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5YH-3K-Z6I" customClass="AnimatableView" customModule="IBAnimatable">
+                                                <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" id="R7j-Se-AUb"/>
+                                                    <constraint firstAttribute="width" constant="200" id="onv-aW-yww"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                        <real key="value" value="3"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                        <color key="value" red="0.82352942228317261" green="0.18823529779911041" blue="0.14509804546833038" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstItem="5YH-3K-Z6I" firstAttribute="centerX" secondItem="XfI-vs-Klt" secondAttribute="centerX" id="SuY-zC-qJd"/>
+                                            <constraint firstItem="5YH-3K-Z6I" firstAttribute="centerY" secondItem="XfI-vs-Klt" secondAttribute="centerY" id="le3-Pq-GtA"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pif-t8-9Jy" userLabel="Bot Panel">
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="75u-pF-Sy6">
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="wXB-Ve-Nx8">
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G0B-Jv-kmo" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="G0B-Jv-kmo" secondAttribute="height" id="IXX-5w-Pqc"/>
+                                                                </constraints>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="qYA-tx-78w"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Top" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qkf-AH-sgw">
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="FcK-Z8-jTw"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="WJt-th-N1Y">
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GpR-xE-BpF" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="GpR-xE-BpF" secondAttribute="height" id="1v5-dx-sXj"/>
+                                                                </constraints>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="DOP-rn-NsG"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ery-U0-7n4">
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="zE2-v2-aoc"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="2Gl-ke-oiy">
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1WE-rk-t4D" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="1WE-rk-t4D" secondAttribute="height" id="pM7-dI-q5F"/>
+                                                                </constraints>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="fAe-iT-Es4"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Right" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zdN-WX-lYa">
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="aSG-ho-4jm"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ojc-jR-F4A">
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a5p-Qm-Tx2" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" secondItem="a5p-Qm-Tx2" secondAttribute="height" id="KAM-N8-nt8"/>
+                                                                </constraints>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="U0Z-BG-mKq"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Bottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VCe-5b-zdS">
+                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="qOq-2s-TIf"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="75u-pF-Sy6" firstAttribute="leading" secondItem="Pif-t8-9Jy" secondAttribute="leading" constant="10" id="cwn-6x-vrp"/>
+                                            <constraint firstAttribute="bottom" secondItem="75u-pF-Sy6" secondAttribute="bottom" constant="10" id="euW-Le-T71"/>
+                                            <constraint firstAttribute="trailing" secondItem="75u-pF-Sy6" secondAttribute="trailing" constant="10" id="ezg-o2-Xj4"/>
+                                            <constraint firstItem="75u-pF-Sy6" firstAttribute="top" secondItem="Pif-t8-9Jy" secondAttribute="top" constant="10" id="kpG-tX-V6P"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="Eb4-7r-Usj" firstAttribute="top" secondItem="6rF-a8-fWx" secondAttribute="bottom" id="B2f-gh-XDo"/>
+                            <constraint firstItem="pNt-lR-6Yk" firstAttribute="top" secondItem="Eb4-7r-Usj" secondAttribute="bottom" id="c3f-am-CNW"/>
+                            <constraint firstItem="Eb4-7r-Usj" firstAttribute="leading" secondItem="RXa-AH-gCS" secondAttribute="leading" id="eaG-x6-Ie0"/>
+                            <constraint firstAttribute="trailing" secondItem="Eb4-7r-Usj" secondAttribute="trailing" id="rkI-wL-bHX"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="botCheckBox" destination="a5p-Qm-Tx2" id="N3D-gH-7ba"/>
+                        <outlet property="leftCheckBox" destination="GpR-xE-BpF" id="BHt-3E-Toa"/>
+                        <outlet property="rightCheckBox" destination="1WE-rk-t4D" id="AE3-Zw-Bs5"/>
+                        <outlet property="topCheckBox" destination="G0B-Jv-kmo" id="xDx-hv-xxK"/>
+                        <outlet property="viewToBorder" destination="5YH-3K-Z6I" id="I7p-ec-DdY"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lrc-NQ-UrS" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5198" y="591"/>
         </scene>
         <!--Gradient View Controller-->
         <scene sceneID="Mwp-lR-EKb">
@@ -441,7 +648,9 @@ Opacity</string>
     </scenes>
     <resources>
         <image name="back" width="21" height="21"/>
+        <image name="checked" width="80" height="80"/>
         <image name="login-bg" width="375" height="667"/>
+        <image name="unchecked" width="80" height="81"/>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="JfQ-7P-WNG"/>


### PR DESCRIPTION
`BorderSides` is now a public struct (defined in BorderSide.swift).
`borderSides` property of `BorderDesignable`is now of type `BorderSides` (defaultValue `.allSides`)
Add a `@IBInspectable _borderSides` property. 
NB: `borderSide` become `borderSides`

Add a demo of Border in playground app (User Interface => Border Sides)
![screen shot 2016-08-14 at 01 20 03](https://cloud.githubusercontent.com/assets/4633817/17646144/45981ede-61bd-11e6-87ca-4c2d7cefbbf0.png)

I noticed using this demo there is a difference between our borders implementation add CALayer's one ; Our implementation use outer-border, system one seems inner. 
 Since we fallback to the system implementation when borderSides == .AllSides, you can saw the difference, by checking-unchecking one side. I Don't know if it intentional  or not ?
