### PR TITLE
Introducing AnimatableActivityIndicatorView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable changes to this project will be documented in this file.
 - `AnimatableScrollView` doesn't conform anymore to `BlurDesignable`
  
 #### Enhancements
-None
+
+- Introducing `AnimatableActivityIndicatorView` to support custom activity indicator animations. Currently supported:
+  - BallBeats
+  - More will come soon!
 
 #### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - Introducing `AnimatableActivityIndicatorView` to support custom activity indicator animations. Currently supported:
   - BallBeats
+  - BallPulseSync
+  - LineScalePulseOut
   - More will come soon!
 
 #### Bugfixes

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -19,6 +19,7 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 | UIViewController | AnimatableViewController | |
 | UINavigationController | AnimatableNavigationController | |
 | UISlider | AnimatableSlider | |
+| UIActivityIndicatorView | AnimatableActivityIndicatorView | [Lis of animations available](./ActivityIndicator.md) |
 
 ### Designable protocols
 `IBAnimatable` provides a set of Designable protocols as below. Because of the power of protocol-oriented programming in Swift, we don't even have to use Animatable default UI elements e.g. `AnimatableView` to unlocked the power of `IBAnimatable`. We can conform to `IBAnimatable` protocols to use the default implementation in protocol extension to create other custom UI elements.
@@ -182,6 +183,18 @@ Easily add color layer on top of the UI element especially `AnimatableImageView`
 | x | CGFloat | Used to specify the absolute x to move in `MoveTo` animation and x offset in `MoveBy`. When used in `MoveBy`, negative means moving left and positive means moving right. The default value is `CGFloat.NaN` |
 | y | CGFloat | Used to specify the absolute y to move in `MoveTo` animation and y offset in `MoveBy`. When used in `MoveBy`, negative means moving up and positive means moving down. The default value is `CGFloat.NaN`|
 
