### PR TITLE
Fix the bug for using shadow for masked view 

### DIFF
--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -82,6 +82,7 @@ import UIKit
     didSet {
       configMask()
       configBorder()
+      configMaskShadow()
     }
   }
   
@@ -122,5 +123,6 @@ import UIKit
   private func configAfterLayoutSubviews() {
     configMask()
     configBorder()
+    configMaskShadow()
   }
 }

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -119,7 +119,8 @@ import UIKit
   @IBInspectable public var maskType: String? {
     didSet {
       configMask()
-      configBorder()      
+      configBorder()
+      configMaskShadow()
     }
   }
   
@@ -161,6 +162,7 @@ import UIKit
   private func configAfterLayoutSubviews() {
     configMask()
     configBorder()
+    configMaskShadow()
     configGradient()    
   }
 }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -120,6 +120,7 @@ import UIKit
     didSet {
       configMask()
       configBorder()
+      configMaskShadow()
     }
   }
   
@@ -161,6 +162,7 @@ import UIKit
   private func configAfterLayoutSubviews() {
     configMask()
     configBorder()
+    configMaskShadow()
     configGradient()
   }
 }

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -252,7 +252,7 @@ public extension MaskDesignable where Self: UIView {
     layer.mask?.removeFromSuperlayer()
     
     let maskLayer = CAShapeLayer()
-    maskLayer.frame = CGRect(origin: CGPoint.zero, size: bounds.size)
+    maskLayer.frame = CGRect(origin: .zero, size: bounds.size)
     maskLayer.path = path.CGPath
     layer.mask = maskLayer
   }

