### PR TITLE
Fix blur effect view

### DIFF
--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -33,11 +33,13 @@ public extension BlurDesignable where Self: UIView {
     }
 
     let blurEffectView = createVisualEffectView(effect: UIBlurEffect(style: blurEffectStyle))
-    if let vibrancyStyle = vibrancyEffectStyle {
-      subviews.flatMap { $0 as? AnimatableVibrancyView }
-        .forEach { $0.removeFromSuperview() }
-
-      let vibrancyEffectView = createVisualEffectView(effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: vibrancyStyle)))
+    subviews.flatMap { $0 as? AnimatableVibrancyView }
+      .forEach { $0.removeFromSuperview() }
+    
+    // Add `vibrancyEffectView` if `vibrancyEffectStyle` has been set.
+    if let vibrancyEffectStyle = vibrancyEffectStyle {
+      let blurEffectStyleForVibrancy = UIBlurEffect(style: vibrancyEffectStyle)
+      let vibrancyEffectView = createVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffectStyleForVibrancy))
       subviews.forEach {
         vibrancyEffectView.contentView.addSubview($0)
       }

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -28,15 +28,17 @@ public extension BlurDesignable where Self: UIView {
    configBlurEffectStyle method, should be called in layoutSubviews() method
    */
   public func configBlurEffectStyle() {
+    // Remove the existing visual effect view
+    subviews.flatMap { $0 as? PrivateVisualEffectView }
+      .forEach { $0.removeFromSuperview() }
+    
     guard let blurEffectStyle = blurEffectStyle else {
       return
     }
 
     let blurEffectView = createVisualEffectView(effect: UIBlurEffect(style: blurEffectStyle))
-    subviews.flatMap { $0 as? AnimatableVibrancyView }
-      .forEach { $0.removeFromSuperview() }
     
-    // Add `vibrancyEffectView` if `vibrancyEffectStyle` has been set.
+    // If `vibrancyEffectStyle` has been set, add `vibrancyEffectView` into `blurEffectView`.
     if let vibrancyEffectStyle = vibrancyEffectStyle {
       let blurEffectStyleForVibrancy = UIBlurEffect(style: vibrancyEffectStyle)
       let vibrancyEffectView = createVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffectStyleForVibrancy))
@@ -45,14 +47,14 @@ public extension BlurDesignable where Self: UIView {
       }
       blurEffectView.contentView.addSubview(vibrancyEffectView)
     }
+
     insertSubview(blurEffectView, at: 0)
   }
 }
 
 private extension BlurDesignable where Self: UIView {
-
   func createVisualEffectView(effect: UIVisualEffect) -> UIVisualEffectView {
-    let visualEffectView = AnimatableVibrancyView(effect: effect)
+    let visualEffectView = PrivateVisualEffectView(effect: effect)
     visualEffectView.alpha = blurOpacity.isNaN ? 1.0 : blurOpacity
     if layer.cornerRadius > 0 {
       visualEffectView.layer.cornerRadius = layer.cornerRadius
@@ -65,6 +67,7 @@ private extension BlurDesignable where Self: UIView {
   }
 }
 
-private class AnimatableVibrancyView: UIVisualEffectView {
+/// Private class of visual effect view used in `BlurDesignable` only
+private class PrivateVisualEffectView: UIVisualEffectView {
 
 }

--- a/IBAnimatable/FadeAnimator.swift
+++ b/IBAnimatable/FadeAnimator.swift
@@ -1,4 +1,4 @@
- //
+//
 //  Created by Jake Lin on 2/27/16.
 //  Copyright © 2016 IBAnimatable. All rights reserved.
 //

--- a/IBAnimatableApp/AnimationsViewController.swift
+++ b/IBAnimatableApp/AnimationsViewController.swift
@@ -85,7 +85,7 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
     guard let param = selectedEntry.params[safe: component - 1] else {
       return nil
     }
-    return param.titleAt(row).colorize(.white)
+    return param.title(at: row).colorize(.white)
   }
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     if component == 0 {

--- a/IBAnimatableApp/BlurEffectViewController.swift
+++ b/IBAnimatableApp/BlurEffectViewController.swift
@@ -39,7 +39,7 @@ extension BlurEffectViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
     if component == 2 {
-      return (opacityValues.titleAt(row)).colorize(.white)
+      return (opacityValues.title(at: row)).colorize(.white)
     }
       return values[safe: row]?.colorize(.white)
   }
@@ -47,7 +47,7 @@ extension BlurEffectViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     imageView.blurEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 0)])
     imageView.vibrancyEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 1)])