+### TransitionAnimatable protocol
+| Property name | Data type | Description |
+| ------------- |:-------------:| ----- |
+| transitionAnimationType | Optional&lt;String> | Supported transition animations. Tap on "Playground" button to see all predefined transition animations, e.g. `Fade`, `SystemCube(Left)` and `SystemPageCurl(Bottom)`. The transition type starts with `System` can only use in Push/Pop transitions, not Present/Dismiss transitions. Note: For `SystemRotate` seems that only `SystemRotate(90)` is working. |
+| transitionDuration | Double | transition duration. The default value is defined in [`Constants`](../IBAnimatable/Constants.swift) (0.7 seconds) |
+| interactiveGestureType | Optional&lt;String> | interactive gesture type. used to specify the gesture to dismiss/pop current scence. All supported interactive gesture types are in [`InteractiveGestureType`](../IBAnimatable/InteractiveGestureType.swift) |
+
+Also see [Transition Animators](Transitions.md#transition-animators) and [Interactive Animators](Transitions.md#interactive-animators)
+
+### ActivityIndicatorAnimatable
+
+Fully documented in [Activity indicator animations](ActivityIndicator.md)
 
 ### Extension
 #### UIViewController
@@ -196,15 +209,6 @@ With these methods, we can navigate back or dismiss current ViewController witho
 | Method name | Description |
 | ------------- | ----- |
 | class func animate(animation: AnimatableExecution, completion: AnimatableCompletion? = nil) | Simplify CALayer animations with completion closure |
-
-### TransitionAnimatable protocol
-| Property name | Data type | Description |
-| ------------- |:-------------:| ----- |
-| transitionAnimationType | Optional&lt;String> | Supported transition animations. Tap on "Playground" button to see all predefined transition animations, e.g. `Fade`, `SystemCube(Left)` and `SystemPageCurl(Bottom)`. The transition type starts with `System` can only use in Push/Pop transitions, not Present/Dismiss transitions. Note: For `SystemRotate` seems that only `SystemRotate(90)` is working. |
-| transitionDuration | Double | transition duration. The default value is defined in [`Constants`](../IBAnimatable/Constants.swift) (0.7 seconds) |
-| interactiveGestureType | Optional&lt;String> | interactive gesture type. used to specify the gesture to dismiss/pop current scence. All supported interactive gesture types are in [`InteractiveGestureType`](../IBAnimatable/InteractiveGestureType.swift) |
-
-Also see [Transition Animators](Transitions.md#transition-animators) and [Interactive Animators](Transitions.md#interactive-animators)
 
 ### Segues
 See [Segues](Transitions.md#segues)

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -19,7 +19,7 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 | UIViewController | AnimatableViewController | |
 | UINavigationController | AnimatableNavigationController | |
 | UISlider | AnimatableSlider | |
-| UIActivityIndicatorView | AnimatableActivityIndicatorView | [Lis of animations available](./ActivityIndicator.md) |
+| UIActivityIndicatorView | AnimatableActivityIndicatorView | [List of animations available](./ActivityIndicator.md) |
 
 ### Designable protocols
 `IBAnimatable` provides a set of Designable protocols as below. Because of the power of protocol-oriented programming in Swift, we don't even have to use Animatable default UI elements e.g. `AnimatableView` to unlocked the power of `IBAnimatable`. We can conform to `IBAnimatable` protocols to use the default implementation in protocol extension to create other custom UI elements.

--- a/Documentation/ActivityIndicator.md
+++ b/Documentation/ActivityIndicator.md
@@ -1,0 +1,31 @@
+# Activity indicator animations
+
+`IBAnimatable` provide a broad set of nice loading animations. We can use them in interface builder as well as in code by using `AnimatableActivityIndicatorView`.
+
+You can see an example of each animation in the demo app. Launch the app, then tap on "Playground" button, and tap on "Activity Indicator" cell. Choose your animation, and see the result.
+
+### Properties
+
+| Property name | Data type | Description |
+| ------------- |:-------------:| ----- |
+| animationType | String | Supported activity indicator animations. Take a look at the [supported animations](#supported-animations)  |
+| color | UIColor | Color of the activity indicator. Default is black. |
+| hidesWhenStopped | Bool | Controls whether the receiver is hidden when the animation is stopped. Default is true |
+| isAnimating | Bool | Wether the activityIndicator is animating or not |
+
+### Methods available
+
+| Method name | Description |
+| ------------- | ----- |
+| startAnimating() | Start the animation |
+| stopAnimating() | Stop the animation. The activityIndicator will be hidden if `hidesWhenStopped` value is `true`. |
+
+
+###Supported animation:
+
+1. [BallBeat](#ballbeat)
+
+### BallBeat
+
+![ActivityIndicator - BallBeat](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorBallBeat.gif)
+

--- a/Documentation/ActivityIndicators.md
+++ b/Documentation/ActivityIndicators.md
@@ -24,8 +24,17 @@ You can see an example of each animation in the demo app. Launch the app, then t
 ###Supported animation:
 
 1. [BallBeat](#ballbeat)
+2. [BallPulseSync](#ballpulsesync)
+3. [LineScalePulseOut](#linescalepulseout)
 
 ### BallBeat
 
 ![ActivityIndicator - BallBeat](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorBallBeat.gif)
 
+### BallPulseSync
+
+![ActivityIndicator - BallPulseSync](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorBallPulseSync.gif)
+
+### LineScalePulseOut
+
+![ActivityIndicator - LineScalePulseOut](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorLineScalePulseOut.gif)

--- a/Documentation/ActivityIndicators.md
+++ b/Documentation/ActivityIndicators.md
@@ -1,6 +1,6 @@
 # Activity indicator animations
 
-`IBAnimatable` provide a broad set of nice loading animations. We can use them in interface builder as well as in code by using `AnimatableActivityIndicatorView`.
+`IBAnimatable` provides a broad set of nice loading animations. We can use them in Interface Builder as well as in code by using `AnimatableActivityIndicatorView`.
 
 You can see an example of each animation in the demo app. Launch the app, then tap on "Playground" button, and tap on "Activity Indicator" cell. Choose your animation, and see the result.
 

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -1,0 +1,48 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+public protocol ActivityIndicatorAnimatable: class {
+  var animationType: String { get set }
+  var color: UIColor { get set }
+  var hidesWhenStopped: Bool { get set }
+  var isAnimating: Bool { get set }
+}
+
+public extension ActivityIndicatorAnimatable where Self: UIView {
+
+  public func startAnimating() {
+    hidden = false
+    configLayer()
+    isAnimating = true
+  }
+
+  public func stopAnimating() {
+    layer.sublayers = nil
+    isAnimating = false
+    hidden = hidesWhenStopped ? true : hidden
+  }
+
+}
+
+private extension ActivityIndicatorAnimatable where Self: UIView {
+
+  func configLayer() {
+    guard layer.sublayers == nil else {
+      return
+    }
+
+    layer.sublayers = nil
+    let type = ActivityIndicatorType.fromString(animationType)
+    guard type != .None else {
+      return
+    }
+
+    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(type)
+    activityIndicator.configAnimation(in: layer, size: bounds.size, color: color)
+    layer.speed = 1
+  }
+
+}

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -34,7 +34,6 @@ private extension ActivityIndicatorAnimatable where Self: UIView {
       return
     }
 
-    layer.sublayers = nil
     let type = ActivityIndicatorType.fromString(animationType)
     guard type != .None else {
       return

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -22,7 +22,9 @@ public extension ActivityIndicatorAnimatable where Self: UIView {
   public func stopAnimating() {
     layer.sublayers = nil
     isAnimating = false
-    hidden = hidesWhenStopped ? true : hidden
+    if hidesWhenStopped {
+      hidden = true
+    }
   }
 
 }

--- a/IBAnimatable/ActivityIndicatorAnimating.swift
+++ b/IBAnimatable/ActivityIndicatorAnimating.swift
@@ -1,0 +1,10 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public protocol ActivityIndicatorAnimating {
+  func configAnimation(in layer: CALayer, size: CGSize, color: UIColor)
+}

--- a/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
@@ -1,0 +1,70 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public class ActivityIndicatorAnimationBallBeat: ActivityIndicatorAnimating {
+
+  // MARK: Properties
+
+  private let duration: CFTimeInterval = 0.7
+
+  // MARK: ActivityIndicatorAnimating
+
+  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+    let circleSpacing: CGFloat = 2
+    let circleSize = (size.width - circleSpacing * 2) / 3
+    let x = (layer.bounds.size.width - size.width) / 2
+    let y = (layer.bounds.size.height - circleSize) / 2
+    let beginTime = CACurrentMediaTime()
+    let beginTimes = [0.35, 0, 0.35]
+
+    // Draw circles
+    for i in 0 ..< 3 {
+      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
+                         y: y,
+                         width: circleSize,
+                         height: circleSize)
+      animation.beginTime = beginTime + beginTimes[i]
+      circle.frame = frame
+      circle.addAnimation(animation, forKey: "animation")
+      layer.addSublayer(circle)
+    }
+  }
+
+}
+
+// MARK: - Setup
+
+private extension ActivityIndicatorAnimationBallBeat {
+
+  var scaleAnimation: CAKeyframeAnimation {
+    let scaleAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
+    scaleAnimation.keyTimes = [0, 0.5, 1]
+    scaleAnimation.values = [1, 0.75, 1]
+    scaleAnimation.duration = duration
+    return scaleAnimation
+  }
+
+  var opacityAnimation: CAKeyframeAnimation {
+    let opacityAnimation = CAKeyframeAnimation(keyPath: "opacity")
+    opacityAnimation.keyTimes = [0, 0.5, 1]
+    opacityAnimation.values = [1, 0.2, 1]
+    opacityAnimation.duration = duration
+    return opacityAnimation
+  }
+
+  var animation: CAAnimationGroup {
+    let animation = CAAnimationGroup()
+    animation.animations = [scaleAnimation, opacityAnimation]
+    animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear)
+    animation.duration = duration
+    animation.repeatCount = HUGE
+    animation.removedOnCompletion = false
+    return animation
+  }
+
+}

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -1,0 +1,63 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating {
+
+  // MARK: Properties
+
+  private let duration: CFTimeInterval = 0.6
+  private var size: CGSize = .zero
+  private var circleSize: CGFloat = 0
+
+  // MARK: ActivityIndicatorAnimating
+
+  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+    let circleSpacing: CGFloat = 2
+    self.size = size
+    circleSize = (size.width - circleSpacing * 2) / 3
+    let x = (layer.bounds.size.width - size.width) / 2
+    let y = (layer.bounds.size.height - circleSize) / 2
+    let beginTime = CACurrentMediaTime()
+    let beginTimes: [CFTimeInterval] = [0.07, 0.14, 0.21]
+    let animation = self.animation
+    
+    // Draw circles
+    for i in 0 ..< 3 {
+      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
+                         y: y,
+                         width: circleSize,
+                         height: circleSize)
+
+      animation.beginTime = beginTime + beginTimes[i]
+      circle.frame = frame
+      circle.addAnimation(animation, forKey: "animation")
+      layer.addSublayer(circle)
+    }
+
+  }
+
+}
+
+// MARK: - Setup
+
+private extension ActivityIndicatorAnimationBallPulseSync {
+
+  var animation: CAKeyframeAnimation {
+    let deltaY = (size.height / 2 - circleSize / 2) / 2
+    let timingFunciton = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+    let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
+    animation.keyTimes = [0, 0.33, 0.66, 1]
+    animation.timingFunctions = [timingFunciton, timingFunciton, timingFunciton]
+    animation.values = [0, deltaY, -deltaY, 0]
+    animation.duration = duration
+    animation.repeatCount = HUGE
+    animation.removedOnCompletion = false
+    return animation
+  }
+
+}

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -1,0 +1,59 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnimating {
+
+  // MARK: Properties
+
+  private let duration: CFTimeInterval = 1
+
+  // MARK: ActivityIndicatorAnimating
+
+  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+    let lineSize = size.width / 9
+    let x = (layer.bounds.size.width - size.width) / 2
+    let y = (layer.bounds.size.height - size.height) / 2
+    let duration: CFTimeInterval = 1
+    let beginTime = CACurrentMediaTime()
+    let beginTimes = [0.4, 0.2, 0, 0.2, 0.4]
+    let animation = self.animation
+
+    // Draw lines
+    for i in 0 ..< 5 {
+      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
+                         y: y,
+                         width: lineSize,
+                         height: size.height)
+
+      animation.beginTime = beginTime + beginTimes[i]
+      line.frame = frame
+      line.addAnimation(animation, forKey: "animation")
+      layer.addSublayer(line)
+    }
+
+  }
+
+}
+
+// MARK: - Setup
+
+private extension ActivityIndicatorAnimationLineScalePulseOut {
+
+  var animation: CAKeyframeAnimation {
+    let timingFunction = CAMediaTimingFunction(controlPoints: 0.85, 0.25, 0.37, 0.85)
+    let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")
+    animation.keyTimes = [0, 0.5, 1]
+    animation.timingFunctions = [timingFunction, timingFunction]
+    animation.values = [1, 0.4, 1]
+    animation.duration = duration
+    animation.repeatCount = HUGE
+    animation.removedOnCompletion = false
+    return animation
+  }
+
+}

--- a/IBAnimatable/ActivityIndicatorFactory.swift
+++ b/IBAnimatable/ActivityIndicatorFactory.swift
@@ -12,6 +12,10 @@ public struct ActivityIndicatorFactory {
       fatalError()
     case .BallBeat:
       return ActivityIndicatorAnimationBallBeat()
+    case .BallPulseSync:
+      return ActivityIndicatorAnimationBallPulseSync()
+    case .LineScalePulseOut:
+      return ActivityIndicatorAnimationLineScalePulseOut()
     }
   }
 }

