### PR TITLE
Feature/transition animatable

### DIFF
--- a/IBAnimatable/AnimatableNavigationController.swift
+++ b/IBAnimatable/AnimatableNavigationController.swift
@@ -8,7 +8,14 @@ import UIKit
 public class AnimatableNavigationController: UINavigationController, TransitionAnimatable {
   
   // MARK: - TransitionAnimatable
-  @IBInspectable public var transitionAnimationType: String? {
+  @IBInspectable  var _transitionAnimationType: String? {
+    didSet {
+      if let _transitionAnimationType = _transitionAnimationType {
+        transitionAnimationType = TransitionAnimationType.fromString(_transitionAnimationType)
+      }
+    }
+  }
+   public var transitionAnimationType: TransitionAnimationType? {
     didSet {
       configureNavigationControllerDelegate()
     }
@@ -18,16 +25,18 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
       configureNavigationControllerDelegate()
     }
   }
-  @IBInspectable public var interactiveGestureType: String? {
+  public var interactiveGestureType: InteractiveGestureType? {
     didSet {
       configureNavigationControllerDelegate()
     }
   }
-  
-  // MARK: - Lifecylce
-  public override func viewDidLoad() {
-    super.viewDidLoad()
-    configureNavigationControllerDelegate()
+
+  @IBInspectable var _interactiveGestureType: String? {
+    didSet {
+      if let _interactiveGestureType = _interactiveGestureType {
+        interactiveGestureType = InteractiveGestureType.fromString(_interactiveGestureType)
+      }
+    }
   }
   
   // MARK: - Private
@@ -35,7 +44,7 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
   private var navigator: Navigator?
   
   private func configureNavigationControllerDelegate() {
-    guard let transitionAnimationType = transitionAnimationType, let animationType = TransitionAnimationType.fromString(transitionAnimationType) else {
+    guard let animationType = transitionAnimationType else {
       navigator = nil
       delegate = nil
       return
@@ -45,7 +54,7 @@ public class AnimatableNavigationController: UINavigationController, TransitionA
     if transitionDuration.isNaN {
       duration = defaultTransitionDuration
     }
-    if let interactiveGestureType = interactiveGestureType, let gestureType = InteractiveGestureType.fromString(interactiveGestureType) {
+    if let gestureType = interactiveGestureType {
       navigator = Navigator(transitionAnimationType: animationType, transitionDuration: duration, interactiveGestureType: gestureType)
     } else {
       navigator = Navigator(transitionAnimationType: animationType, transitionDuration: duration)

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -16,9 +16,25 @@ import UIKit
   @IBInspectable public var rootWindowBackgroundColor: UIColor?
 
   // MARK: - TransitionAnimatable
-  @IBInspectable public var transitionAnimationType: String?
+  @IBInspectable  var _transitionAnimationType: String? {
+    didSet {
+      if let _transitionAnimationType = _transitionAnimationType {
+        transitionAnimationType = TransitionAnimationType.fromString(_transitionAnimationType)
+      }
+    }
+  }
+  public var transitionAnimationType: TransitionAnimationType?
+  
   @IBInspectable public var transitionDuration: Double = .nan
-  @IBInspectable public var interactiveGestureType: String?
+  
+  public var interactiveGestureType: InteractiveGestureType?
+  @IBInspectable var _interactiveGestureType: String? {
+    didSet {
+      if let _interactiveGestureType = _interactiveGestureType {
+        interactiveGestureType = InteractiveGestureType.fromString(_interactiveGestureType)
+      }
+    }
+  }
 
   // MARK: - Lifecylce
   public override func viewWillAppear(_ animated: Bool) {
@@ -44,15 +60,15 @@ import UIKit
     super.prepare(for: segue, sender: sender)
     
     // Configure custom transition animation
-    guard let transitionAnimationType = transitionAnimationType, let animationType = TransitionAnimationType.fromString(transitionAnimationType) else {
+    guard let animationType = transitionAnimationType else {
       super.prepare(for: segue, sender: sender)
       return
     }
     
     let toViewController = segue.destination
     // If interactiveGestureType has been set
-    if let interactiveGestureType = interactiveGestureType, let interactiveGestureTypeValue = InteractiveGestureType.fromString(interactiveGestureType) {
-      toViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(animationType, transitionDuration: transitionDuration, interactiveGestureType: interactiveGestureTypeValue)
+    if let interactiveGestureType = interactiveGestureType {
+      toViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(animationType, transitionDuration: transitionDuration, interactiveGestureType: interactiveGestureType)
     } else {
       toViewController.transitioningDelegate = PresenterManager.sharedManager().retrievePresenter(animationType, transitionDuration: transitionDuration)
     }

--- a/IBAnimatable/TransitionAnimatable.swift
+++ b/IBAnimatable/TransitionAnimatable.swift
@@ -9,7 +9,7 @@ public protocol TransitionAnimatable: class {
   /**
    String value of `TransitionAnimationType` enum, used to specify the transition animations
    */
-  var transitionAnimationType: String? { get set }
+  var transitionAnimationType: TransitionAnimationType? { get set }
   
   /**
    Transition duration: default value should be `Double.NaN`. Need to use `Double` instead of `NSTimeInterval` because IB doesn't support `NSTimeInterval`
@@ -17,7 +17,7 @@ public protocol TransitionAnimatable: class {
   var transitionDuration: Double { get set }
   
   /**
-   String value of `InteractiveTransitionType` enum, used to specify the gesture to dismiss/pop current scence
+   String value of `InteractiveGestureType` enum, used to specify the gesture to dismiss/pop current scence
    */
-  var interactiveGestureType: String? { get set }
+  var interactiveGestureType: InteractiveGestureType? { get set }
 }

--- a/IBAnimatableApp/ContainerTransitionViewController.swift
+++ b/IBAnimatableApp/ContainerTransitionViewController.swift
@@ -33,22 +33,22 @@ private extension ContainerTransitionViewController {
   func createChildViewControllers() {
     var viewController = AnimatableViewController()
     viewController.view.backgroundColor = .blue
-    viewController.transitionAnimationType = "Explode"
+    viewController.transitionAnimationType = TransitionAnimationType.fromString("Explode")
     viewControllers.append(viewController)
    
     viewController = AnimatableViewController()
     viewController.view.backgroundColor = .green
-    viewController.transitionAnimationType = "Fold"
+    viewController.transitionAnimationType = TransitionAnimationType.fromString("Fold")
     viewControllers.append(viewController)
 
     viewController = AnimatableViewController()
     viewController.view.backgroundColor = .yellow
-    viewController.transitionAnimationType = "NatGeo"
+    viewController.transitionAnimationType = TransitionAnimationType.fromString("NatGeo")
     viewControllers.append(viewController)
     
     viewController = AnimatableViewController()
     viewController.view.backgroundColor = .red
-    viewController.transitionAnimationType = "Portal"
+    viewController.transitionAnimationType = TransitionAnimationType.fromString("Portal")
     viewControllers.append(viewController)
     
     cycleFromViewController(containerView, fromViewController: nil, toViewController: viewControllers[0])
@@ -56,7 +56,7 @@ private extension ContainerTransitionViewController {
   }
   
   func cycleFromViewController(_ containerView: UIView, fromViewController: AnimatableViewController?, toViewController: AnimatableViewController) {
-    guard let animationType = TransitionAnimationType.fromString(toViewController.transitionAnimationType ?? "") else {
+    guard let animationType = TransitionAnimationType.fromString(toViewController.transitionAnimationType?.stringValue ?? "") else {
       return
     }
     

--- a/IBAnimatableApp/TransitionPresentedViewController.swift
+++ b/IBAnimatableApp/TransitionPresentedViewController.swift
@@ -61,10 +61,8 @@ private extension TransitionPresentedViewController {
     }
     
     // No gesture for this animator
-    guard let interactiveGestureTypeString = self.interactiveGestureType,
-      let interactiveGestureType = InteractiveGestureType.fromString(interactiveGestureTypeString),
-      let transitionAnimationTypeString = self.transitionAnimationType,
-      let transitionAnimationType = TransitionAnimationType.fromString(transitionAnimationTypeString) else {
+    guard let interactiveGestureType = self.interactiveGestureType,
+      let transitionAnimationType = self.transitionAnimationType else {
         return
     }
     
@@ -77,14 +75,14 @@ private extension TransitionPresentedViewController {
     }
     
     // Set up the segues without dismiss interaction
-    var segueName = "IBAnimatable.Present" + extractAnimationType(transitionAnimationType) + "Segue"
+    var segueName = "IBAnimatable.Present" + extractAnimationType(transitionAnimationType.stringValue) + "Segue"
     
     if let segueClass = NSClassFromString(segueName) as? UIStoryboardSegue.Type {
       presentingSegueClass = segueClass
     }
     
     // Set up the segues with dismiss interaction
-    segueName = "IBAnimatable.Present" + extractAnimationType(transitionAnimationType) + "WithDismissInteractionSegue"
+    segueName = "IBAnimatable.Present" + extractAnimationType(transitionAnimationType.stringValue) + "WithDismissInteractionSegue"
     
     if let segueClass = NSClassFromString(segueName) as? UIStoryboardSegue.Type {
       presentingWithDismissInteractionSegueClass = segueClass

--- a/IBAnimatableApp/TransitionPushedViewController.swift
+++ b/IBAnimatableApp/TransitionPushedViewController.swift
@@ -18,7 +18,6 @@ class TransitionPushedViewController: UIViewController {
     }
     configureGestureLabel()
   }
-
 }
 
 private extension TransitionPushedViewController {
@@ -32,10 +31,8 @@ private extension TransitionPushedViewController {
     }
     
     // No gesture for this animator
-    guard let interactiveGestureTypeString = navigationController.interactiveGestureType,
-      let interactiveGestureType = InteractiveGestureType.fromString(interactiveGestureTypeString),
-      let transitionAnimationTypeString = navigationController.transitionAnimationType,
-      let transitionAnimationType = TransitionAnimationType.fromString(transitionAnimationTypeString) else {
+    guard let interactiveGestureType = navigationController.interactiveGestureType,
+      let transitionAnimationType = navigationController.transitionAnimationType else {
       return
     }
     

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -24,12 +24,13 @@ class TransitionTableViewController: UITableViewController {
     guard let toNavigationController = segue.destination as? AnimatableNavigationController, let indexPath = tableView.indexPathForSelectedRow else {
       return
     }
+    let transitionString = transitionAnimations[(indexPath as NSIndexPath).section][(indexPath as NSIndexPath).row]
     
-    let transitionAnimationType = String(transitionAnimations[(indexPath as NSIndexPath).section][(indexPath as NSIndexPath).row])
+    let transitionAnimationType = TransitionAnimationType.fromString(transitionString)
     
     // Set the transition animation type for `AnimatableNavigationController`, used for Push/Pop transitions
     toNavigationController.transitionAnimationType = transitionAnimationType
-    toNavigationController.navigationBar.topItem?.title = transitionAnimationType
+    toNavigationController.navigationBar.topItem?.title = transitionString
    
     // Set the transition animation type for `AnimatableViewController`, used for Present/Dismiss transitions
     if let toViewController = toNavigationController.topViewController as? TransitionViewController {

--- a/IBAnimatableApp/TransitionViewController.swift
+++ b/IBAnimatableApp/TransitionViewController.swift
@@ -14,7 +14,8 @@ class TransitionViewController: AnimatableViewController {
     super.viewDidLoad()
     
     // Transition animations start with `System` do not support Present transition, so hide it
-    if let animationType = transitionAnimationType, animationType.hasPrefix("System") {
+    if let animationType = transitionAnimationType,
+      animationType.stringValue.hasPrefix("System") {
       // Cannot use `hidden` here because of `UIStackView`
       presentButton.alpha = 0
     }


### PR DESCRIPTION
TransitionAnimatable Updated to use enums. 
for instance : 
`var transitionAnimationType: String? { get set }`
becomes
`var transitionAnimationType: TransitionAnimationType? { get set }`

I have one interrogation : 
Should it be an optional or not (adding a none clause) ? 
I don't know enough the TransitionAnimatable system to decide about this.

PS: Seems that I didn't made the last Xcode beta update. 
There is maybe some errors, I will update it tomorrow