-    imageView.blurOpacity = CGFloat(Double(opacityValues.valueAt(pickerView.selectedRow(inComponent: 2)))!)
+    imageView.blurOpacity = CGFloat(Double(opacityValues.value(at: pickerView.selectedRow(inComponent: 2)))!)
   }
 
   func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {

--- a/IBAnimatableApp/BlurEffectViewController.swift
+++ b/IBAnimatableApp/BlurEffectViewController.swift
@@ -1,9 +1,6 @@
 //
-//  BlurEffectViewController.swift
-//  IBAnimatableApp
-//
 //  Created by jason akakpo on 27/07/16.
-//  Copyright © 2016 Jake Lin. All rights reserved.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
 //
 
 import UIKit
@@ -11,8 +8,8 @@ import IBAnimatable
 
 class BlurEffectViewController: UIViewController {
   
-  @IBOutlet weak var imageView: AnimatableImageView!
- 
+  @IBOutlet var blurEffectView: AnimatableView!
+  
   let opacityValues = ParamType.number(min: 0.0, max: 1.0, interval: 0.1, ascending: false, unit: "")
   lazy var values: [String] = {
     var values = ["none", "extraLight", "light", "dark"]
@@ -45,9 +42,9 @@ extension BlurEffectViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   }
 
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-    imageView.blurEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 0)])
-    imageView.vibrancyEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 1)])
-    imageView.blurOpacity = CGFloat(Double(opacityValues.value(at: pickerView.selectedRow(inComponent: 2)))!)
+    blurEffectView.blurEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 0)])
+    blurEffectView.vibrancyEffectStyle = UIBlurEffectStyle(string:values[pickerView.selectedRow(inComponent: 1)])
+    blurEffectView.blurOpacity = CGFloat(Double(opacityValues.value(at: pickerView.selectedRow(inComponent: 2)))!)
   }
 
   func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {

--- a/IBAnimatableApp/BlurEffectViewController.swift
+++ b/IBAnimatableApp/BlurEffectViewController.swift
@@ -29,6 +29,8 @@ extension BlurEffectViewController : UIPickerViewDelegate, UIPickerViewDataSourc
     if component == 2 {
       return opacityValues.count()
     }
+    
+    // When component == 0 || component == 1, display blur effects
     return values.count
   }
   func numberOfComponents(in pickerView: UIPickerView) -> Int {
@@ -37,7 +39,7 @@ extension BlurEffectViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
     if component == 2 {
-      return (opacityValues.titleAt(row) ).colorize(.white)
+      return (opacityValues.titleAt(row)).colorize(.white)
     }
       return values[safe: row]?.colorize(.white)
   }

--- a/IBAnimatableApp/GradientViewController.swift
+++ b/IBAnimatableApp/GradientViewController.swift
@@ -21,11 +21,11 @@ class GradientViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     if usePredefinedGradient {
-    gView.predefinedGradient = GradientType(rawValue: gradientValues.valueAt(0))
-    gView.startPoint = GradientStartPoint(rawValue: startPointValues.valueAt(0)) ?? .top
+      gView.predefinedGradient = GradientType(rawValue: gradientValues.value(at: 0))
+      gView.startPoint = GradientStartPoint(rawValue: startPointValues.value(at: 0)) ?? .top
     } else {
-      gView.startColor = ColorType(rawValue: self.colorValues.valueAt(0))?.color
-      gView.endColor = ColorType(rawValue: self.colorValues.valueAt(0))?.color
+      gView.startColor = ColorType(rawValue: self.colorValues.value(at: 0))?.color
+      gView.endColor = ColorType(rawValue: self.colorValues.value(at: 0))?.color
     }
   }
 }
@@ -43,21 +43,21 @@ extension GradientViewController : UIPickerViewDelegate, UIPickerViewDataSource 
     label.textColor = .white
     label.textAlignment = .center
     label.minimumScaleFactor = 0.5