--- a/IBAnimatable/ActivityIndicatorFactory.swift
+++ b/IBAnimatable/ActivityIndicatorFactory.swift
@@ -1,0 +1,17 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public struct ActivityIndicatorFactory {
+  public static func generateActivityIndicator(activityIndicatorType: ActivityIndicatorType) -> ActivityIndicatorAnimating {
+    switch activityIndicatorType {
+    case .None:
+      fatalError()
+    case .BallBeat:
+      return ActivityIndicatorAnimationBallBeat()
+    }
+  }
+}

--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -18,113 +18,200 @@ enum ActivityIndicatorShape {
   case Pacman
 
   func createLayerWith(size size: CGSize, color: UIColor) -> CALayer {
-    let layer: CAShapeLayer = CAShapeLayer()
-    var path: UIBezierPath = UIBezierPath()
     let lineWidth: CGFloat = 2
-
+    let layer: CAShapeLayer
     switch self {
     case .Circle:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius: size.width / 2,
-                            startAngle: 0,
-                            endAngle: CGFloat(2 * M_PI),
-                            clockwise: false)
-      layer.fillColor = color.CGColor
+      return circleShapeLayer(with: size, color: color)
     case .CircleSemi:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius: size.width / 2,
-                            startAngle: CGFloat(-M_PI / 6),
-                            endAngle: CGFloat(-5 * M_PI / 6),
-                            clockwise: false)
-      path.closePath()
-      layer.fillColor = color.CGColor
+      return semiCircleShapeLayer(with: size, color: color)
     case .Ring:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius: size.width / 2,
-                            startAngle: 0,
-                            endAngle: CGFloat(2 * M_PI),
-                            clockwise: false)
-      layer.fillColor = nil
-      layer.strokeColor = color.CGColor
-      layer.lineWidth = lineWidth
+      return ringShapeLayer(with: size, color: color, lineWidth: lineWidth)
     case .RingTwoHalfVertical:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius:size.width / 2,
-                            startAngle:CGFloat(-3 * M_PI_4),
-                            endAngle:CGFloat(-M_PI_4),
-                            clockwise:true)
-      path.moveToPoint(
-        CGPoint(x: size.width / 2 - size.width / 2 * CGFloat(cos(M_PI_4)),
-          y: size.height / 2 + size.height / 2 * CGFloat(sin(M_PI_4)))
-      )
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius:size.width / 2,
-                            startAngle:CGFloat(-5 * M_PI_4),
-                            endAngle:CGFloat(-7 * M_PI_4),
-                            clockwise:false)
-      layer.fillColor = nil
-      layer.strokeColor = color.CGColor
-      layer.lineWidth = lineWidth
+      return ringTwoHalfVerticalShapeLayer(with: size, color: color, lineWidth: lineWidth)
     case .RingTwoHalfHorizontal:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius:size.width / 2,
-                            startAngle:CGFloat(3 * M_PI_4),
-                            endAngle:CGFloat(5 * M_PI_4),
-                            clockwise:true)
-      path.moveToPoint(
-        CGPoint(x: size.width / 2 + size.width / 2 * CGFloat(cos(M_PI_4)),
-          y: size.height / 2 - size.height / 2 * CGFloat(sin(M_PI_4)))
-      )
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius:size.width / 2,
-                            startAngle:CGFloat(-M_PI_4),
-                            endAngle:CGFloat(M_PI_4),
-                            clockwise:true)
-      layer.fillColor = nil
-      layer.strokeColor = color.CGColor
-      layer.lineWidth = lineWidth
+      return ringTwoHalfHorizontalShapeLayer(with: size, color: color, lineWidth: lineWidth)
     case .RingThirdFour:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius: size.width / 2,
-                            startAngle: CGFloat(-3 * M_PI_4),
-                            endAngle: CGFloat(-M_PI_4),
-                            clockwise: false)
-      layer.fillColor = nil
-      layer.strokeColor = color.CGColor
-      layer.lineWidth = 2
+      return ringThirdFourShapeLayer(with: size, color: color, lineWidth: lineWidth)
     case .Rectangle:
-      path.moveToPoint(CGPoint(x: 0, y: 0))
-      path.addLineToPoint(CGPoint(x: size.width, y: 0))
-      path.addLineToPoint(CGPoint(x: size.width, y: size.height))
-      path.addLineToPoint(CGPoint(x: 0, y: size.height))
-      layer.fillColor = color.CGColor
+      return rectangleShapeLayer(with: size, color: color)
     case .Triangle:
-      let offsetY = size.height / 4
-
-      path.moveToPoint(CGPoint(x: 0, y: size.height - offsetY))
-      path.addLineToPoint(CGPoint(x: size.width / 2, y: size.height / 2 - offsetY))
-      path.addLineToPoint(CGPoint(x: size.width, y: size.height - offsetY))
-      path.closePath()
-      layer.fillColor = color.CGColor
+      return triangleShapeLayer(with: size, color: color)
     case .Line:
-      path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: size.width, height: size.height),
-                          cornerRadius: size.width / 2)
-      layer.fillColor = color.CGColor
+      return lineShapeLayer(with: size, color: color)
     case .Pacman:
-      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
-                            radius: size.width / 4,
-                            startAngle: 0,
-                            endAngle: CGFloat(2 * M_PI),
-                            clockwise: true)
-      layer.fillColor = nil
-      layer.strokeColor = color.CGColor
-      layer.lineWidth = size.width / 2
+      return pacmanShapeLayer(with: size, color: color)
     }
+  }
 
+  func completingLayer(layer: CAShapeLayer, path: UIBezierPath, size: CGSize) -> CAShapeLayer {
     layer.backgroundColor = nil
     layer.path = path.CGPath
     layer.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-
     return layer
   }