--- a/IBAnimatable/ShadowDesignable.swift
+++ b/IBAnimatable/ShadowDesignable.swift
@@ -70,9 +70,9 @@ public extension ShadowDesignable where Self: UIView {
     commonSetup()
     // if a layer mask is specified, display the shadow to match the mask
     if let mask = layer.mask as? CAShapeLayer {
-      mask.masksToBounds = false
       if let unwrappedShadowColor = shadowColor {
-        mask.shadowColor = unwrappedShadowColor.CGColor
+//        layer.shadowColor = unwrappedShadowColor.CGColor
+//        mask.shadowColor = unwrappedShadowColor.CGColor
       }
       if !shadowRadius.isNaN && shadowRadius > 0 {
         mask.shadowRadius = shadowRadius

--- a/IBAnimatable/ShadowDesignable.swift
+++ b/IBAnimatable/ShadowDesignable.swift
@@ -68,25 +68,43 @@ public extension ShadowDesignable where Self: UIView {
   
   public func configMaskShadow() {
     commonSetup()
-    // if a layer mask is specified, display the shadow to match the mask
+    
+    // if a `layer.mask` is specified, add a new shadow layer to display the shadow to match the mask shape.
     if let mask = layer.mask as? CAShapeLayer {
+      // Clear default layer borders
+      layer.shadowColor = nil
+      layer.shadowRadius = 0
+      layer.shadowOpacity = 0
+      
+      // Remove any previous shadow layer
+      layer.superlayer?.sublayers?.filter { $0.name == "shadowLayer-\(unsafeAddressOf(self))" }
+        .forEach { $0.removeFromSuperlayer() }
+      
+      // Create new layer with object's memory reference to make this string unique. Otherwise common name will remove all the shadow layers as it's adding in layer's superview.
+      let shadowLayer = CAShapeLayer()
+      shadowLayer.name = "shadowLayer-\(unsafeAddressOf(self))"
+      shadowLayer.frame = frame
+      
+      // Configure shadow properties
       if let unwrappedShadowColor = shadowColor {
-//        layer.shadowColor = unwrappedShadowColor.CGColor
-//        mask.shadowColor = unwrappedShadowColor.CGColor
+        shadowLayer.shadowColor = unwrappedShadowColor.CGColor
       }
       if !shadowRadius.isNaN && shadowRadius > 0 {
-        mask.shadowRadius = shadowRadius
+        shadowLayer.shadowRadius = shadowRadius
       }
       if !shadowOpacity.isNaN && shadowOpacity >= 0 && shadowOpacity <= 1 {
-        mask.shadowOpacity = Float(shadowOpacity)
+        shadowLayer.shadowOpacity = Float(shadowOpacity)
       }
       if !shadowOffset.x.isNaN {
-        mask.shadowOffset.width = shadowOffset.x
+        shadowLayer.shadowOffset.width = shadowOffset.x
       }
       if !shadowOffset.y.isNaN {
-        mask.shadowOffset.height = shadowOffset.y
+        shadowLayer.shadowOffset.height = shadowOffset.y
       }
-      mask.shadowPath = mask.path
+      shadowLayer.shadowPath = mask.path
+      
+      // Add to layer's superview in order to render shadow otherwise it will clip out due to mask layer.
+      layer.superlayer?.insertSublayer(shadowLayer, below: layer)
     }
   }
   

--- a/IBAnimatable/ShadowDesignable.swift
+++ b/IBAnimatable/ShadowDesignable.swift
@@ -66,6 +66,30 @@ public extension ShadowDesignable where Self: UIView {
     }
   }
   
+  public func configMaskShadow() {
+    commonSetup()
+    // if a layer mask is specified, display the shadow to match the mask
+    if let mask = layer.mask as? CAShapeLayer {
+      mask.masksToBounds = false
+      if let unwrappedShadowColor = shadowColor {
+        mask.shadowColor = unwrappedShadowColor.CGColor
+      }
+      if !shadowRadius.isNaN && shadowRadius > 0 {
+        mask.shadowRadius = shadowRadius
+      }
+      if !shadowOpacity.isNaN && shadowOpacity >= 0 && shadowOpacity <= 1 {
+        mask.shadowOpacity = Float(shadowOpacity)
+      }
+      if !shadowOffset.x.isNaN {
+        mask.shadowOffset.width = shadowOffset.x
+      }
+      if !shadowOffset.y.isNaN {
+        mask.shadowOffset.height = shadowOffset.y
+      }
+      mask.shadowPath = mask.path
+    }
+  }
+  
   private func commonSetup() {
     // Need to set `layer.masksToBounds` to `false`. 
     // If `layer.masksToBounds == true` then shadow doesn't work any more.

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -50,7 +50,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Mask" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gM0-9A-UM6">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Mask, border and shadow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gM0-9A-UM6">
                                                     <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/IBAnimatableApp/UserInterfaceMask.storyboard
+++ b/IBAnimatableApp/UserInterfaceMask.storyboard
@@ -85,6 +85,24 @@
                                     <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
                                         <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                                     </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="shadowColor">
+                                        <color key="value" red="0.14117647059999999" green="0.78039215689999997" blue="0.35294117650000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowRadius">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOpacity">
+                                        <real key="value" value="0.5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="point" keyPath="shadowOffset">
+                                        <point key="value" x="30" y="30"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.87843137250000003" green="0.41568627450000001" blue="0.039215686270000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="auto-bg" translatesAutoresizingMaskIntoConstraints="NO" id="rm0-49-clX" customClass="AnimatableImageView" customModule="IBAnimatable">

--- a/IBAnimatableApp/UserInterfaceMask.storyboard
+++ b/IBAnimatableApp/UserInterfaceMask.storyboard
@@ -107,6 +107,20 @@
                             </view>
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="auto-bg" translatesAutoresizingMaskIntoConstraints="NO" id="rm0-49-clX" customClass="AnimatableImageView" customModule="IBAnimatable">
                                 <rect key="frame" x="0.0" y="394" width="375" height="179"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="shadowColor">
+                                        <color key="value" red="0.14117647059999999" green="0.78039215689999997" blue="0.35294117650000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowRadius">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="shadowOpacity">
+                                        <real key="value" value="0.90000000000000002"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="point" keyPath="shadowOffset">
+                                        <point key="value" x="10" y="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/IBAnimatableApp/UserInterfaceMask.storyboard
+++ b/IBAnimatableApp/UserInterfaceMask.storyboard
@@ -109,16 +109,16 @@
                                 <rect key="frame" x="0.0" y="394" width="375" height="179"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="shadowColor">
-                                        <color key="value" red="0.14117647059999999" green="0.78039215689999997" blue="0.35294117650000001" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="shadowRadius">
                                         <real key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="shadowOpacity">
-                                        <real key="value" value="0.90000000000000002"/>
+                                        <real key="value" value="0.5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="point" keyPath="shadowOffset">
-                                        <point key="value" x="10" y="10"/>
+                                        <point key="value" x="0.0" y="10"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </imageView>

--- a/IBAnimatableApp/UserInterfaceMaskTableViewController.swift
+++ b/IBAnimatableApp/UserInterfaceMaskTableViewController.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 class UserInterfaceMaskTableViewController: UITableViewController {
-  private let masks = ["None", "Circle", "Polygon", "Polygon(12)", "Star", "Star(6)", "Triangle", "Wave", "Wave(up,10,5)", "Wave(down,40,0)", "Parallelogram", "Parallelogram(150)"]
+  private let masks = ["None", "Circle", "Polygon", "Polygon(12)", "Star", "Star(6)", "Triangle", "Wave", "Wave(up,10,5)", "Wave(down,40,0)", "Parallelogram", "Parallelogram(110)"]
   
   override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     if let maskViewController = segue.destinationViewController as? MaskViewController, indexPath = tableView.indexPathForSelectedRow {


### PR DESCRIPTION
Fix #267 

Great thanks to @Abdul-Moiz for reporting and fixing this issue. I like the solution by using `shadowLayer.name = "shadowLayer-\(unsafeAddressOf(self))"`

Have updated the demo app to test them "User Interface" -> "Mask"

![simulator screen shot sep 1 2016 9 45 20 pm](https://cloud.githubusercontent.com/assets/573856/18166232/49c2041e-708d-11e6-8861-f963288d006b.png)