-    label.text = componentValues[component].titleAt(row)
+    label.text = componentValues[component].title(at: row)
     return label
   }
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-      return componentValues[component].titleAt(row).colorize(.white)
+    return componentValues[component].title(at: row).colorize(.white)
   }
   
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     if usePredefinedGradient {
-      gView.predefinedGradient = GradientType(rawValue: gradientValues.valueAt(pickerView.selectedRow(inComponent: 0)))
-      gView.startPoint = GradientStartPoint(rawValue: startPointValues.valueAt(pickerView.selectedRow(inComponent: 1))) ?? .top
+      gView.predefinedGradient = GradientType(rawValue: gradientValues.value(at: pickerView.selectedRow(inComponent: 0)))
+      gView.startPoint = GradientStartPoint(rawValue: startPointValues.value(at: pickerView.selectedRow(inComponent: 1))) ?? .top
     } else {
-      gView.startColor = ColorType(rawValue: self.colorValues.valueAt(pickerView.selectedRow(inComponent: 0)))?.color
-      gView.endColor = ColorType(rawValue: self.colorValues.valueAt(pickerView.selectedRow(inComponent: 1)))?.color
-      gView.startPoint = GradientStartPoint(rawValue: startPointValues.valueAt(pickerView.selectedRow(inComponent: 2))) ?? .top
+      gView.startColor = ColorType(rawValue: self.colorValues.value(at: pickerView.selectedRow(inComponent: 0)))?.color
+      gView.endColor = ColorType(rawValue: self.colorValues.value(at: pickerView.selectedRow(inComponent: 1)))?.color
+      gView.startPoint = GradientStartPoint(rawValue: startPointValues.value(at: pickerView.selectedRow(inComponent: 2))) ?? .top
 
     }
     gView.configGradient()