+
+}
+
+// MARK: - Circles
+
+private extension ActivityIndicatorShape {
+
+  func circleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius: size.width / 2,
+                          startAngle: 0,
+                          endAngle: CGFloat(2 * M_PI),
+                          clockwise: false)
+    layer.fillColor = color.CGColor
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func semiCircleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius: size.width / 2,
+                          startAngle: CGFloat(-M_PI / 6),
+                          endAngle: CGFloat(-5 * M_PI / 6),
+                          clockwise: false)
+    path.closePath()
+    layer.fillColor = color.CGColor
+    return completingLayer(layer, path: path, size: size)
+  }
+
+}
+
+// MARK: - Rings
+
+private extension ActivityIndicatorShape {
+
+  func ringShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius: size.width / 2,
+                          startAngle: 0,
+                          endAngle: CGFloat(2 * M_PI),
+                          clockwise: false)
+    layer.fillColor = nil
+    layer.strokeColor = color.CGColor
+    layer.lineWidth = lineWidth
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func ringTwoHalfVerticalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius:size.width / 2,
+                          startAngle:CGFloat(-3 * M_PI_4),
+                          endAngle:CGFloat(-M_PI_4),
+                          clockwise:true)
+    path.moveToPoint(
+      CGPoint(x: size.width / 2 - size.width / 2 * CGFloat(cos(M_PI_4)),
+        y: size.height / 2 + size.height / 2 * CGFloat(sin(M_PI_4)))
+    )
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius:size.width / 2,
+                          startAngle:CGFloat(-5 * M_PI_4),
+                          endAngle:CGFloat(-7 * M_PI_4),
+                          clockwise:false)
+    layer.fillColor = nil
+    layer.strokeColor = color.CGColor
+    layer.lineWidth = lineWidth
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func ringTwoHalfHorizontalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius:size.width / 2,
+                          startAngle:CGFloat(3 * M_PI_4),
+                          endAngle:CGFloat(5 * M_PI_4),
+                          clockwise:true)
+    path.moveToPoint(
+      CGPoint(x: size.width / 2 + size.width / 2 * CGFloat(cos(M_PI_4)),
+        y: size.height / 2 - size.height / 2 * CGFloat(sin(M_PI_4)))
+    )
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius:size.width / 2,
+                          startAngle:CGFloat(-M_PI_4),
+                          endAngle:CGFloat(M_PI_4),
+                          clockwise:true)
+    layer.fillColor = nil
+    layer.strokeColor = color.CGColor
+    layer.lineWidth = lineWidth
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func ringThirdFourShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius: size.width / 2,
+                          startAngle: CGFloat(-3 * M_PI_4),
+                          endAngle: CGFloat(-M_PI_4),
+                          clockwise: false)
+    layer.fillColor = nil
+    layer.strokeColor = color.CGColor
+    layer.lineWidth = lineWidth
+    return completingLayer(layer, path: path, size: size)
+  }
+
+}
+
+// MARK: - Others
+
+private extension ActivityIndicatorShape {
+
+  func rectangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.moveToPoint(CGPoint(x: 0, y: 0))
+    path.addLineToPoint(CGPoint(x: size.width, y: 0))
+    path.addLineToPoint(CGPoint(x: size.width, y: size.height))
+    path.addLineToPoint(CGPoint(x: 0, y: size.height))
+    layer.fillColor = color.CGColor
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func triangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    let offsetY = size.height / 4
+    path.moveToPoint(CGPoint(x: 0, y: size.height - offsetY))
+    path.addLineToPoint(CGPoint(x: size.width / 2, y: size.height / 2 - offsetY))
+    path.addLineToPoint(CGPoint(x: size.width, y: size.height - offsetY))
+    path.closePath()
+    layer.fillColor = color.CGColor
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func lineShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: size.width, height: size.height),
+                        cornerRadius: size.width / 2)
+    layer.fillColor = color.CGColor
+    return completingLayer(layer, path: path, size: size)
+  }
+
+  func pacmanShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+    let layer = CAShapeLayer()
+    var path = UIBezierPath()
+    path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                          radius: size.width / 4,
+                          startAngle: 0,
+                          endAngle: CGFloat(2 * M_PI),
+                          clockwise: true)
+    layer.fillColor = nil
+    layer.strokeColor = color.CGColor
+    layer.lineWidth = size.width / 2
+    return completingLayer(layer, path: path, size: size)
+  }
+
 }

--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -1,0 +1,130 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+enum ActivityIndicatorShape {
+  case Circle
+  case CircleSemi
+  case Ring
+  case RingTwoHalfVertical
+  case RingTwoHalfHorizontal
+  case RingThirdFour
+  case Rectangle
+  case Triangle
+  case Line
+  case Pacman
+
+  func createLayerWith(size size: CGSize, color: UIColor) -> CALayer {
+    let layer: CAShapeLayer = CAShapeLayer()
+    var path: UIBezierPath = UIBezierPath()
+    let lineWidth: CGFloat = 2
+
+    switch self {
+    case .Circle:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius: size.width / 2,
+                            startAngle: 0,
+                            endAngle: CGFloat(2 * M_PI),
+                            clockwise: false)
+      layer.fillColor = color.CGColor
+    case .CircleSemi:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius: size.width / 2,
+                            startAngle: CGFloat(-M_PI / 6),
+                            endAngle: CGFloat(-5 * M_PI / 6),
+                            clockwise: false)
+      path.closePath()
+      layer.fillColor = color.CGColor
+    case .Ring:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius: size.width / 2,
+                            startAngle: 0,
+                            endAngle: CGFloat(2 * M_PI),
+                            clockwise: false)
+      layer.fillColor = nil
+      layer.strokeColor = color.CGColor
+      layer.lineWidth = lineWidth
+    case .RingTwoHalfVertical:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius:size.width / 2,
+                            startAngle:CGFloat(-3 * M_PI_4),
+                            endAngle:CGFloat(-M_PI_4),
+                            clockwise:true)
+      path.moveToPoint(
+        CGPoint(x: size.width / 2 - size.width / 2 * CGFloat(cos(M_PI_4)),
+          y: size.height / 2 + size.height / 2 * CGFloat(sin(M_PI_4)))
+      )
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius:size.width / 2,
+                            startAngle:CGFloat(-5 * M_PI_4),
+                            endAngle:CGFloat(-7 * M_PI_4),
+                            clockwise:false)
+      layer.fillColor = nil
+      layer.strokeColor = color.CGColor
+      layer.lineWidth = lineWidth
+    case .RingTwoHalfHorizontal:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius:size.width / 2,
+                            startAngle:CGFloat(3 * M_PI_4),
+                            endAngle:CGFloat(5 * M_PI_4),
+                            clockwise:true)
+      path.moveToPoint(
+        CGPoint(x: size.width / 2 + size.width / 2 * CGFloat(cos(M_PI_4)),
+          y: size.height / 2 - size.height / 2 * CGFloat(sin(M_PI_4)))
+      )
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius:size.width / 2,
+                            startAngle:CGFloat(-M_PI_4),
+                            endAngle:CGFloat(M_PI_4),
+                            clockwise:true)
+      layer.fillColor = nil
+      layer.strokeColor = color.CGColor
+      layer.lineWidth = lineWidth
+    case .RingThirdFour:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius: size.width / 2,
+                            startAngle: CGFloat(-3 * M_PI_4),
+                            endAngle: CGFloat(-M_PI_4),
+                            clockwise: false)
+      layer.fillColor = nil
+      layer.strokeColor = color.CGColor
+      layer.lineWidth = 2
+    case .Rectangle:
+      path.moveToPoint(CGPoint(x: 0, y: 0))
+      path.addLineToPoint(CGPoint(x: size.width, y: 0))
+      path.addLineToPoint(CGPoint(x: size.width, y: size.height))
+      path.addLineToPoint(CGPoint(x: 0, y: size.height))
+      layer.fillColor = color.CGColor
+    case .Triangle:
+      let offsetY = size.height / 4
+
+      path.moveToPoint(CGPoint(x: 0, y: size.height - offsetY))
+      path.addLineToPoint(CGPoint(x: size.width / 2, y: size.height / 2 - offsetY))
+      path.addLineToPoint(CGPoint(x: size.width, y: size.height - offsetY))
+      path.closePath()
+      layer.fillColor = color.CGColor
+    case .Line:
+      path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: size.width, height: size.height),
+                          cornerRadius: size.width / 2)
+      layer.fillColor = color.CGColor
+    case .Pacman:
+      path.addArcWithCenter(CGPoint(x: size.width / 2, y: size.height / 2),
+                            radius: size.width / 4,
+                            startAngle: 0,
+                            endAngle: CGFloat(2 * M_PI),
+                            clockwise: true)
+      layer.fillColor = nil
+      layer.strokeColor = color.CGColor
+      layer.lineWidth = size.width / 2
+    }
+
+    layer.backgroundColor = nil
+    layer.path = path.CGPath
+    layer.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+
+    return layer
+  }
+}

--- a/IBAnimatable/ActivityIndicatorType.swift
+++ b/IBAnimatable/ActivityIndicatorType.swift
@@ -8,10 +8,16 @@ import UIKit
 public enum ActivityIndicatorType: String {
   case None
   case BallBeat
+  case BallPulseSync
+  case LineScalePulseOut
 
   public static func fromString(string: String) -> ActivityIndicatorType {
     if string.hasPrefix("BallBeat") {
       return ActivityIndicatorType.BallBeat
+    } else if string.hasPrefix("BallPulseSync") {
+      return ActivityIndicatorType.BallPulseSync
+    } else if string.hasPrefix("LineScalePulseOut") {
+      return ActivityIndicatorType.LineScalePulseOut
     }
     return None
   }

--- a/IBAnimatable/ActivityIndicatorType.swift
+++ b/IBAnimatable/ActivityIndicatorType.swift
@@ -1,0 +1,19 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public enum ActivityIndicatorType: String {
+  case None
+  case BallBeat
+
+  public static func fromString(string: String) -> ActivityIndicatorType {
+    if string.hasPrefix("BallBeat") {
+      return ActivityIndicatorType.BallBeat
+    }
+    return None
+  }
+
+}

--- a/IBAnimatable/AnimatableActivityIndicatorView.swift
+++ b/IBAnimatable/AnimatableActivityIndicatorView.swift
@@ -1,0 +1,19 @@
+//
+//  AnimatableIndicatorView.swift
+//  IBAnimatableApp
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
+
+  // MARK: ActivityIndicatorAnimatable
+  @IBInspectable public var animationType: String = "BallBeats"
+  @IBInspectable public var color: UIColor = .blackColor()
+  @IBInspectable public var hidesWhenStopped: Bool = true
+  public var isAnimating: Bool = false
+
+}

--- a/IBAnimatable/AnimatableActivityIndicatorView.swift
+++ b/IBAnimatable/AnimatableActivityIndicatorView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
+@IBDesignable public class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
 
   // MARK: ActivityIndicatorAnimatable
   @IBInspectable public var animationType: String = "BallBeats"

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -149,6 +149,13 @@
 		E2DAD63B1D5F5CC600333ABF /* DropDownAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DAD63A1D5F5CC600333ABF /* DropDownAnimator.swift */; };
 		E2E28E6C1C6A6C30003F3852 /* GradientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6A1C6A6C30003F3852 /* GradientType.swift */; };
 		E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */; };
+		E2E62B771D69B17900294A73 /* ActivityIndicatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B761D69B17900294A73 /* ActivityIndicatorType.swift */; };
+		E2E62B791D69B20500294A73 /* AnimatableActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B781D69B20500294A73 /* AnimatableActivityIndicatorView.swift */; };
+		E2E62B7B1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B7A1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift */; };
+		E2E62B801D69B5F000294A73 /* ActivityIndicatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B7F1D69B5F000294A73 /* ActivityIndicatorFactory.swift */; };
+		E2E62B821D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */; };
+		E2E62B841D69B63800294A73 /* ActivityIndicatorAnimating.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B831D69B63800294A73 /* ActivityIndicatorAnimating.swift */; };
+		E2E62B861D69B6B400294A73 /* ActivityIndicatorShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B851D69B6B400294A73 /* ActivityIndicatorShape.swift */; };
 		E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */; };
 		E2F45B591CDBAF39001D2E37 /* PresentFlipSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B581CDBAF39001D2E37 /* PresentFlipSegue.swift */; };
 		E2F45B5B1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B5A1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift */; };
@@ -317,6 +324,13 @@
 		E2E28E6A1C6A6C30003F3852 /* GradientType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientType.swift; sourceTree = "<group>"; };
 		E2E28E6D1C6A6D22003F3852 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		E2E28E711C6A6E70003F3852 /* GradientsTypeScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradientsTypeScript.swift; path = Scripts/GradientsTypeScript.swift; sourceTree = SOURCE_ROOT; };
+		E2E62B761D69B17900294A73 /* ActivityIndicatorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorType.swift; sourceTree = "<group>"; };
+		E2E62B781D69B20500294A73 /* AnimatableActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableActivityIndicatorView.swift; sourceTree = "<group>"; };
+		E2E62B7A1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimatable.swift; sourceTree = "<group>"; };
+		E2E62B7F1D69B5F000294A73 /* ActivityIndicatorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorFactory.swift; sourceTree = "<group>"; };
+		E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallBeat.swift; sourceTree = "<group>"; };
+		E2E62B831D69B63800294A73 /* ActivityIndicatorAnimating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimating.swift; sourceTree = "<group>"; };
+		E2E62B851D69B6B400294A73 /* ActivityIndicatorShape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorShape.swift; sourceTree = "<group>"; };
 		E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlipAnimator.swift; sourceTree = "<group>"; };
 		E2F45B581CDBAF39001D2E37 /* PresentFlipSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFlipSegue.swift; sourceTree = "<group>"; };
 		E2F45B5A1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFlipWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
@@ -551,6 +565,7 @@
 				AE6F18761BFD4A3200CFDF4F /* view */,
 				AE0FAD3F1C1ED2BD00B5289B /* controller */,
 				AE154B0B1C7880680093C05B /* animator */,
+				E2E62B7C1D69B2B200294A73 /* activity indicator */,
 				AE0FAD391C1ECA2900B5289B /* extension */,
 				AE0FAD3E1C1ED26A00B5289B /* segue */,
 				AE154B2A1C7BB5370093C05B /* common */,
@@ -566,6 +581,7 @@
 				AED1A1241BFEA328001346FA /* Animatable */,
 				AED1A1231BFEA319001346FA /* Designable */,
 				AE154B861C7D1AA10093C05B /* TransitionAnimatable */,
+				E2E62B871D69BBA000294A73 /* ActivityIndicator */,
 			);
 			name = protocol;
 			sourceTree = "<group>";
@@ -588,6 +604,7 @@
 				AED1A10D1BFE983A001346FA /* AnimatableTextView.swift */,
 				E20884B41D1ED0F800E4101E /* AnimatableSlider.swift */,
 				AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */,
+				E2E62B781D69B20500294A73 /* AnimatableActivityIndicatorView.swift */,
 			);
 			name = view;
 			sourceTree = "<group>";
@@ -614,6 +631,7 @@
 				E22183BC1D3BD47400866197 /* PresentationModalSize.swift */,
 				E22183BE1D3BD54B00866197 /* PresentationModalPosition.swift */,
 				E2DAD6381D5F4C2E00333ABF /* PresentationKeyboardTranslation.swift */,
+				E2E62B761D69B17900294A73 /* ActivityIndicatorType.swift */,
 			);
 			name = enum;
 			sourceTree = "<group>";
@@ -690,6 +708,41 @@
 				E2472EA61C6F980C00A20E27 /* FlatColorsTypeScript.swift */,
 			);
 			name = scripts;