--- a/IBAnimatableApp/MaskViewController.swift
+++ b/IBAnimatableApp/MaskViewController.swift
@@ -75,7 +75,7 @@ extension MaskViewController : UIPickerViewDelegate, UIPickerViewDataSource {
     if component == 0 {
       label.text = entries[safe: row]?.name
     } else {
-      label.text = selectedEntry.params[safe: component - 1]?.titleAt(row)
+      label.text = selectedEntry.params[safe: component - 1]?.title(at: row)
     }
     return label
     

--- a/IBAnimatableApp/ParamType.swift
+++ b/IBAnimatableApp/ParamType.swift
@@ -3,7 +3,7 @@
 //  IBAnimatableApp
 //
 //  Created by jason akakpo on 27/07/16.
-//  Copyright © 2016 Jake Lin. All rights reserved.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
 //
 
 import Foundation
@@ -11,6 +11,7 @@ import UIKit
 
 
 extension String {
+  /// Returns `NSAttributedString` with specified color.
   func colorize(_ color: UIColor) -> NSAttributedString {
     return NSAttributedString(string: self, attributes: [NSForegroundColorAttributeName: color])
   }
@@ -22,7 +23,6 @@ extension Array {
     return indices.contains(index) ? self[index] : nil  /// Returns the element at the specified index iff it is within bounds, otherwise nil.
   }
 }
-
 
 
 enum ParamType {
@@ -46,7 +46,7 @@ enum ParamType {
     }
   }
   /// Number at Index, use just for number case.
-  func valueAt(_ index: Int) -> String {
+  func value(at index: Int) -> String {
     let formatter = NumberFormatter()
     formatter.minimumFractionDigits = 0
     formatter.maximumFractionDigits = 3
@@ -61,12 +61,12 @@ enum ParamType {
     }
   }
   
-  func titleAt(_ index: Int) -> String {
+  func title(at index: Int) -> String {
     switch self {
     case .enumeration(_):
-      return valueAt(index)
+      return value(at: index)
     case let .number(_, _, _, _, unit):
-      return   ("\(valueAt(index)) \(unit)").trimmingCharacters(in: CharacterSet.whitespaces)
+      return   ("\(value(at: index)) \(unit)").trimmingCharacters(in: CharacterSet.whitespaces)
     }
   }
 }
@@ -82,7 +82,7 @@ extension PickerEntry {
   func toString(selectedIndexes indexes: Int?...) -> String {
     
     let paramString = indexes.enumerated().flatMap({ (i: Int, index: Int?) -> String? in
-      return params[safe:i]?.valueAt(index ?? 0)
+      return params[safe:i]?.value(at: index ?? 0)
     }).joined(separator: ",")
     
     return "\(name)(\(paramString))"

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -278,7 +278,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JdN-Fw-n4f" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="gJl-3C-ZLK" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4474" y="-282"/>
+            <point key="canvasLocation" x="4730" y="-282"/>
         </scene>
         <!--UserInterfaceMask-->
         <scene sceneID="jMl-6T-PN8">
@@ -301,6 +301,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="login-bg" translatesAutoresizingMaskIntoConstraints="NO" id="YyC-Db-hLM" customClass="AnimatableImageView" customModule="IBAnimatable"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JH8-bL-Mlf" customClass="AnimatableView" customModule="IBAnimatable">
+                                <subviews>
+                                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" image="checked" translatesAutoresizingMaskIntoConstraints="NO" id="3zJ-p8-8T7">
+                                        <frame key="frameInset" minX="50.00%" minY="120" width="80" height="80"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="62w-fm-V0f" customClass="AnimatableView" customModule="IBAnimatable">
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="cfZ-nJ-ANc" userLabel="Picker Stack View" customClass="AnimatableStackView" customModule="IBAnimatable">
@@ -364,17 +373,21 @@ Opacity</string>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="JH8-bL-Mlf" firstAttribute="centerX" secondItem="YyC-Db-hLM" secondAttribute="centerX" id="07q-D4-TQQ"/>
                             <constraint firstItem="YyC-Db-hLM" firstAttribute="width" secondItem="cfy-Fq-hgK" secondAttribute="width" id="0ec-U9-lrX"/>
+                            <constraint firstItem="JH8-bL-Mlf" firstAttribute="width" secondItem="YyC-Db-hLM" secondAttribute="width" id="BuZ-5B-a1Q"/>
                             <constraint firstItem="YyC-Db-hLM" firstAttribute="centerY" secondItem="cfy-Fq-hgK" secondAttribute="centerY" id="CHQ-Mf-kHl"/>
                             <constraint firstAttribute="bottom" secondItem="62w-fm-V0f" secondAttribute="bottom" id="GNa-Y6-Ych"/>
+                            <constraint firstItem="JH8-bL-Mlf" firstAttribute="height" secondItem="YyC-Db-hLM" secondAttribute="height" id="PEE-tx-y27"/>
                             <constraint firstAttribute="trailing" secondItem="62w-fm-V0f" secondAttribute="trailing" id="Xiq-Pp-h45"/>
                             <constraint firstItem="62w-fm-V0f" firstAttribute="leading" secondItem="cfy-Fq-hgK" secondAttribute="leading" id="bML-ll-g7M"/>
                             <constraint firstItem="YyC-Db-hLM" firstAttribute="height" secondItem="cfy-Fq-hgK" secondAttribute="height" id="eZa-zs-qXa"/>
+                            <constraint firstItem="JH8-bL-Mlf" firstAttribute="centerY" secondItem="YyC-Db-hLM" secondAttribute="centerY" id="hEq-dR-xrg"/>
                             <constraint firstItem="YyC-Db-hLM" firstAttribute="centerX" secondItem="cfy-Fq-hgK" secondAttribute="centerX" id="tZG-ct-gOe"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="imageView" destination="YyC-Db-hLM" id="50v-4v-VYt"/>
+                        <outlet property="blurEffectView" destination="JH8-bL-Mlf" id="bYF-Mj-mSN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FX3-ux-6qf" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -532,7 +545,6 @@ Opacity</string>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstItem="75u-pF-Sy6" firstAttribute="leading" secondItem="Pif-t8-9Jy" secondAttribute="leading" constant="10" id="cwn-6x-vrp"/>
                                             <constraint firstAttribute="bottom" secondItem="75u-pF-Sy6" secondAttribute="bottom" constant="10" id="euW-Le-T71"/>


### PR DESCRIPTION
In this PR, we fix the blur effect view. Now we can re-set `blurEffectStyle` and it will apply the new blue effect to the view 😉. We can also support `vibrancyEffectStyle` but we can only set it once because  once we use `UIVisualEffectView`, Apple uses a private class like `_UIVisualEffectContentView` to contain subviews which will change the view hierarchy. After that, we are not able to restore the original view hierarchy. Also, the Auto Layout constraints will be broken when the system change the view hierarchy. We need to manually re-set up the constraints or use Autoresizing masks to layout the subviews.

@lastMove Can you have a look when you have time. 

Related to #221 and #298