+			sourceTree = "<group>";
+		};
+		E2E62B7C1D69B2B200294A73 /* activity indicator */ = {
+			isa = PBXGroup;
+			children = (
+				E2E62B7D1D69B5D300294A73 /* common */,
+				E2E62B7E1D69B5D700294A73 /* animations */,
+			);
+			name = "activity indicator";
+			sourceTree = "<group>";
+		};
+		E2E62B7D1D69B5D300294A73 /* common */ = {
+			isa = PBXGroup;
+			children = (
+				E2E62B7F1D69B5F000294A73 /* ActivityIndicatorFactory.swift */,
+				E2E62B851D69B6B400294A73 /* ActivityIndicatorShape.swift */,
+			);
+			name = common;
+			sourceTree = "<group>";
+		};
+		E2E62B7E1D69B5D700294A73 /* animations */ = {
+			isa = PBXGroup;
+			children = (
+				E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */,
+			);
+			name = animations;
+			sourceTree = "<group>";
+		};
+		E2E62B871D69BBA000294A73 /* ActivityIndicator */ = {
+			isa = PBXGroup;
+			children = (
+				E2E62B7A1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift */,
+				E2E62B831D69B63800294A73 /* ActivityIndicatorAnimating.swift */,
+			);
+			name = ActivityIndicator;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -834,8 +887,10 @@
 				AE9407871CAE86DE0084BCB8 /* TransitionType.swift in Sources */,
 				AEE552B11C839EB7009CF623 /* TransitionPresenterManager.swift in Sources */,
 				AE6B01721C2A444900950BB2 /* RotationDesignable.swift in Sources */,
+				E2E62B861D69B6B400294A73 /* ActivityIndicatorShape.swift in Sources */,
 				E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */,
 				AEDE6E6B1CCECE8A000DECF0 /* PinchInteractiveAnimator.swift in Sources */,
+				E2E62B791D69B20500294A73 /* AnimatableActivityIndicatorView.swift in Sources */,
 				E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
 				E210ABC11D3A9388001D0362 /* PresentationAnimationType.swift in Sources */,
@@ -844,6 +899,7 @@
 				AE6B01801C2A445100950BB2 /* AnimatableStackView.swift in Sources */,
 				AE6B01661C2A444000950BB2 /* MaskType.swift in Sources */,
 				E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */,
+				E2E62B771D69B17900294A73 /* ActivityIndicatorType.swift in Sources */,
 				AE6B01811C2A445100950BB2 /* AnimatableTableView.swift in Sources */,
 				AE6B01671C2A444500950BB2 /* Animatable.swift in Sources */,
 				E210ABC41D3A95F9001D0362 /* CoverAnimator.swift in Sources */,
@@ -891,6 +947,7 @@
 				E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */,
 				AEDD8A321C7EDAE30033175A /* SystemFlipAnimator.swift in Sources */,
 				AE6B01681C2A444900950BB2 /* BlurDesignable.swift in Sources */,
+				E2E62B801D69B5F000294A73 /* ActivityIndicatorFactory.swift in Sources */,
 				AE9407891CAE871C0084BCB8 /* TransitionPageType.swift in Sources */,
 				AE6B01711C2A444900950BB2 /* PlaceholderDesignable.swift in Sources */,
 				AE6B01821C2A445100950BB2 /* AnimatableTableViewCell.swift in Sources */,
@@ -925,6 +982,7 @@
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
 				AE6B016E1C2A444900950BB2 /* NavigationBarDesginable.swift in Sources */,
+				E2E62B841D69B63800294A73 /* ActivityIndicatorAnimating.swift in Sources */,
 				AEC23FC01CB3DC4800E42D99 /* ScreenEdgePanInteractiveAnimator.swift in Sources */,
 				AEC9F60E1CB31DCB00C82D16 /* GestureDirection.swift in Sources */,
 				E299DF541CD5F8C300EC30D4 /* TurnAnimator.swift in Sources */,
@@ -933,7 +991,9 @@
 				AE677B9A1CADCF6700D62273 /* SystemRippleEffectAnimator.swift in Sources */,
 				AE154B7F1C7D061A0093C05B /* TransitionAnimationType.swift in Sources */,
 				AE677B991CADCF6500D62273 /* SystemCameraIrisAnimator.swift in Sources */,
+				E2E62B821D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift in Sources */,
 				E299DF5C1CD6067C00EC30D4 /* PresentCardsSegue.swift in Sources */,
+				E2E62B7B1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift in Sources */,
 				E210ABC61D3A9713001D0362 /* AnimatedPresenting.swift in Sources */,
 				AE6B016F1C2A444900950BB2 /* MaskDesignable.swift in Sources */,
 				AE6B01741C2A444900950BB2 /* SideImageDesignable.swift in Sources */,

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		E2E62B821D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */; };
 		E2E62B841D69B63800294A73 /* ActivityIndicatorAnimating.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B831D69B63800294A73 /* ActivityIndicatorAnimating.swift */; };
 		E2E62B861D69B6B400294A73 /* ActivityIndicatorShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B851D69B6B400294A73 /* ActivityIndicatorShape.swift */; };
+		E2E62B891D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2E62B881D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard */; };
+		E2E62B8B1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E62B8A1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift */; };
 		E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */; };
 		E2F45B591CDBAF39001D2E37 /* PresentFlipSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B581CDBAF39001D2E37 /* PresentFlipSegue.swift */; };
 		E2F45B5B1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F45B5A1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift */; };
@@ -331,6 +333,8 @@
 		E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallBeat.swift; sourceTree = "<group>"; };
 		E2E62B831D69B63800294A73 /* ActivityIndicatorAnimating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimating.swift; sourceTree = "<group>"; };
 		E2E62B851D69B6B400294A73 /* ActivityIndicatorShape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorShape.swift; sourceTree = "<group>"; };
+		E2E62B881D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = UserInterfaceActivityIndicator.storyboard; sourceTree = "<group>"; };
+		E2E62B8A1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInterfaceActivityIndicatorViewController.swift; sourceTree = "<group>"; };
 		E2F45B561CDB845F001D2E37 /* FlipAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlipAnimator.swift; sourceTree = "<group>"; };
 		E2F45B581CDBAF39001D2E37 /* PresentFlipSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFlipSegue.swift; sourceTree = "<group>"; };
 		E2F45B5A1CDBAF5C001D2E37 /* PresentFlipWithDismissInteractionSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentFlipWithDismissInteractionSegue.swift; sourceTree = "<group>"; };
@@ -518,6 +522,7 @@
 				AE87646D1D2331010044E0AB /* UserInterfaceMaskTableViewController.swift */,
 				AE87646F1D2332F60044E0AB /* MaskViewController.swift */,
 				E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */,
+				E2E62B8A1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift */,
 			);
 			name = code;
 			sourceTree = "<group>";
@@ -686,6 +691,7 @@
 			children = (
 				AE0D30991CE149150093B578 /* UserInterface.storyboard */,
 				AE87646B1D232F1D0044E0AB /* UserInterfaceMask.storyboard */,
+				E2E62B881D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard */,
 			);
 			name = UserInterface;
 			sourceTree = "<group>";
@@ -854,6 +860,7 @@
 				AE0D309C1CE14A170093B578 /* Animations.storyboard in Resources */,
 				AE154B101C788A560093C05B /* Transitions.storyboard in Resources */,
 				AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */,
+				E2E62B891D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard in Resources */,
 				AE0D309A1CE149150093B578 /* UserInterface.storyboard in Resources */,
 				AE87646C1D232F1D0044E0AB /* UserInterfaceMask.storyboard in Resources */,
 			);
@@ -1027,6 +1034,7 @@
 				E25EC6E71CDE034300743DB8 /* ContainerTransitionViewController.swift in Sources */,
 				AEDB24D11CE9EC0F0086612C /* TransitionPresentedViewController.swift in Sources */,
 				E2D33E531D3A5490006F2492 /* PresentingViewController.swift in Sources */,
+				E2E62B8B1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift in Sources */,
 				AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IBAnimatableApp.xcodeproj/project.pbxproj
+++ b/IBAnimatableApp.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		E2614B611D23C94300BBBAFA /* AnimatableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2614B601D23C94300BBBAFA /* AnimatableScrollView.swift */; };
 		E26B3EDA1CCD4C1D00BFD0AB /* NatGeoAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */; };
 		E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */; };
+		E27594971D69FB4E005DBA0C /* ActivityIndicatorAnimationBallPulseSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27594961D69FB4E005DBA0C /* ActivityIndicatorAnimationBallPulseSync.swift */; };
+		E27594991D69FB66005DBA0C /* ActivityIndicatorAnimationLineScalePulseOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27594981D69FB66005DBA0C /* ActivityIndicatorAnimationLineScalePulseOut.swift */; };
 		E27691E91CAFC72C004A725C /* SystemMoveInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */; };
 		E27691EB1CAFC91A004A725C /* SystemPushAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */; };
 		E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */; };
@@ -303,6 +305,8 @@
 		E2614B601D23C94300BBBAFA /* AnimatableScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableScrollView.swift; sourceTree = "<group>"; };
 		E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NatGeoAnimator.swift; sourceTree = "<group>"; };
 		E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentNatGeoSegue.swift; sourceTree = "<group>"; };
+		E27594961D69FB4E005DBA0C /* ActivityIndicatorAnimationBallPulseSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallPulseSync.swift; sourceTree = "<group>"; };
+		E27594981D69FB66005DBA0C /* ActivityIndicatorAnimationLineScalePulseOut.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationLineScalePulseOut.swift; sourceTree = "<group>"; };
 		E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemMoveInAnimator.swift; sourceTree = "<group>"; };
 		E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPushAnimator.swift; sourceTree = "<group>"; };
 		E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRevealAnimator.swift; sourceTree = "<group>"; };
@@ -738,6 +742,8 @@
 			isa = PBXGroup;
 			children = (
 				E2E62B811D69B60A00294A73 /* ActivityIndicatorAnimationBallBeat.swift */,
+				E27594961D69FB4E005DBA0C /* ActivityIndicatorAnimationBallPulseSync.swift */,
+				E27594981D69FB66005DBA0C /* ActivityIndicatorAnimationLineScalePulseOut.swift */,
 			);
 			name = animations;
 			sourceTree = "<group>";
@@ -897,6 +903,7 @@
 				E2E62B861D69B6B400294A73 /* ActivityIndicatorShape.swift in Sources */,
 				E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */,
 				AEDE6E6B1CCECE8A000DECF0 /* PinchInteractiveAnimator.swift in Sources */,
+				E27594971D69FB4E005DBA0C /* ActivityIndicatorAnimationBallPulseSync.swift in Sources */,
 				E2E62B791D69B20500294A73 /* AnimatableActivityIndicatorView.swift in Sources */,
 				E20078A31CB912E1002B2C16 /* PresentFoldSegue.swift in Sources */,
 				AEE552A81C815AC5009CF623 /* FadeAnimator.swift in Sources */,
@@ -1011,6 +1018,7 @@
 				AE7C26111CB4F680002CF125 /* InteractiveAnimatorFactory.swift in Sources */,
 				AE4C53F61C8843AB007C9EFA /* InteractiveGestureType.swift in Sources */,
 				CAB56443CD667F41413A560F /* SystemTransitionType.swift in Sources */,
+				E27594991D69FB66005DBA0C /* ActivityIndicatorAnimationLineScalePulseOut.swift in Sources */,
 				E210ABCC1D3AAAD0001D0362 /* PresentationPresenterManager.swift in Sources */,
 				CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */,
 				E21E840E1D3A31A900C742E7 /* AnimatablePresentationController.swift in Sources */,

--- a/IBAnimatableApp/Playground.storyboard
+++ b/IBAnimatableApp/Playground.storyboard
@@ -95,8 +95,35 @@
                                             <segue destination="YMk-Jn-KUW" kind="show" id="gFA-vq-8RQ"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="uDf-bP-Roh" style="IBUITableViewCellStyleDefault" id="x9C-HM-AGl" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="3Fm-ye-H8s" style="IBUITableViewCellStyleDefault" id="jeF-es-O5e" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="224" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jeF-es-O5e" id="RYQ-lO-BIo">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Activity Indicator" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Fm-ye-H8s">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="jdq-a3-17E" kind="show" id="04Y-ni-wbb"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="uDf-bP-Roh" style="IBUITableViewCellStyleDefault" id="x9C-HM-AGl" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="268" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="x9C-HM-AGl" id="T30-6U-gWZ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -123,7 +150,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="DHY-gE-QzJ" style="IBUITableViewCellStyleDefault" id="leW-Pc-8Nt" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="268" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="312" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="leW-Pc-8Nt" id="6Es-tX-lSH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -150,7 +177,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="1k4-58-akZ" style="IBUITableViewCellStyleDefault" id="Mvc-tD-5em" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="312" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="356" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Mvc-tD-5em" id="M6i-U2-ARG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -211,7 +238,7 @@
                 <viewControllerPlaceholder storyboardName="UserInterface" id="VGT-SK-HRG" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dpn-Wz-hk3" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6308" y="-360"/>
+            <point key="canvasLocation" x="6327" y="-392"/>
         </scene>
         <!--Animations-->
         <scene sceneID="IlU-Wj-CPN">
@@ -219,7 +246,7 @@
                 <viewControllerPlaceholder storyboardName="Animations" id="YMk-Jn-KUW" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eLW-Ww-QM4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6300.5" y="-308"/>
+            <point key="canvasLocation" x="6319.5" y="-340"/>
         </scene>
         <!--Transitions-->
         <scene sceneID="rFV-yH-sSh">
@@ -227,7 +254,7 @@
                 <viewControllerPlaceholder storyboardName="Transitions" id="Yrg-NP-dYZ" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PSX-rh-CnY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6300" y="-257"/>
+            <point key="canvasLocation" x="6319" y="-289"/>
         </scene>
         <!--Interactions-->
         <scene sceneID="LKK-ky-A7J">
@@ -235,7 +262,15 @@
                 <viewControllerPlaceholder storyboardName="Interactions" id="rei-S7-RFR" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RB5-Hg-lBY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6302.5" y="-156"/>
+            <point key="canvasLocation" x="6321.5" y="-188"/>
+        </scene>
+        <!--UserInterfaceActivityIndicator-->
+        <scene sceneID="kqp-wX-GlM">
+            <objects>
+                <viewControllerPlaceholder storyboardName="UserInterfaceActivityIndicator" id="jdq-a3-17E" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dbD-CE-CNS" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="6377" y="-131"/>
         </scene>
         <!--Presentations-->
         <scene sceneID="JYL-TY-QR4">
@@ -243,7 +278,7 @@
                 <viewControllerPlaceholder storyboardName="Presentations" id="tXh-nS-4b7" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Sb-x6-cQw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6308.5" y="-206"/>
+            <point key="canvasLocation" x="6327.5" y="-238"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="VjR-mb-m73">

--- a/IBAnimatableApp/UserInterfaceActivityIndicator.storyboard
+++ b/IBAnimatableApp/UserInterfaceActivityIndicator.storyboard
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Wz2-Hk-E3D">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--Activity Indicator-->
+        <scene sceneID="XoQ-zy-P7g">
+            <objects>
+                <viewController id="Wz2-Hk-E3D" customClass="UserInterfaceActivityIndicatorViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="AVr-l3-mcS"/>
+                        <viewControllerLayoutGuide type="bottom" id="JOq-WV-Or9"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="s3t-uY-U24" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f8l-f9-P39">
+                                <rect key="frame" x="0.0" y="20" width="375" height="431"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JF8-xw-qb4" customClass="AnimatableActivityIndicatorView" customModule="IBAnimatable">
+                                        <rect key="frame" x="137.5" y="165.5" width="100" height="100"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="100" id="FDN-lh-rVN"/>
+                                            <constraint firstAttribute="width" constant="100" id="ddU-ZR-B5M"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                                <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="animationType" value="BallBeats"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your animation..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gHt-Jp-Y8M">
+                                        <rect key="frame" x="0.0" y="413" width="375" height="18"/>
+                                        <fontDescription key="fontDescription" type="italicSystem" pointSize="15"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="JF8-xw-qb4" firstAttribute="centerX" secondItem="f8l-f9-P39" secondAttribute="centerX" id="2bP-Fw-ZgR"/>
+                                    <constraint firstAttribute="bottom" secondItem="gHt-Jp-Y8M" secondAttribute="bottom" id="CY3-vM-HtW"/>
+                                    <constraint firstAttribute="trailing" secondItem="gHt-Jp-Y8M" secondAttribute="trailing" id="PEI-Ey-9b6"/>
+                                    <constraint firstItem="JF8-xw-qb4" firstAttribute="centerY" secondItem="f8l-f9-P39" secondAttribute="centerY" id="dBC-Kx-Mg9"/>
+                                    <constraint firstItem="gHt-Jp-Y8M" firstAttribute="leading" secondItem="f8l-f9-P39" secondAttribute="leading" id="fmJ-am-OOs"/>
+                                </constraints>
+                            </view>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBX-G5-Aa0">
+                                <rect key="frame" x="0.0" y="451" width="375" height="216"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="Wz2-Hk-E3D" id="Izr-iM-3UC"/>
+                                    <outlet property="delegate" destination="Wz2-Hk-E3D" id="2uU-ll-gaM"/>
+                                </connections>
+                            </pickerView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="f8l-f9-P39" firstAttribute="top" secondItem="AVr-l3-mcS" secondAttribute="bottom" id="4ze-4g-TKM"/>
+                            <constraint firstItem="JOq-WV-Or9" firstAttribute="top" secondItem="oBX-G5-Aa0" secondAttribute="bottom" id="EdE-FJ-Vta"/>
+                            <constraint firstAttribute="trailing" secondItem="oBX-G5-Aa0" secondAttribute="trailing" id="GBv-61-zNP"/>
+                            <constraint firstItem="f8l-f9-P39" firstAttribute="leading" secondItem="s3t-uY-U24" secondAttribute="leading" id="IoQ-Z1-7EO"/>
+                            <constraint firstItem="oBX-G5-Aa0" firstAttribute="top" secondItem="f8l-f9-P39" secondAttribute="bottom" id="T5i-V0-dws"/>
+                            <constraint firstAttribute="trailing" secondItem="f8l-f9-P39" secondAttribute="trailing" id="sa1-tZ-Tc7"/>
+                            <constraint firstItem="oBX-G5-Aa0" firstAttribute="leading" secondItem="s3t-uY-U24" secondAttribute="leading" id="zWR-ke-NwG"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="predefinedGradient" value="EmeraldWater"/>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <navigationItem key="navigationItem" title="Activity Indicator" id="dnd-WX-BNs">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="3zf-B6-oNU">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="W2t-Do-Y7I" kind="unwind" unwindAction="unwindToViewController:" id="fSA-RZ-1aH"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <connections>
+                        <outlet property="activityIndicatorView" destination="JF8-xw-qb4" id="mR0-uM-Ouz"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Us4-fB-W5g" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="W2t-Do-Y7I" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="414" y="441"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="back" width="21" height="21"/>
+    </resources>
+</document>

--- a/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
+++ b/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
@@ -1,0 +1,57 @@
+//
+//  Created by Tom Baranes on 21/08/16.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+import IBAnimatable
+
+class UserInterfaceActivityIndicatorViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSource {
+
+  // MARK: Properties IB
+
+  @IBOutlet weak var activityIndicatorView: AnimatableActivityIndicatorView!
+
+  // MARK: Properties
+
+  private var activityIndicatorsType: [String] {
+    var types = [String]()
+    iterateEnum(ActivityIndicatorType).forEach {
+      types.append($0.rawValue)
+    }
+    return types
+  }
+
+  // MARK: Life cycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    if let animatableView = view as? AnimatableView {
+      animatableView.predefinedGradient = String(generateRandomGradient())
+    }
+  }
+
+}
+
+extension UserInterfaceActivityIndicatorViewController {
+
+  func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+    return 1
+  }
+  
+  func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    return activityIndicatorsType.count
+  }
+
+  func pickerView(pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+    let title = activityIndicatorsType[row]
+    return NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName:UIColor.whiteColor()])
+  }
+
+  func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    activityIndicatorView.stopAnimating()
+    activityIndicatorView.animationType = activityIndicatorsType[row]
+    activityIndicatorView.startAnimating()
+  }
+
+}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also check out [swift2.3 branch](https://github.com/IBAnimatable/IBAnima
 
 ## Documentations
 * [<del>Fully</del> Mostly documented API Reference](Documentation/APIs.md) 
-* [Activity indicator animations](Documentation/ActivityIndicator.md)
+* [Activity indicator animations](Documentation/ActivityIndicators.md)
 * [How to design and prototype custom transition animation and gesture interaction in Interface Builder with IBAnimatable](Documentation/Transitions.md)
 
 ## How to run the example App

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can also check out [swift2.3 branch](https://github.com/IBAnimatable/IBAnima
 
 ## Documentations
 * [<del>Fully</del> Mostly documented API Reference](Documentation/APIs.md) 
+* [Activity indicator animations](Documentation/ActivityIndicator.md)
 * [How to design and prototype custom transition animation and gesture interaction in Interface Builder with IBAnimatable](Documentation/Transitions.md)
 
 ## How to run the example App

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Many thanks to [all contributors](https://github.com/IBAnimatable/IBAnimatable/g
 * Framer Studio - Design and preview animations in one place.
 * [Spring by Meng To](https://github.com/MengTo/Spring) - steal a lot of animation parameters from this project.
 * [VCTransitionsLibrary by Colin Eberhardt](https://github.com/ColinEberhardt/VCTransitionsLibrary) - port all transition animations from this project, and add parameters support and fix bugs.
+* [NVActivityIndicatorView by Vinh Nguyen](https://github.com/ninjaprox/NVActivityIndicatorView) - port all activity indicator animations from this project.
 * [Invision ToDo App UI Kit](http://www.invisionapp.com/do), The demo App's original design is from this UI Kit and redone in Interface Builder. We also added interaction, navigation and animations.
 
 ## Change Log


### PR DESCRIPTION
Related to #246 

This PR introduces several new classes / protocols:
- `ActivityIndicatorType`: enums for each activity indicator
- `ActivityIndicatorAnimatable`: protocol for every subclass who wants to handle custom activity indicator. Any of the current `Animatable*` classes confirm to it
- `AnimatableActivityIndicatorView`: `UIView` subclass which conforms to `ActivityIndicatorAnimatable`
- `ActivityIndicatorAnimating`: Protocol which will be conformed by every activity indicator animation
- `ActivityIndicatorFactory`:  `ActivityIndicatorAnimating` generator
- `ActivityIndicatorAnimationBallBeat`: ball beat indicator view animation, only animation supported (will add some once the architecture has been validated) 

The global architecture follows the same architecture as transitions, presentations... and is fully customisable from interface builder, currently supported:
- Animation type
- Activity indicator color
- Hides when stopped

I also add a new section in the playground example "IndicatorView", inspired from the new examples in swift3 branch: one picker and everything will be up to date automatically following the enum.

As always, don't hesitate to criticise the naming, I'm not myself sure for all of them 😬 
