### PR TITLE
Refactor activity indicators

### DIFF
--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -4,21 +4,29 @@
 //
 
 import UIKit
+
+/// Protocol for activity indicator animations.
 public protocol ActivityIndicatorAnimatable: class {
+  /// Animation type
   var animationType: String { get set }
+  /// Color of the indicator
   var color: UIColor { get set }
+  /// Specify whether hide the indicator when the animation stopped
   var hidesWhenStopped: Bool { get set }
+  /// Animating status
   var isAnimating: Bool { get set }
 }
 
 public extension ActivityIndicatorAnimatable where Self: UIView {
 
+  /// Start animating the activity indicator
   public func startAnimating() {
     isHidden = false
     configLayer()
     isAnimating = true
   }
 
+  /// Stop animating the activity indicator
   public func stopAnimating() {
     layer.sublayers = nil
     isAnimating = false
@@ -36,12 +44,11 @@ private extension ActivityIndicatorAnimatable where Self: UIView {
       return
     }
 
-    let type = ActivityIndicatorType.fromString(string: animationType)
-    guard type != .None else {
+    guard let activityIndicatorType = ActivityIndicatorType(string: animationType), activityIndicatorType != .none else {
       return
     }
 
-    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(activityIndicatorType: type)
+    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(activityIndicatorType: activityIndicatorType)
     activityIndicator.configAnimation(in: layer, size: bounds.size, color: color)
     layer.speed = 1
   }

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -5,10 +5,10 @@
 
 import UIKit
 
-/// Protocol for activity indicator animations.
+/// Protocol for activity indicator view.
 public protocol ActivityIndicatorAnimatable: class {
   /// Animation type
-  var animationType: String { get set }
+  var animationType: ActivityIndicatorType { get set }
   /// Color of the indicator
   var color: UIColor { get set }
   /// Specify whether hide the indicator when the animation stopped
@@ -44,11 +44,11 @@ private extension ActivityIndicatorAnimatable where Self: UIView {
       return
     }
 
-    guard let activityIndicatorType = ActivityIndicatorType(string: animationType), activityIndicatorType != .none else {
+    if case .none = animationType {
       return
     }
 
-    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(activityIndicatorType: activityIndicatorType)
+    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(activityIndicatorType: animationType)
     activityIndicator.configAnimation(in: layer, size: bounds.size, color: color)
     layer.speed = 1
   }

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -48,7 +48,7 @@ private extension ActivityIndicatorAnimatable where Self: UIView {
       return
     }
 
-    let activityIndicator = ActivityIndicatorFactory.generateActivityIndicator(activityIndicatorType: animationType)
+    let activityIndicator = ActivityIndicatorFactory.makeActivityIndicator(activityIndicatorType: animationType)
     activityIndicator.configAnimation(in: layer, size: bounds.size, color: color)
     layer.speed = 1
   }

--- a/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
@@ -40,7 +40,7 @@ public class ActivityIndicatorAnimationAudioEqualizer: ActivityIndicatorAnimatin
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationAudioEqualizer {
+private extension ActivityIndicatorAnimationAudioEqualizer {
 
   func makeAnimation(duration: CFTimeInterval, values: [Double]) -> CAKeyframeAnimation {
     let animation = CAKeyframeAnimation()

--- a/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
@@ -25,7 +25,7 @@ public class ActivityIndicatorAnimationAudioEqualizer: ActivityIndicatorAnimatin
     // Draw lines
     for i in 0 ..< 4 {
       let animation = makeAnimation(duration: duration[i], values: values)
-      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,

--- a/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
@@ -24,8 +24,8 @@ public class ActivityIndicatorAnimationAudioEqualizer: ActivityIndicatorAnimatin
 
     // Draw lines
     for i in 0 ..< 4 {
-      let animation = createAnimation(duration: duration[i], values: values)
-      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let animation = makeAnimation(duration: duration[i], values: values)
+      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,
@@ -42,7 +42,7 @@ public class ActivityIndicatorAnimationAudioEqualizer: ActivityIndicatorAnimatin
 
 fileprivate extension ActivityIndicatorAnimationAudioEqualizer {
 
-  func createAnimation(duration: CFTimeInterval, values: [Double]) -> CAKeyframeAnimation {
+  func makeAnimation(duration: CFTimeInterval, values: [Double]) -> CAKeyframeAnimation {
     let animation = CAKeyframeAnimation()
     animation.keyPath = "path"
     animation.isAdditive = true

--- a/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationBallBeat: ActivityIndicatorAnimating {
 
     // Draw circles
     for i in 0 ..< 3 {
-      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
@@ -39,7 +39,7 @@ public class ActivityIndicatorAnimationBallBeat: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallBeat {
+private extension ActivityIndicatorAnimationBallBeat {
 
   var scaleAnimation: CAKeyframeAnimation {
     let scaleAnimation = CAKeyframeAnimation(keyPath: "transform.scale")

--- a/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationBallBeat: ActivityIndicatorAnimating {
 
     // Draw circles
     for i in 0 ..< 3 {
-      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
@@ -17,7 +17,7 @@ public class ActivityIndicatorAnimationBallClipRotate: ActivityIndicatorAnimatin
     let animation = self.animation
 
     // Draw circle
-    let circle = ActivityIndicatorShape.RingThirdFour.createLayerWith(size: CGSize(width: size.width, height: size.height), color: color)
+    let circle = ActivityIndicatorShape.RingThirdFour.makeLayer(size: CGSize(width: size.width, height: size.height), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
@@ -44,7 +44,7 @@ private extension ActivityIndicatorAnimationBallClipRotate {
   var rotateAnimation: CAKeyframeAnimation {
     let rotateAnimation = CAKeyframeAnimation(keyPath: "transform.rotation.z")
     rotateAnimation.keyTimes = scaleAnimation.keyTimes
-    rotateAnimation.values = [0, M_PI, 2 * M_PI]
+    rotateAnimation.values = [0, CGFloat.pi, 2 * CGFloat.pi]
     return rotateAnimation
   }
 

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
@@ -32,7 +32,7 @@ public class ActivityIndicatorAnimationBallClipRotate: ActivityIndicatorAnimatin
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallClipRotate {
+private extension ActivityIndicatorAnimationBallClipRotate {
 
   var scaleAnimation: CAKeyframeAnimation {
     let scaleAnimation = CAKeyframeAnimation(keyPath: "transform.scale")

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
@@ -17,7 +17,7 @@ public class ActivityIndicatorAnimationBallClipRotate: ActivityIndicatorAnimatin
     let animation = self.animation
 
     // Draw circle
-    let circle = ActivityIndicatorShape.RingThirdFour.makeLayer(size: CGSize(width: size.width, height: size.height), color: color)
+    let circle = ActivityIndicatorShape.ringThirdFour.makeLayer(size: CGSize(width: size.width, height: size.height), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -38,7 +38,7 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
 
 fileprivate extension ActivityIndicatorAnimationBallClipRotateMultiple {
 
-  func createAnimationIn(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, reverse: Bool) -> CAAnimation {
+  func makeAnimationIn(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, reverse: Bool) -> CAAnimation {
     // Scale animation
     let scaleAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
     scaleAnimation.keyTimes = [0, 0.5, 1]
@@ -69,12 +69,12 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotateMultiple {
 
   // swiftlint:disable:next function_parameter_count
   func circleOf(shape: ActivityIndicatorShape, duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGFloat, color: UIColor, reverse: Bool) {
-    let circle = shape.createLayerWith(size: CGSize(width: size, height: size), color: color)
+    let circle = shape.makeLayer(size: CGSize(width: size, height: size), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size) / 2,
                        y: (layer.bounds.size.height - size) / 2,
                        width: size,
                        height: size)
-    let animation = createAnimationIn(duration: duration, timingFunction: timingFunction, reverse: reverse)
+    let animation = makeAnimationIn(duration: duration, timingFunction: timingFunction, reverse: reverse)
 
     circle.frame = frame
     circle.add(animation, forKey: "animation")

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -18,18 +18,20 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
     let smallCircleSize: CGFloat = size.width / 2
     let longDuration: CFTimeInterval = 1
     let timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-    circleOf(shape: .ringTwoHalfHorizontal,
+    let circleLayer1 = makeCircleLayerOf(shape: .ringTwoHalfHorizontal,
              duration: longDuration,
              timingFunction: timingFunction,
-             layer: layer,
+             layerSize: layer.frame.size,
              size: bigCircleSize,
              color: color, reverse: false)
-    circleOf(shape: .ringTwoHalfVertical,
+    let circleLayer2 = makeCircleLayerOf(shape: .ringTwoHalfVertical,
              duration: longDuration,
              timingFunction: timingFunction,
-             layer: layer,
+             layerSize: layer.frame.size,
              size: smallCircleSize,
              color: color, reverse: true)
+    layer.addSublayer(circleLayer1)
+    layer.addSublayer(circleLayer2)
   }
 
 }
@@ -38,7 +40,7 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
 
 private extension ActivityIndicatorAnimationBallClipRotateMultiple {
 
-  func makeAnimationIn(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, reverse: Bool) -> CAAnimation {
+  func makeAnimation(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, reverse: Bool) -> CAAnimation {
     // Scale animation
     let scaleAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
     scaleAnimation.keyTimes = [0, 0.5, 1]
@@ -68,17 +70,18 @@ private extension ActivityIndicatorAnimationBallClipRotateMultiple {
   }
 
   // swiftlint:disable:next function_parameter_count
-  func circleOf(shape: ActivityIndicatorShape, duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGFloat, color: UIColor, reverse: Bool) {
-    let circle = shape.makeLayer(size: CGSize(width: size, height: size), color: color)
-    let frame = CGRect(x: (layer.bounds.size.width - size) / 2,
-                       y: (layer.bounds.size.height - size) / 2,
+  func makeCircleLayerOf(shape: ActivityIndicatorShape, duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layerSize: CGSize, size: CGFloat, color: UIColor, reverse: Bool) -> CALayer {
+    let circleLayer = shape.makeLayer(size: CGSize(width: size, height: size), color: color)
+    let frame = CGRect(x: (layerSize.width - size) / 2,
+                       y: (layerSize.height - size) / 2,
                        width: size,
                        height: size)
-    let animation = makeAnimationIn(duration: duration, timingFunction: timingFunction, reverse: reverse)
+    let animation = makeAnimation(duration: duration, timingFunction: timingFunction, reverse: reverse)
 
-    circle.frame = frame
-    circle.add(animation, forKey: "animation")
-    layer.addSublayer(circle)
+    circleLayer.frame = frame
+    circleLayer.add(animation, forKey: "animation")
+    
+    return circleLayer
   }
 
 }

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -18,13 +18,13 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
     let smallCircleSize: CGFloat = size.width / 2
     let longDuration: CFTimeInterval = 1
     let timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-    circleOf(shape: .RingTwoHalfHorizontal,
+    circleOf(shape: .ringTwoHalfHorizontal,
              duration: longDuration,
              timingFunction: timingFunction,
              layer: layer,
              size: bigCircleSize,
              color: color, reverse: false)
-    circleOf(shape: .RingTwoHalfVertical,
+    circleOf(shape: .ringTwoHalfVertical,
              duration: longDuration,
              timingFunction: timingFunction,
              layer: layer,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -51,9 +51,9 @@ private extension ActivityIndicatorAnimationBallClipRotateMultiple {
     rotateAnimation.keyTimes = scaleAnimation.keyTimes
     rotateAnimation.timingFunctions = [timingFunction, timingFunction]
     if !reverse {
-      rotateAnimation.values = [0, M_PI, 2 * M_PI]
+      rotateAnimation.values = [0, CGFloat.pi, 2 * CGFloat.pi]
     } else {
-      rotateAnimation.values = [0, -M_PI, -2 * M_PI]
+      rotateAnimation.values = [0, -CGFloat.pi, -2 * CGFloat.pi]
     }
     rotateAnimation.duration = duration
 

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -36,7 +36,7 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallClipRotateMultiple {
+private extension ActivityIndicatorAnimationBallClipRotateMultiple {
 
   func makeAnimationIn(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, reverse: Bool) -> CAAnimation {
     // Scale animation

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -89,7 +89,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
     let rotateAnimation = CAKeyframeAnimation(keyPath:"transform.rotation.z")
     rotateAnimation.keyTimes = scaleAnimation.keyTimes
     rotateAnimation.timingFunctions = [timingFunction, timingFunction]
-    rotateAnimation.values = [0, M_PI, 2 * M_PI]
+    rotateAnimation.values = [0, CGFloat.pi, 2 * CGFloat.pi]
     rotateAnimation.duration = duration
     return rotateAnimation
   }

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationBallClipRotatePulse: ActivityIndicatorAni
 private extension ActivityIndicatorAnimationBallClipRotatePulse {
 
   func animateSmallCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
-    let animation = makeSmallCircleAanimation()
+    let animation = makeSmallCircleAnimation()
     let circleSize = size.width / 2
     let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - circleSize) / 2,
@@ -38,7 +38,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
     layer.addSublayer(circle)
   }
 
-  func makeSmallCircleAanimation() -> CAKeyframeAnimation {
+  func makeSmallCircleAnimation() -> CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform.scale")
     animation.keyTimes = [0, 0.3, 1]
     animation.timingFunctions = [timingFunction, timingFunction]
@@ -56,7 +56,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
 private extension ActivityIndicatorAnimationBallClipRotatePulse {
 
   func animateBigCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
-    let animation = makeBigCircleAanimation()
+    let animation = makeBigCircleAnimation()
     let circle = ActivityIndicatorShape.ringTwoHalfVertical.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
@@ -67,7 +67,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
     layer.addSublayer(circle)
   }
 
-  func makeBigCircleAanimation() -> CAAnimationGroup {
+  func makeBigCircleAnimation() -> CAAnimationGroup {
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, rotateAnimation]
     animation.duration = duration

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -28,7 +28,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
   func animateSmallCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
     let animation = makeSmallCircleAanimation()
     let circleSize = size.width / 2
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - circleSize) / 2,
                        y: (layer.bounds.size.height - circleSize) / 2,
                        width: circleSize,
@@ -57,7 +57,7 @@ private extension ActivityIndicatorAnimationBallClipRotatePulse {
 
   func animateBigCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
     let animation = makeBigCircleAanimation()
-    let circle = ActivityIndicatorShape.RingTwoHalfVertical.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.ringTwoHalfVertical.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -28,7 +28,7 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
   func smallCircleWith(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
     let animation = createSmallCircleAanimation()
     let circleSize = size.width / 2
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - circleSize) / 2,
                        y: (layer.bounds.size.height - circleSize) / 2,
                        width: circleSize,
@@ -57,7 +57,7 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
 
   func bigCircleWith(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
     let animation = createBigCircleAanimation()
-    let circle = ActivityIndicatorShape.RingTwoHalfVertical.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.RingTwoHalfVertical.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -15,18 +15,18 @@ public class ActivityIndicatorAnimationBallClipRotatePulse: ActivityIndicatorAni
   // MARK: ActivityIndicatorAnimating
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
-    smallCircleWith(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
-    bigCircleWith(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
+    animateSmallCircle(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
+    animateBigCircle(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
   }
 
 }
 
 // MARK: Small circle
 
-fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
+private extension ActivityIndicatorAnimationBallClipRotatePulse {
 
-  func smallCircleWith(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
-    let animation = createSmallCircleAanimation()
+  func animateSmallCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
+    let animation = makeSmallCircleAanimation()
     let circleSize = size.width / 2
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - circleSize) / 2,
@@ -38,7 +38,7 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
     layer.addSublayer(circle)
   }
 
-  func createSmallCircleAanimation() -> CAKeyframeAnimation {
+  func makeSmallCircleAanimation() -> CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform.scale")
     animation.keyTimes = [0, 0.3, 1]
     animation.timingFunctions = [timingFunction, timingFunction]
@@ -53,10 +53,10 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
 
 // MARK: Big circle
 
-fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
+private extension ActivityIndicatorAnimationBallClipRotatePulse {
 
-  func bigCircleWith(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
-    let animation = createBigCircleAanimation()
+  func animateBigCircle(duration: CFTimeInterval, timingFunction: CAMediaTimingFunction, layer: CALayer, size: CGSize, color: UIColor) {
+    let animation = makeBigCircleAanimation()
     let circle = ActivityIndicatorShape.RingTwoHalfVertical.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
@@ -67,7 +67,7 @@ fileprivate extension ActivityIndicatorAnimationBallClipRotatePulse {
     layer.addSublayer(circle)
   }
 
-  func createBigCircleAanimation() -> CAAnimationGroup {
+  func makeBigCircleAanimation() -> CAAnimationGroup {
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, rotateAnimation]
     animation.duration = duration

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
     // Draw circles
     for i in 0 ..< 3 {
       for j in 0 ..< 3 {
-        let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+        let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
         let frame = CGRect(x: x + circleSize * CGFloat(j) + circleSpacing * CGFloat(j),
                            y: y + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                            width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
     // Draw circles
     for i in 0 ..< 3 {
       for j in 0 ..< 3 {
-        let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+        let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
         let frame = CGRect(x: x + circleSize * CGFloat(j) + circleSpacing * CGFloat(j),
                            y: y + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                            width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
@@ -44,7 +44,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallGridBeat {
+private extension ActivityIndicatorAnimationBallGridBeat {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "opacity")

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
     // Draw circles
     for i in 0 ..< 3 {
       for j in 0 ..< 3 {
-        let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+        let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
         let frame = CGRect(x: x + circleSize * CGFloat(j) + circleSpacing * CGFloat(j),
                            y: y + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                            width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
     // Draw circles
     for i in 0 ..< 3 {
       for j in 0 ..< 3 {
-        let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+        let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
         let frame = CGRect(x: x + circleSize * CGFloat(j) + circleSpacing * CGFloat(j),
                            y: y + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                            width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
@@ -44,7 +44,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallGridPulse {
+private extension ActivityIndicatorAnimationBallGridPulse {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
@@ -21,7 +21,7 @@ public class ActivityIndicatorAnimationBallPulse: ActivityIndicatorAnimating {
 
         // Draw circles
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+            let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
             let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                 y: y,
                 width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
@@ -21,7 +21,7 @@ public class ActivityIndicatorAnimationBallPulse: ActivityIndicatorAnimating {
 
         // Draw circles
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+            let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
             let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                 y: y,
                 width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
@@ -37,7 +37,7 @@ public class ActivityIndicatorAnimationBallPulse: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallPulse {
+private extension ActivityIndicatorAnimationBallPulse {
 
   var animation: CAKeyframeAnimation {
     let duration: CFTimeInterval = 0.75

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
@@ -45,7 +45,7 @@ public class ActivityIndicatorAnimationBallPulseRise: ActivityIndicatorAnimating
 
 // MARK: - Setup Odd
 
-fileprivate extension ActivityIndicatorAnimationBallPulseRise {
+private extension ActivityIndicatorAnimationBallPulseRise {
 
   var oddAnimation: CAAnimation {
     let scaleAnimation = oddScaleAnimation
@@ -80,7 +80,7 @@ fileprivate extension ActivityIndicatorAnimationBallPulseRise {
 
 // MARK: - Even Odd
 
-fileprivate extension ActivityIndicatorAnimationBallPulseRise {
+private extension ActivityIndicatorAnimationBallPulseRise {
 
   var evenAnimation: CAAnimation {
     let scaleAnimation = evenScaleAnimation

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
@@ -25,7 +25,7 @@ public class ActivityIndicatorAnimationBallPulseRise: ActivityIndicatorAnimating
     let oddAnimation = self.oddAnimation
     let evenAnimation = self.evenAnimation
     for i in 0 ..< 5 {
-      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
@@ -25,7 +25,7 @@ public class ActivityIndicatorAnimationBallPulseRise: ActivityIndicatorAnimating
     let oddAnimation = self.oddAnimation
     let evenAnimation = self.evenAnimation
     for i in 0 ..< 5 {
-      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -45,7 +45,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallPulseSync {
+private extension ActivityIndicatorAnimationBallPulseSync {
 
   var animation: CAKeyframeAnimation {
     let deltaY = (size.height / 2 - circleSize / 2) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -27,7 +27,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
     
     // Draw circles
     for i in 0 ..< 3 {
-      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -27,7 +27,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
     
     // Draw circles
     for i in 0 ..< 3 {
-      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
                          y: y,
                          width: circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
@@ -43,7 +43,7 @@ public class ActivityIndicatorAnimationBallRotate: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallRotate {
+private extension ActivityIndicatorAnimationBallRotate {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
@@ -19,9 +19,9 @@ public class ActivityIndicatorAnimationBallRotate: ActivityIndicatorAnimating {
     let animation = self.animation
 
     // Draw circles
-    let leftCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-    let rightCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-    let centerCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let leftCircle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let rightCircle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let centerCircle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
 
     leftCircle.opacity = 0.8
     leftCircle.frame = CGRect(x: 0, y: (size.height - circleSize) / 2, width: circleSize, height: circleSize)

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
@@ -67,7 +67,7 @@ private extension ActivityIndicatorAnimationBallRotate {
     let rotateAnimation = CAKeyframeAnimation(keyPath:"transform.rotation.z")
     rotateAnimation.keyTimes = [0, 0.5, 1]
     rotateAnimation.timingFunctions = [timingFunction, timingFunction]
-    rotateAnimation.values = [0, M_PI, 2 * M_PI]
+    rotateAnimation.values = [0, CGFloat.pi, 2 * CGFloat.pi]
     rotateAnimation.duration = duration
     return rotateAnimation
 

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
@@ -19,9 +19,9 @@ public class ActivityIndicatorAnimationBallRotate: ActivityIndicatorAnimating {
     let animation = self.animation
 
     // Draw circles
-    let leftCircle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
-    let rightCircle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
-    let centerCircle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let leftCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let rightCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let centerCircle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
 
     leftCircle.opacity = 0.8
     leftCircle.frame = CGRect(x: 0, y: (size.height - circleSize) / 2, width: circleSize, height: circleSize)

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
@@ -17,7 +17,7 @@ public class ActivityIndicatorAnimationBallRotateChase: ActivityIndicatorAnimati
     let circleSize = size.width / 5
     for i in 0 ..< 5 {
       let factor = Float(i) * 1.0 / 5
-      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let animation = rotateAnimation(rate: factor, x: layer.bounds.size.width / 2, y: layer.bounds.size.height / 2, size: CGSize(width: size.width - circleSize, height: size.height - circleSize))
 
       circle.frame = CGRect(x: 0, y: 0, width: circleSize, height: circleSize)

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
@@ -31,7 +31,7 @@ public class ActivityIndicatorAnimationBallRotateChase: ActivityIndicatorAnimati
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallRotateChase {
+private extension ActivityIndicatorAnimationBallRotateChase {
 
   func rotateAnimation(rate: Float, x: CGFloat, y: CGFloat, size: CGSize) -> CAAnimationGroup {
     let fromScale = 1 - rate

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
@@ -17,7 +17,7 @@ public class ActivityIndicatorAnimationBallRotateChase: ActivityIndicatorAnimati
     let circleSize = size.width / 5
     for i in 0 ..< 5 {
       let factor = Float(i) * 1.0 / 5
-      let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
       let animation = rotateAnimation(rate: factor, x: layer.bounds.size.width / 2, y: layer.bounds.size.height / 2, size: CGSize(width: size.width - circleSize, height: size.height - circleSize))
 
       circle.frame = CGRect(x: 0, y: 0, width: circleSize, height: circleSize)

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
@@ -46,7 +46,7 @@ private extension ActivityIndicatorAnimationBallRotateChase {
     let positionAnimation = CAKeyframeAnimation(keyPath: "position")
     positionAnimation.duration = duration
     positionAnimation.repeatCount = .infinity
-    positionAnimation.path = UIBezierPath(arcCenter: CGPoint(x: x, y: y), radius: size.width / 2, startAngle: 3 * CGFloat(M_PI) * 0.5, endAngle: 3 * CGFloat(M_PI) * 0.5 + 2 * CGFloat(M_PI), clockwise: true).cgPath
+    positionAnimation.path = UIBezierPath(arcCenter: CGPoint(x: x, y: y), radius: size.width / 2, startAngle: 3 * CGFloat.pi / 2, endAngle: 3 * CGFloat.pi / 2 + 2 * CGFloat.pi, clockwise: true).cgPath
 
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, positionAnimation]

--- a/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationBallScale: ActivityIndicatorAnimating {
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                           y: (layer.bounds.size.height - size.height) / 2,
                           width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
@@ -27,7 +27,7 @@ public class ActivityIndicatorAnimationBallScale: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallScale {
+private extension ActivityIndicatorAnimationBallScale {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationBallScale: ActivityIndicatorAnimating {
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
     circle.frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                           y: (layer.bounds.size.height - size.height) / 2,
                           width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
@@ -35,7 +35,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallScaleMultiple {
+private extension ActivityIndicatorAnimationBallScaleMultiple {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
@@ -18,7 +18,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
         let beginTimes = [0, 0.2, 0.4]
         let animation = self.animation
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
+            let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
             let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                 y: (layer.bounds.size.height - size.height) / 2,
                 width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
@@ -18,7 +18,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
         let beginTimes = [0, 0.2, 0.4]
         let animation = self.animation
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Circle.createLayerWith(size: size, color: color)
+            let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
             let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                 y: (layer.bounds.size.height - size.height) / 2,
                 width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
@@ -30,7 +30,7 @@ public class ActivityIndicatorAnimationBallScaleRipple: ActivityIndicatorAnimati
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallScaleRipple {
+private extension ActivityIndicatorAnimationBallScaleRipple {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationBallScaleRipple: ActivityIndicatorAnimati
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.Ring.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.Ring.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationBallScaleRipple: ActivityIndicatorAnimati
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.Ring.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.ring.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -35,7 +35,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallScaleRippleMultiple {
+private extension ActivityIndicatorAnimationBallScaleRippleMultiple {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -19,7 +19,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
         let beginTimes = [0.0, 0.2, 0.4]
         let animation = self.animation
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Ring.makeLayer(size: size, color: color)
+            let circle = ActivityIndicatorShape.ring.makeLayer(size: size, color: color)
             let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                 y: (layer.bounds.size.height - size.height) / 2,
                 width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -19,7 +19,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
         let beginTimes = [0.0, 0.2, 0.4]
         let animation = self.animation
         for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.Ring.createLayerWith(size: size, color: color)
+            let circle = ActivityIndicatorShape.Ring.makeLayer(size: size, color: color)
             let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                 y: (layer.bounds.size.height - size.height) / 2,
                 width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -54,7 +54,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallSpinFadeLoader {
+private extension ActivityIndicatorAnimationBallSpinFadeLoader {
   
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -25,7 +25,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
     
     // Draw circles
     for i in 0 ..< 8 {
-      let circle = circleAt(angle: CGFloat(M_PI_4 * Double(i)),
+      let circle = circleAt(angle: CGFloat.pi / 4 * CGFloat(i),
                             size: circleSize,
                             origin: CGPoint(x: x, y: y),
                             containerSize: size,

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -39,7 +39,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
   
   func circleAt(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
     let radius = containerSize.width / 2 - size / 2
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: size, height: size), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: size, height: size), color: color)
     let frame = CGRect(
       x: origin.x + radius * (cos(angle) + 1),
       y: origin.y + radius * (sin(angle) + 1),

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -25,7 +25,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
     
     // Draw circles
     for i in 0 ..< 8 {
-      let circle = circleAt(angle: CGFloat.pi / 4 * CGFloat(i),
+      let circle = makeCircleLayer(angle: CGFloat.pi / 4 * CGFloat(i),
                             size: circleSize,
                             origin: CGPoint(x: x, y: y),
                             containerSize: size,
@@ -37,7 +37,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
     }
   }
   
-  func circleAt(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
+  func makeCircleLayer(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
     let radius = containerSize.width / 2 - size / 2
     let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: size, height: size), color: color)
     let frame = CGRect(

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -39,7 +39,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
   
   func circleAt(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
     let radius = containerSize.width / 2 - size / 2
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: size, height: size), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: size, height: size), color: color)
     let frame = CGRect(
       x: origin.x + radius * (cos(angle) + 1),
       y: origin.y + radius * (sin(angle) + 1),

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -23,19 +23,19 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
     let animation = self.animation
 
     let topCenterCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-    changeAnimation(animation: animation, values:["{0,0}", "{hx,fy}", "{-hx,fy}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
+    change(animation: animation, values:["{0,0}", "{hx,fy}", "{-hx,fy}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     topCenterCircle.frame = CGRect(x: x + size.width / 2 - circleSize / 2, y: y, width: circleSize, height: circleSize)
     topCenterCircle.add(animation, forKey: "animation")
     layer.addSublayer(topCenterCircle)
 
     let bottomLeftCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-    changeAnimation(animation: animation, values: ["{0,0}", "{hx,-fy}", "{fx,0}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
+    change(animation: animation, values: ["{0,0}", "{hx,-fy}", "{fx,0}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     bottomLeftCircle.frame = CGRect(x: x, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomLeftCircle.add(animation, forKey: "animation")
     layer.addSublayer(bottomLeftCircle)
 
     let bottomRightCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-    changeAnimation(animation: animation, values: ["{0,0}", "{-fx,0}", "{-hx,-fy}", "{0,0}"], deltaX: deltaX, deltaY:deltaY)
+    change(animation: animation, values: ["{0,0}", "{-fx,0}", "{-hx,-fy}", "{0,0}"], deltaX: deltaX, deltaY:deltaY)
     bottomRightCircle.frame = CGRect(x: x + size.width - circleSize, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomRightCircle.add(animation, forKey: "animation")
     layer.addSublayer(bottomRightCircle)
@@ -57,7 +57,7 @@ private extension ActivityIndicatorAnimationBallTrianglePath {
     return animation
   }
 
-  func changeAnimation(animation: CAKeyframeAnimation, values rawValues: [String], deltaX: CGFloat, deltaY: CGFloat) {
+  func change(animation: CAKeyframeAnimation, values rawValues: [String], deltaX: CGFloat, deltaY: CGFloat) {
     let values = NSMutableArray(capacity: 5)
     for rawValue in rawValues {
       let point = CGPointFromString(translateString(valueString: rawValue, deltaX: deltaX, deltaY: deltaY))

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -22,19 +22,19 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
     let y = (layer.bounds.size.height - size.height) / 2
     let animation = self.animation
 
-    let topCenterCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let topCenterCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values:["{0,0}", "{hx,fy}", "{-hx,fy}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     topCenterCircle.frame = CGRect(x: x + size.width / 2 - circleSize / 2, y: y, width: circleSize, height: circleSize)
     topCenterCircle.add(animation, forKey: "animation")
     layer.addSublayer(topCenterCircle)
 
-    let bottomLeftCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let bottomLeftCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values: ["{0,0}", "{hx,-fy}", "{fx,0}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     bottomLeftCircle.frame = CGRect(x: x, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomLeftCircle.add(animation, forKey: "animation")
     layer.addSublayer(bottomLeftCircle)
 
-    let bottomRightCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let bottomRightCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values: ["{0,0}", "{-fx,0}", "{-hx,-fy}", "{0,0}"], deltaX: deltaX, deltaY:deltaY)
     bottomRightCircle.frame = CGRect(x: x + size.width - circleSize, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomRightCircle.add(animation, forKey: "animation")

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -45,7 +45,7 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallTrianglePath {
+private extension ActivityIndicatorAnimationBallTrianglePath {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform")

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -22,19 +22,19 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
     let y = (layer.bounds.size.height - size.height) / 2
     let animation = self.animation
 
-    let topCenterCircle = ActivityIndicatorShape.Ring.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let topCenterCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values:["{0,0}", "{hx,fy}", "{-hx,fy}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     topCenterCircle.frame = CGRect(x: x + size.width / 2 - circleSize / 2, y: y, width: circleSize, height: circleSize)
     topCenterCircle.add(animation, forKey: "animation")
     layer.addSublayer(topCenterCircle)
 
-    let bottomLeftCircle = ActivityIndicatorShape.Ring.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let bottomLeftCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values: ["{0,0}", "{hx,-fy}", "{fx,0}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
     bottomLeftCircle.frame = CGRect(x: x, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomLeftCircle.add(animation, forKey: "animation")
     layer.addSublayer(bottomLeftCircle)
 
-    let bottomRightCircle = ActivityIndicatorShape.Ring.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let bottomRightCircle = ActivityIndicatorShape.Ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     changeAnimation(animation: animation, values: ["{0,0}", "{-fx,0}", "{-hx,-fy}", "{0,0}"], deltaX: deltaX, deltaY:deltaY)
     bottomRightCircle.frame = CGRect(x: x + size.width - circleSize, y: y + size.height - circleSize, width: circleSize, height: circleSize)
     bottomRightCircle.add(animation, forKey: "animation")

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
@@ -47,7 +47,7 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
 private extension ActivityIndicatorAnimationBallZigZag {
 
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
     layer.addSublayer(circle)

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
@@ -30,14 +30,16 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
     animation.duration = duration
     animation.repeatCount = .infinity
     animation.isRemovedOnCompletion = false
-    circleAt(frame: frame, layer: layer, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
-
+    let circle1 = makeCircleLayer(frame: frame, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    layer.addSublayer(circle1)
+    
     // Circle 2 animation
     animation.values = [NSValue(caTransform3D: CATransform3DMakeTranslation(0, 0, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(deltaX, deltaY, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(-deltaX, deltaY, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(0, 0, 0))]
-    circleAt(frame: frame, layer: layer, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    let circle2 = makeCircleLayer(frame: frame, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    layer.addSublayer(circle2)
   }
 
 }
@@ -46,11 +48,11 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
 
 private extension ActivityIndicatorAnimationBallZigZag {
 
-  func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
+  func makeCircleLayer(frame: CGRect, size: CGSize, color: UIColor, animation: CAAnimation) -> CALayer {
     let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
-    layer.addSublayer(circle)
+    return circle
   }
 
 }

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
@@ -44,7 +44,7 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallZigZag {
+private extension ActivityIndicatorAnimationBallZigZag {
 
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
@@ -47,7 +47,7 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
 fileprivate extension ActivityIndicatorAnimationBallZigZag {
 
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
     layer.addSublayer(circle)

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
@@ -50,7 +50,7 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
 private extension ActivityIndicatorAnimationBallZigZagDeflect {
   
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
     layer.addSublayer(circle)

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
@@ -33,14 +33,16 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
     animation.repeatCount = .infinity
     animation.autoreverses = true
     animation.isRemovedOnCompletion = false
-    circleAt(frame: frame, layer: layer, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    let circle1 = makeCircleLayer(frame: frame, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    layer.addSublayer(circle1)
     
     // Circle 2
     animation.values = [NSValue(caTransform3D: CATransform3DMakeTranslation(0, 0, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(deltaX, deltaY, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(-deltaX, deltaY, 0)),
                         NSValue(caTransform3D: CATransform3DMakeTranslation(0, 0, 0))]
-    circleAt(frame: frame, layer: layer, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    let circle2 = makeCircleLayer(frame: frame, size: CGSize(width: circleSize, height: circleSize), color: color, animation: animation)
+    layer.addSublayer(circle2)
   }
   
 }
@@ -49,11 +51,11 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
 
 private extension ActivityIndicatorAnimationBallZigZagDeflect {
   
-  func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
+  func makeCircleLayer(frame: CGRect, size: CGSize, color: UIColor, animation: CAAnimation) -> CALayer{
     let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
-    layer.addSublayer(circle)
+    return circle
   }
   
 }

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
@@ -50,7 +50,7 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
 fileprivate extension ActivityIndicatorAnimationBallZigZagDeflect {
   
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)
     circle.frame = frame
     circle.add(animation, forKey: "animation")
     layer.addSublayer(circle)

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
@@ -47,7 +47,7 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationBallZigZagDeflect {
+private extension ActivityIndicatorAnimationBallZigZagDeflect {
   
   func circleAt(frame: CGRect, layer: CALayer, size: CGSize, color: UIColor, animation: CAAnimation) {
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: size, color: color)

--- a/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
@@ -56,7 +56,7 @@ private extension ActivityIndicatorAnimationCubeTransition {
     let rotateAnimation = CAKeyframeAnimation(keyPath: "transform.rotation.z")
     rotateAnimation.keyTimes = scaleAnimation.keyTimes
     rotateAnimation.timingFunctions = scaleAnimation.timingFunctions
-    rotateAnimation.values = [0, CGFloat(-M_PI_2), CGFloat(-M_PI), CGFloat(-1.5 * M_PI), CGFloat(-2 * M_PI)]
+    rotateAnimation.values = [0, -CGFloat.pi / 2, -CGFloat.pi, -1.5 * CGFloat.pi, -2 * CGFloat.pi]
     rotateAnimation.duration = duration
     return rotateAnimation
   }

--- a/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
@@ -28,7 +28,7 @@ public class ActivityIndicatorAnimationCubeTransition: ActivityIndicatorAnimatin
 
     let animation = self.animation
     for i in 0 ..< 2 {
-      let square = ActivityIndicatorShape.Rectangle.makeLayer(size: CGSize(width: squareSize, height: squareSize), color: color)
+      let square = ActivityIndicatorShape.rectangle.makeLayer(size: CGSize(width: squareSize, height: squareSize), color: color)
       let frame = CGRect(x: x, y: y, width: squareSize, height: squareSize)
 
       animation.beginTime = beginTime + beginTimes[i]

--- a/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
@@ -41,7 +41,7 @@ public class ActivityIndicatorAnimationCubeTransition: ActivityIndicatorAnimatin
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationCubeTransition {
+private extension ActivityIndicatorAnimationCubeTransition {
 
   var animation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
@@ -28,7 +28,7 @@ public class ActivityIndicatorAnimationCubeTransition: ActivityIndicatorAnimatin
 
     let animation = self.animation
     for i in 0 ..< 2 {
-      let square = ActivityIndicatorShape.Rectangle.createLayerWith(size: CGSize(width: squareSize, height: squareSize), color: color)
+      let square = ActivityIndicatorShape.Rectangle.makeLayer(size: CGSize(width: squareSize, height: squareSize), color: color)
       let frame = CGRect(x: x, y: y, width: squareSize, height: squareSize)
 
       animation.beginTime = beginTime + beginTimes[i]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
@@ -37,7 +37,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationLineScale {
+private extension ActivityIndicatorAnimationLineScale {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")

--- a/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
 
     let animation = self.animation
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i), y: y, width: lineSize, height: size.height)
 
       animation.beginTime = beginTime + beginTimes[i]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
 
     let animation = self.animation
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i), y: y, width: lineSize, height: size.height)
 
       animation.beginTime = beginTime + beginTimes[i]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
@@ -24,7 +24,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
     // Animation
     let animation = self.animation
     for i in 0..<4 {
-      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i), y: y, width: lineSize, height: size.height)
       animation.beginTime = beginTime + beginTimes[i]
       animation.duration = durations[i]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
@@ -37,7 +37,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationLineScaleParty {
+private extension ActivityIndicatorAnimationLineScaleParty {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform.scale")

--- a/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
@@ -24,7 +24,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
     // Animation
     let animation = self.animation
     for i in 0..<4 {
-      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i), y: y, width: lineSize, height: size.height)
       animation.beginTime = beginTime + beginTimes[i]
       animation.duration = durations[i]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
 
     // Draw lines
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -41,7 +41,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationLineScalePulseOut {
+private extension ActivityIndicatorAnimationLineScalePulseOut {
 
   var animation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.85, 0.25, 0.37, 0.85)

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
 
     // Draw lines
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
 
     let animation = self.animation
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -39,7 +39,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationLineScalePulseOutRapid {
+private extension ActivityIndicatorAnimationLineScalePulseOutRapid {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
 
     let animation = self.animation
     for i in 0 ..< 5 {
-      let line = ActivityIndicatorShape.Line.createLayerWith(size: CGSize(width: lineSize, height: size.height), color: color)
+      let line = ActivityIndicatorShape.Line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
                          y: y,
                          width: lineSize,

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -39,7 +39,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationLineSpinFadeLoader {
+private extension ActivityIndicatorAnimationLineSpinFadeLoader {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "opacity")

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -24,7 +24,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
 
     let animation = self.animation
     for i in 0 ..< 8 {
-      let line = lineAt(angle: CGFloat.pi / 4 * CGFloat(i),
+      let line = makeLineLayer(angle: CGFloat.pi / 4 * CGFloat(i),
                         size: lineSize,
                         origin: CGPoint(x: x, y: y),
                         containerSize: size,
@@ -52,7 +52,7 @@ private extension ActivityIndicatorAnimationLineSpinFadeLoader {
     return animation
   }
 
-  func lineAt(angle: CGFloat, size: CGSize, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
+  func makeLineLayer(angle: CGFloat, size: CGSize, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
     let radius = containerSize.width / 2 - max(size.width, size.height) / 2
     let lineContainerSize = CGSize(width: max(size.width, size.height), height: max(size.width, size.height))
     let lineContainer = CALayer()

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -24,7 +24,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
 
     let animation = self.animation
     for i in 0 ..< 8 {
-      let line = lineAt(angle: CGFloat(M_PI_4 * Double(i)),
+      let line = lineAt(angle: CGFloat.pi / 4 * CGFloat(i),
                         size: lineSize,
                         origin: CGPoint(x: x, y: y),
                         containerSize: size,
@@ -71,7 +71,7 @@ private extension ActivityIndicatorAnimationLineSpinFadeLoader {
     lineContainer.frame = lineContainerFrame
     line.frame = lineFrame
     lineContainer.addSublayer(line)
-    lineContainer.sublayerTransform = CATransform3DMakeRotation(CGFloat(M_PI_2) + angle, 0, 0, 1)
+    lineContainer.sublayerTransform = CATransform3DMakeRotation(CGFloat.pi / 2 + angle, 0, 0, 1)
     return lineContainer
   }
 

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -61,7 +61,7 @@ private extension ActivityIndicatorAnimationLineSpinFadeLoader {
       y: origin.y + radius * (sin(angle) + 1),
       width: lineContainerSize.width,
       height: lineContainerSize.height)
-    let line = ActivityIndicatorShape.Line.makeLayer(size: size, color: color)
+    let line = ActivityIndicatorShape.line.makeLayer(size: size, color: color)
     let lineFrame = CGRect(
       x: (lineContainerSize.width - size.width) / 2,
       y: (lineContainerSize.height - size.height) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -61,7 +61,7 @@ fileprivate extension ActivityIndicatorAnimationLineSpinFadeLoader {
       y: origin.y + radius * (sin(angle) + 1),
       width: lineContainerSize.width,
       height: lineContainerSize.height)
-    let line = ActivityIndicatorShape.Line.createLayerWith(size: size, color: color)
+    let line = ActivityIndicatorShape.Line.makeLayer(size: size, color: color)
     let lineFrame = CGRect(
       x: (lineContainerSize.width - size.width) / 2,
       y: (lineContainerSize.height - size.height) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -9,12 +9,12 @@ public class ActivityIndicatorAnimationOrbit: ActivityIndicatorAnimating {
 
   // MARK: Properties
 
-  let duration: CFTimeInterval = 1.9
-  let satelliteCoreRatio: CGFloat = 0.25
-  let distanceRatio: CGFloat = 1.5
-  var coreSize: CGFloat = 0
-  var satelliteSize: CGFloat = 0
-  var size: CGSize = .zero
+  fileprivate let duration: CFTimeInterval = 1.9
+  fileprivate let satelliteCoreRatio: CGFloat = 0.25
+  fileprivate let distanceRatio: CGFloat = 1.5
+  fileprivate var coreSize: CGFloat = 0
+  fileprivate var satelliteSize: CGFloat = 0
+  fileprivate var size: CGSize = .zero
 
   // MARK: ActivityIndicatorAnimating
 
@@ -23,10 +23,10 @@ public class ActivityIndicatorAnimationOrbit: ActivityIndicatorAnimating {
 
     coreSize = size.width / (1 + satelliteCoreRatio + distanceRatio)
     satelliteSize = coreSize * satelliteCoreRatio
-    ring1InLayer(layer: layer, color: color)
-    ring2InLayer(layer: layer, color: color)
-    coreInLayer(layer: layer, color: color)
-    satelliteInLayer(layer: layer, color: color)
+    animateRing1(in: layer, color: color)
+    animateRing2(in: layer, color: color)
+    animateCore(in: layer, color: color)
+    animateSatellite(in: layer, color: color)
   }
 
 }
@@ -35,8 +35,8 @@ public class ActivityIndicatorAnimationOrbit: ActivityIndicatorAnimating {
 
 private extension ActivityIndicatorAnimationOrbit {
 
-  func satelliteInLayer(layer: CALayer, color: UIColor) {
-    let rotateAnimation = createSatelliteRotateAnimation(layer: layer)
+  func animateSatellite(in layer: CALayer, color: UIColor) {
+    let rotateAnimation = makeSatelliteRotateAnimation(layer: layer)
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: satelliteSize, height: satelliteSize), color: color)
 
     let frame = CGRect(x: 0, y: 0, width: satelliteSize, height: satelliteSize)
@@ -45,7 +45,7 @@ private extension ActivityIndicatorAnimationOrbit {
     layer.addSublayer(circle)
   }
 
-  func createSatelliteRotateAnimation(layer: CALayer) -> CAKeyframeAnimation {
+  func makeSatelliteRotateAnimation(layer: CALayer) -> CAKeyframeAnimation {
     let rotateAnimation = CAKeyframeAnimation(keyPath: "position")
     rotateAnimation.path = UIBezierPath(arcCenter: CGPoint(x: layer.bounds.midX, y: layer.bounds.midY),
                                         radius: (size.width - satelliteSize) / 2,
@@ -64,7 +64,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
 private extension ActivityIndicatorAnimationOrbit {
 
-  func coreInLayer(layer: CALayer, color: UIColor) {
+  func animateCore(in layer: CALayer, color: UIColor) {
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
@@ -94,7 +94,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
 private extension ActivityIndicatorAnimationOrbit {
 
-  func ring1InLayer(layer: CALayer, color: UIColor) {
+  func animateRing1(in layer: CALayer, color: UIColor) {
     let animation = ring1Animation
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
@@ -140,7 +140,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
 private extension ActivityIndicatorAnimationOrbit {
 
-  func ring2InLayer(layer: CALayer, color: UIColor) {
+  func animateRing2(in layer: CALayer, color: UIColor) {
     let animation = ring2Animation
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -33,7 +33,7 @@ public class ActivityIndicatorAnimationOrbit: ActivityIndicatorAnimating {
 
 // MARK: - Satellite
 
-fileprivate extension ActivityIndicatorAnimationOrbit {
+private extension ActivityIndicatorAnimationOrbit {
 
   func satelliteInLayer(layer: CALayer, color: UIColor) {
     let rotateAnimation = createSatelliteRotateAnimation(layer: layer)
@@ -62,7 +62,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
 // MARK: - Core
 
-fileprivate extension ActivityIndicatorAnimationOrbit {
+private extension ActivityIndicatorAnimationOrbit {
 
   func coreInLayer(layer: CALayer, color: UIColor) {
     let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
@@ -92,7 +92,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
 // MARK: - Ring 1
 
-fileprivate extension ActivityIndicatorAnimationOrbit {
+private extension ActivityIndicatorAnimationOrbit {
 
   func ring1InLayer(layer: CALayer, color: UIColor) {
     let animation = ring1Animation
@@ -138,7 +138,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
 // MARK: - Ring 2
 
-fileprivate extension ActivityIndicatorAnimationOrbit {
+private extension ActivityIndicatorAnimationOrbit {
 
   func ring2InLayer(layer: CALayer, color: UIColor) {
     let animation = ring2Animation

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -37,7 +37,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
   func animateSatellite(in layer: CALayer, color: UIColor) {
     let rotateAnimation = makeSatelliteRotateAnimation(layer: layer)
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: satelliteSize, height: satelliteSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: satelliteSize, height: satelliteSize), color: color)
 
     let frame = CGRect(x: 0, y: 0, width: satelliteSize, height: satelliteSize)
     circle.frame = frame
@@ -65,7 +65,7 @@ private extension ActivityIndicatorAnimationOrbit {
 private extension ActivityIndicatorAnimationOrbit {
 
   func animateCore(in layer: CALayer, color: UIColor) {
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,
@@ -96,7 +96,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
   func animateRing1(in layer: CALayer, color: UIColor) {
     let animation = ring1Animation
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,
@@ -142,7 +142,7 @@ private extension ActivityIndicatorAnimationOrbit {
 
   func animateRing2(in layer: CALayer, color: UIColor) {
     let animation = ring2Animation
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -49,8 +49,8 @@ private extension ActivityIndicatorAnimationOrbit {
     let rotateAnimation = CAKeyframeAnimation(keyPath: "position")
     rotateAnimation.path = UIBezierPath(arcCenter: CGPoint(x: layer.bounds.midX, y: layer.bounds.midY),
                                         radius: (size.width - satelliteSize) / 2,
-                                        startAngle: CGFloat(M_PI) * 1.5,
-                                        endAngle: CGFloat(M_PI) * 1.5 + 4 * CGFloat(M_PI),
+                                        startAngle: CGFloat.pi * 1.5,
+                                        endAngle: CGFloat.pi * 1.5 + 4 * CGFloat.pi,
                                         clockwise: true).cgPath
     rotateAnimation.duration = duration * 2
     rotateAnimation.repeatCount = .infinity

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -37,7 +37,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
   func satelliteInLayer(layer: CALayer, color: UIColor) {
     let rotateAnimation = createSatelliteRotateAnimation(layer: layer)
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: satelliteSize, height: satelliteSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: satelliteSize, height: satelliteSize), color: color)
 
     let frame = CGRect(x: 0, y: 0, width: satelliteSize, height: satelliteSize)
     circle.frame = frame
@@ -65,7 +65,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 fileprivate extension ActivityIndicatorAnimationOrbit {
 
   func coreInLayer(layer: CALayer, color: UIColor) {
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,
@@ -96,7 +96,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
   func ring1InLayer(layer: CALayer, color: UIColor) {
     let animation = ring1Animation
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,
@@ -142,7 +142,7 @@ fileprivate extension ActivityIndicatorAnimationOrbit {
 
   func ring2InLayer(layer: CALayer, color: UIColor) {
     let animation = ring2Animation
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: coreSize, height: coreSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: coreSize, height: coreSize), color: color)
     let frame = CGRect(x: (layer.bounds.size.width - coreSize) / 2,
                        y: (layer.bounds.size.height - coreSize) / 2,
                        width: coreSize,

--- a/IBAnimatable/ActivityIndicatorAnimationPacman.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationPacman.swift
@@ -30,7 +30,7 @@ fileprivate extension ActivityIndicatorAnimationPacman {
 
   func pacmanInLayer(layer: CALayer, color: UIColor) {
     let pacmanSize = 2 * size.width / 3
-    let pacman = ActivityIndicatorShape.Pacman.createLayerWith(size: CGSize(width: pacmanSize, height: pacmanSize), color: color)
+    let pacman = ActivityIndicatorShape.Pacman.makeLayer(size: CGSize(width: pacmanSize, height: pacmanSize), color: color)
     let animation = pacmanAnimation
     let frame = CGRect(
       x: (layer.bounds.size.width - size.width) / 2,
@@ -78,7 +78,7 @@ fileprivate extension ActivityIndicatorAnimationPacman {
 
   func circleInLayer(layer: CALayer, color: UIColor) {
     let circleSize = size.width / 5
-    let circle = ActivityIndicatorShape.Circle.createLayerWith(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let animation = circleAnimation
     let frame = CGRect(
       x: (layer.bounds.size.width - size.width) / 2 + size.width - circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationPacman.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationPacman.swift
@@ -30,7 +30,7 @@ private extension ActivityIndicatorAnimationPacman {
 
   func pacmanInLayer(layer: CALayer, color: UIColor) {
     let pacmanSize = 2 * size.width / 3
-    let pacman = ActivityIndicatorShape.Pacman.makeLayer(size: CGSize(width: pacmanSize, height: pacmanSize), color: color)
+    let pacman = ActivityIndicatorShape.pacman.makeLayer(size: CGSize(width: pacmanSize, height: pacmanSize), color: color)
     let animation = pacmanAnimation
     let frame = CGRect(
       x: (layer.bounds.size.width - size.width) / 2,
@@ -78,7 +78,7 @@ private extension ActivityIndicatorAnimationPacman {
 
   func circleInLayer(layer: CALayer, color: UIColor) {
     let circleSize = size.width / 5
-    let circle = ActivityIndicatorShape.Circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let animation = circleAnimation
     let frame = CGRect(
       x: (layer.bounds.size.width - size.width) / 2 + size.width - circleSize,

--- a/IBAnimatable/ActivityIndicatorAnimationPacman.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationPacman.swift
@@ -26,7 +26,7 @@ public class ActivityIndicatorAnimationPacman: ActivityIndicatorAnimating {
 
 // MARK: - Pacman
 
-fileprivate extension ActivityIndicatorAnimationPacman {
+private extension ActivityIndicatorAnimationPacman {
 
   func pacmanInLayer(layer: CALayer, color: UIColor) {
     let pacmanSize = 2 * size.width / 3
@@ -74,7 +74,7 @@ fileprivate extension ActivityIndicatorAnimationPacman {
 
 // MARK: - Circle
 
-fileprivate extension ActivityIndicatorAnimationPacman {
+private extension ActivityIndicatorAnimationPacman {
 
   func circleInLayer(layer: CALayer, color: UIColor) {
     let circleSize = size.width / 5

--- a/IBAnimatable/ActivityIndicatorAnimationPacman.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationPacman.swift
@@ -18,8 +18,8 @@ public class ActivityIndicatorAnimationPacman: ActivityIndicatorAnimating {
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     self.size = size
-    circleInLayer(layer: layer, color: color)
-    pacmanInLayer(layer: layer, color: color)
+    animateCircle(in: layer, color: color)
+    animatePacman(in: layer, color: color)
   }
 
 }
@@ -28,7 +28,7 @@ public class ActivityIndicatorAnimationPacman: ActivityIndicatorAnimating {
 
 private extension ActivityIndicatorAnimationPacman {
 
-  func pacmanInLayer(layer: CALayer, color: UIColor) {
+  func animatePacman(in layer: CALayer, color: UIColor) {
     let pacmanSize = 2 * size.width / 3
     let pacman = ActivityIndicatorShape.pacman.makeLayer(size: CGSize(width: pacmanSize, height: pacmanSize), color: color)
     let animation = pacmanAnimation
@@ -76,7 +76,7 @@ private extension ActivityIndicatorAnimationPacman {
 
 private extension ActivityIndicatorAnimationPacman {
 
-  func circleInLayer(layer: CALayer, color: UIColor) {
+  func animateCircle(in layer: CALayer, color: UIColor) {
     let circleSize = size.width / 5
     let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     let animation = circleAnimation

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -35,7 +35,7 @@ private extension ActivityIndicatorAnimationSemiCircleSpin {
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.rotation.z")
     animation.keyTimes = [0, 0.5, 1]
-    animation.values = [0, M_PI, 2 * M_PI]
+    animation.values = [0, CGFloat.pi, 2 * CGFloat.pi]
     animation.duration = duration
     animation.repeatCount = .infinity
     animation.isRemovedOnCompletion = false

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -30,7 +30,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationSemiCircleSpin {
+private extension ActivityIndicatorAnimationSemiCircleSpin {
 
   var animation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.rotation.z")

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.CircleSemi.makeLayer(size: size, color: color)
+    let circle = ActivityIndicatorShape.circleSemi.makeLayer(size: size, color: color)
     let frame = CGRect(
       x: (layer.bounds.width - size.width) / 2,
       y: (layer.bounds.height - size.height) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
 
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
-    let circle = ActivityIndicatorShape.CircleSemi.createLayerWith(size: size, color: color)
+    let circle = ActivityIndicatorShape.CircleSemi.makeLayer(size: size, color: color)
     let frame = CGRect(
       x: (layer.bounds.width - size.width) / 2,
       y: (layer.bounds.height - size.height) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -38,30 +38,26 @@ private extension ActivityIndicatorAnimationSquareSpin {
     animation.keyTimes = [0, 0.25, 0.5, 0.75, 1]
     animation.timingFunctions = [timingFunction, timingFunction, timingFunction, timingFunction]
     animation.values = [
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat(M_PI)), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat(M_PI)), createRotateYTransform(angle: CGFloat(M_PI)))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: CGFloat(M_PI)))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0)))]
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: 0))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: CGFloat.pi), makeRotateYTransform(angle: 0))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: CGFloat.pi), makeRotateYTransform(angle: CGFloat.pi))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: CGFloat.pi))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: 0)))]
     animation.duration = duration
     animation.repeatCount = .infinity
     animation.isRemovedOnCompletion = false
     return animation
   }
 
-  func createRotateXTransform(angle: CGFloat) -> CATransform3D {
+  func makeRotateXTransform(angle: CGFloat) -> CATransform3D {
     var transform = CATransform3DMakeRotation(angle, 1, 0, 0)
-
     transform.m34 = CGFloat(-1) / 100
-
     return transform
   }
 
-  func createRotateYTransform(angle: CGFloat) -> CATransform3D {
+  func makeRotateYTransform(angle: CGFloat) -> CATransform3D {
     var transform = CATransform3DMakeRotation(angle, 0, 1, 0)
-
     transform.m34 = CGFloat(-1) / 100
-    
     return transform
   }
   

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -30,7 +30,7 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationSquareSpin {
+private extension ActivityIndicatorAnimationSquareSpin {
 
   var animation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.09, 0.57, 0.49, 0.9)

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
 
     let animation = self.animation
-    let square = ActivityIndicatorShape.Rectangle.makeLayer(size: size, color: color)
+    let square = ActivityIndicatorShape.rectangle.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
 
     let animation = self.animation
-    let square = ActivityIndicatorShape.Rectangle.createLayerWith(size: size, color: color)
+    let square = ActivityIndicatorShape.Rectangle.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -27,7 +27,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
 
 // MARK: - Setup
 
-fileprivate extension ActivityIndicatorAnimationTriangleSkewSpin {
+private extension ActivityIndicatorAnimationTriangleSkewSpin {
 
   var animation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.09, 0.57, 0.49, 0.9)

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -17,9 +17,8 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
     let triangle = ActivityIndicatorShape.Triangle.makeLayer(size: size, color: color)
-    let animation = self.animation
     triangle.frame = CGRect(x: x, y: y, width: size.width, height: size.height)
-    triangle.add(animation, forKey: "animation")
+    triangle.add(self.animation, forKey: "animation")
     layer.addSublayer(triangle)
   }
 
@@ -35,30 +34,26 @@ private extension ActivityIndicatorAnimationTriangleSkewSpin {
     animation.keyTimes = [0, 0.25, 0.5, 0.75, 1]
     animation.timingFunctions = [timingFunction, timingFunction, timingFunction, timingFunction]
     animation.values = [
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat.pi), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat.pi), createRotateYTransform(angle: CGFloat.pi))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: CGFloat.pi))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0)))]
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: 0))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: CGFloat.pi), makeRotateYTransform(angle: 0))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: CGFloat.pi), makeRotateYTransform(angle: CGFloat.pi))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: CGFloat.pi))),
+      NSValue(caTransform3D: CATransform3DConcat(makeRotateXTransform(angle: 0), makeRotateYTransform(angle: 0)))]
     animation.duration = duration
     animation.repeatCount = .infinity
     animation.isRemovedOnCompletion = false
     return animation
   }
 
-  func createRotateXTransform(angle: CGFloat) -> CATransform3D {
+  func makeRotateXTransform(angle: CGFloat) -> CATransform3D {
     var transform = CATransform3DMakeRotation(angle, 1, 0, 0)
-
     transform.m34 = CGFloat(-1) / 100
-
     return transform
   }
 
-  func createRotateYTransform(angle: CGFloat) -> CATransform3D {
+  func makeRotateYTransform(angle: CGFloat) -> CATransform3D {
     var transform = CATransform3DMakeRotation(angle, 0, 1, 0)
-
     transform.m34 = CGFloat(-1) / 100
-
     return transform
   }
   

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
-    let triangle = ActivityIndicatorShape.Triangle.makeLayer(size: size, color: color)
+    let triangle = ActivityIndicatorShape.triangle.makeLayer(size: size, color: color)
     triangle.frame = CGRect(x: x, y: y, width: size.width, height: size.height)
     triangle.add(self.animation, forKey: "animation")
     layer.addSublayer(triangle)

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -36,9 +36,9 @@ private extension ActivityIndicatorAnimationTriangleSkewSpin {
     animation.timingFunctions = [timingFunction, timingFunction, timingFunction, timingFunction]
     animation.values = [
       NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat(M_PI)), createRotateYTransform(angle: 0))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat(M_PI)), createRotateYTransform(angle: CGFloat(M_PI)))),
-      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: CGFloat(M_PI)))),
+      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat.pi), createRotateYTransform(angle: 0))),
+      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: CGFloat.pi), createRotateYTransform(angle: CGFloat.pi))),
+      NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: CGFloat.pi))),
       NSValue(caTransform3D: CATransform3DConcat(createRotateXTransform(angle: 0), createRotateYTransform(angle: 0)))]
     animation.duration = duration
     animation.repeatCount = .infinity

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
   public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
-    let triangle = ActivityIndicatorShape.Triangle.createLayerWith(size: size, color: color)
+    let triangle = ActivityIndicatorShape.Triangle.makeLayer(size: size, color: color)
     let animation = self.animation
     triangle.frame = CGRect(x: x, y: y, width: size.width, height: size.height)
     triangle.add(animation, forKey: "animation")

--- a/IBAnimatable/ActivityIndicatorFactory.swift
+++ b/IBAnimatable/ActivityIndicatorFactory.swift
@@ -8,69 +8,69 @@ import UIKit
 public struct ActivityIndicatorFactory {
   public static func generateActivityIndicator(activityIndicatorType: ActivityIndicatorType) -> ActivityIndicatorAnimating {
     switch activityIndicatorType {
-    case .None:
+    case .none:
       fatalError()
-    case .AudioEqualizer:
+    case .audioEqualizer:
       return ActivityIndicatorAnimationAudioEqualizer()
-    case .BallBeat:
+    case .ballBeat:
       return ActivityIndicatorAnimationBallBeat()
-    case .BallClipRotate:
+    case .ballClipRotate:
       return ActivityIndicatorAnimationBallClipRotate()
-    case .BallClipRotateMultiple:
+    case .ballClipRotateMultiple:
       return ActivityIndicatorAnimationBallClipRotateMultiple()
-    case .BallClipRotatePulse:
+    case .ballClipRotatePulse:
       return ActivityIndicatorAnimationBallClipRotatePulse()
-    case .BallGridBeat:
+    case .ballGridBeat:
       return ActivityIndicatorAnimationBallGridBeat()
-    case .BallGridPulse:
+    case .ballGridPulse:
       return ActivityIndicatorAnimationBallGridPulse()
-    case .BallPulse:
+    case .ballPulse:
       return ActivityIndicatorAnimationBallPulse()
-    case .BallPulseRise:
+    case .ballPulseRise:
       return ActivityIndicatorAnimationBallPulseRise()
-    case .BallPulseSync:
+    case .ballPulseSync:
       return ActivityIndicatorAnimationBallPulseSync()
-    case .BallRotate:
+    case .ballRotate:
       return ActivityIndicatorAnimationBallRotate()
-    case .BallRotateChase:
+    case .ballRotateChase:
       return ActivityIndicatorAnimationBallRotateChase()
-    case .BallScale:
+    case .ballScale:
       return ActivityIndicatorAnimationBallScale()
-    case .BallScaleMultiple:
+    case .ballScaleMultiple:
       return ActivityIndicatorAnimationBallScaleMultiple()
-    case .BallScaleRipple:
+    case .ballScaleRipple:
       return ActivityIndicatorAnimationBallScaleRipple()
-    case .BallScaleRippleMultiple:
+    case .ballScaleRippleMultiple:
       return ActivityIndicatorAnimationBallScaleRippleMultiple()
-    case .BallSpinFadeLoader:
+    case .ballSpinFadeLoader:
       return ActivityIndicatorAnimationBallSpinFadeLoader()
-    case .BallTrianglePath:
+    case .ballTrianglePath:
       return ActivityIndicatorAnimationBallTrianglePath()
-    case .BallZigZag:
+    case .ballZigZag:
       return ActivityIndicatorAnimationBallZigZag()
-    case .BallZigZagDeflect:
+    case .ballZigZagDeflect:
       return ActivityIndicatorAnimationBallZigZagDeflect()
-    case .CubeTransition:
+    case .cubeTransition:
       return ActivityIndicatorAnimationCubeTransition()
-    case .LineScale:
+    case .lineScale:
       return ActivityIndicatorAnimationLineScale()
-    case .LineSpinFadeLoader:
+    case .lineSpinFadeLoader:
       return ActivityIndicatorAnimationLineSpinFadeLoader()
-    case .LineScaleParty:
+    case .lineScaleParty:
       return ActivityIndicatorAnimationLineScaleParty()
-    case .LineScalePulseOut:
+    case .lineScalePulseOut:
       return ActivityIndicatorAnimationLineScalePulseOut()
-    case .LineScalePulseOutRapid:
+    case .lineScalePulseOutRapid:
       return ActivityIndicatorAnimationLineScalePulseOutRapid()
-    case .Orbit:
+    case .orbit:
       return ActivityIndicatorAnimationOrbit()
-    case .Pacman:
+    case .pacman:
       return ActivityIndicatorAnimationPacman()
-    case .SemiCircleSpin:
+    case .semiCircleSpin:
       return ActivityIndicatorAnimationSemiCircleSpin()
-    case .SquareSpin:
+    case .squareSpin:
       return ActivityIndicatorAnimationSquareSpin()
-    case .TriangleSkewSpin:
+    case .triangleSkewSpin:
       return ActivityIndicatorAnimationTriangleSkewSpin()
     }
   }

--- a/IBAnimatable/ActivityIndicatorFactory.swift
+++ b/IBAnimatable/ActivityIndicatorFactory.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 public struct ActivityIndicatorFactory {
-  public static func generateActivityIndicator(activityIndicatorType: ActivityIndicatorType) -> ActivityIndicatorAnimating {
+  public static func makeActivityIndicator(activityIndicatorType: ActivityIndicatorType) -> ActivityIndicatorAnimating {
     switch activityIndicatorType {
     case .none:
       fatalError()

--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -6,57 +6,49 @@
 import UIKit
 
 enum ActivityIndicatorShape {
-  case Circle
-  case CircleSemi
-  case Ring
-  case RingTwoHalfVertical
-  case RingTwoHalfHorizontal
-  case RingThirdFour
-  case Rectangle
-  case Triangle
-  case Line
-  case Pacman
+  case circle
+  case circleSemi
+  case ring
+  case ringTwoHalfVertical
+  case ringTwoHalfHorizontal
+  case ringThirdFour
+  case rectangle
+  case triangle
+  case line
+  case pacman
 
   func makeLayer(size: CGSize, color: UIColor) -> CALayer {
     let lineWidth: CGFloat = 2    
     switch self {
-    case .Circle:
-      return circleShapeLayer(with: size, color: color)
-    case .CircleSemi:
-      return semiCircleShapeLayer(with: size, color: color)
-    case .Ring:
-      return ringShapeLayer(with: size, color: color, lineWidth: lineWidth)
-    case .RingTwoHalfVertical:
-      return ringTwoHalfVerticalShapeLayer(with: size, color: color, lineWidth: lineWidth)
-    case .RingTwoHalfHorizontal:
-      return ringTwoHalfHorizontalShapeLayer(with: size, color: color, lineWidth: lineWidth)
-    case .RingThirdFour:
-      return ringThirdFourShapeLayer(with: size, color: color, lineWidth: lineWidth)
-    case .Rectangle:
-      return rectangleShapeLayer(with: size, color: color)
-    case .Triangle:
-      return triangleShapeLayer(with: size, color: color)
-    case .Line:
-      return lineShapeLayer(with: size, color: color)
-    case .Pacman:
-      return pacmanShapeLayer(with: size, color: color)
+    case .circle:
+      return makeCircleShapeLayer(with: size, color: color)
+    case .circleSemi:
+      return makeSemiCircleShapeLayer(with: size, color: color)
+    case .ring:
+      return makeRingShapeLayer(with: size, color: color, lineWidth: lineWidth)
+    case .ringTwoHalfVertical:
+      return makeRingTwoHalfVerticalShapeLayer(with: size, color: color, lineWidth: lineWidth)
+    case .ringTwoHalfHorizontal:
+      return makeRingTwoHalfHorizontalShapeLayer(with: size, color: color, lineWidth: lineWidth)
+    case .ringThirdFour:
+      return makeRingThirdFourShapeLayer(with: size, color: color, lineWidth: lineWidth)
+    case .rectangle:
+      return makeRectangleShapeLayer(with: size, color: color)
+    case .triangle:
+      return makeTriangleShapeLayer(with: size, color: color)
+    case .line:
+      return makeLineShapeLayer(with: size, color: color)
+    case .pacman:
+      return makePacmanShapeLayer(with: size, color: color)
     }
   }
-
-  func completingLayer(layer: CAShapeLayer, path: UIBezierPath, size: CGSize) -> CAShapeLayer {
-    layer.backgroundColor = nil
-    layer.path = path.cgPath
-    layer.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-    return layer
-  }
-
 }
 
 // MARK: - Circles
 
 private extension ActivityIndicatorShape {
 
-  func circleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makeCircleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -65,10 +57,11 @@ private extension ActivityIndicatorShape {
                           endAngle: 2 * CGFloat.pi,
                           clockwise: false)
     layer.fillColor = color.cgColor
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func semiCircleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makeSemiCircleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -78,7 +71,8 @@ private extension ActivityIndicatorShape {
                           clockwise: false)
     path.close()
     layer.fillColor = color.cgColor
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
 }
@@ -87,7 +81,7 @@ private extension ActivityIndicatorShape {
 
 private extension ActivityIndicatorShape {
 
-  func ringShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+  func makeRingShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -98,10 +92,11 @@ private extension ActivityIndicatorShape {
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
     layer.lineWidth = lineWidth
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func ringTwoHalfVerticalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+  func makeRingTwoHalfVerticalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -121,10 +116,11 @@ private extension ActivityIndicatorShape {
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
     layer.lineWidth = lineWidth
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func ringTwoHalfHorizontalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+  func makeRingTwoHalfHorizontalShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -144,10 +140,11 @@ private extension ActivityIndicatorShape {
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
     layer.lineWidth = lineWidth
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func ringThirdFourShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
+  func makeRingThirdFourShapeLayer(with size: CGSize, color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -158,7 +155,8 @@ private extension ActivityIndicatorShape {
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
     layer.lineWidth = lineWidth
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
 }
@@ -167,7 +165,7 @@ private extension ActivityIndicatorShape {
 
 private extension ActivityIndicatorShape {
 
-  func rectangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makeRectangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.move(to: CGPoint(x: 0, y: 0))
@@ -175,10 +173,11 @@ private extension ActivityIndicatorShape {
     path.addLine(to: CGPoint(x: size.width, y: size.height))
     path.addLine(to: CGPoint(x: 0, y: size.height))
     layer.fillColor = color.cgColor
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func triangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makeTriangleShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     let offsetY = size.height / 4
@@ -187,19 +186,21 @@ private extension ActivityIndicatorShape {
     path.addLine(to: CGPoint(x: size.width, y: size.height - offsetY))
     path.close()
     layer.fillColor = color.cgColor
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func lineShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makeLineShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     var path = UIBezierPath()
     path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: size.width, height: size.height),
                         cornerRadius: size.width / 2)
     layer.fillColor = color.cgColor
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
-  func pacmanShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
+  func makePacmanShapeLayer(with size: CGSize, color: UIColor) -> CAShapeLayer {
     let layer = CAShapeLayer()
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
@@ -210,7 +211,16 @@ private extension ActivityIndicatorShape {
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
     layer.lineWidth = size.width / 2
-    return completingLayer(layer: layer, path: path, size: size)
+    layer.apply(path: path, size: size)
+    return layer
   }
 
+}
+
+private extension CAShapeLayer {
+  func apply(path: UIBezierPath, size: CGSize) {
+    self.backgroundColor = nil
+    self.path = path.cgPath
+    self.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+  }
 }

--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -62,7 +62,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
                           startAngle: 0,
-                          endAngle: CGFloat(2 * M_PI),
+                          endAngle: 2 * CGFloat.pi,
                           clockwise: false)
     layer.fillColor = color.cgColor
     return completingLayer(layer: layer, path: path, size: size)
@@ -73,8 +73,8 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
-                          startAngle: CGFloat(-M_PI / 6),
-                          endAngle: CGFloat(-5 * M_PI / 6),
+                          startAngle: -CGFloat.pi / 6,
+                          endAngle: -5 * CGFloat.pi / 6,
                           clockwise: false)
     path.close()
     layer.fillColor = color.cgColor
@@ -93,7 +93,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
                           startAngle: 0,
-                          endAngle: CGFloat(2 * M_PI),
+                          endAngle: 2 * CGFloat.pi,
                           clockwise: false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -106,17 +106,17 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:CGFloat(-3 * M_PI_4),
-                          endAngle:CGFloat(-M_PI_4),
+                          startAngle:-3 * CGFloat.pi / 4,
+                          endAngle:-CGFloat.pi / 4,
                           clockwise:true)
     path.move(
-      to: CGPoint(x: size.width / 2 - size.width / 2 * CGFloat(cos(M_PI_4)),
-        y: size.height / 2 + size.height / 2 * CGFloat(sin(M_PI_4)))
+      to: CGPoint(x: size.width / 2 - size.width / 2 * cos(CGFloat.pi / 4),
+        y: size.height / 2 + size.height / 2 * sin(CGFloat.pi / 4))
     )
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:CGFloat(-5 * M_PI_4),
-                          endAngle:CGFloat(-7 * M_PI_4),
+                          startAngle:-5 * CGFloat.pi / 4,
+                          endAngle:-7 * CGFloat.pi / 4,
                           clockwise:false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -129,17 +129,17 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:CGFloat(3 * M_PI_4),
-                          endAngle:CGFloat(5 * M_PI_4),
+                          startAngle:3 * CGFloat.pi / 4,
+                          endAngle:5 * CGFloat.pi / 4,
                           clockwise:true)
     path.move(
-      to: CGPoint(x: size.width / 2 + size.width / 2 * CGFloat(cos(M_PI_4)),
-        y: size.height / 2 - size.height / 2 * CGFloat(sin(M_PI_4)))
+      to: CGPoint(x: size.width / 2 + size.width / 2 * cos(CGFloat.pi / 4),
+        y: size.height / 2 - size.height / 2 * sin(CGFloat.pi / 4))
     )
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:CGFloat(-M_PI_4),
-                          endAngle:CGFloat(M_PI_4),
+                          startAngle:-CGFloat.pi / 4,
+                          endAngle:CGFloat.pi / 4,
                           clockwise:true)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -152,8 +152,8 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
-                          startAngle: CGFloat(-3 * M_PI_4),
-                          endAngle: CGFloat(-M_PI_4),
+                          startAngle: -3 * CGFloat.pi / 4,
+                          endAngle: -CGFloat.pi / 4,
                           clockwise: false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -205,7 +205,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 4,
                           startAngle: 0,
-                          endAngle: CGFloat(2 * M_PI),
+                          endAngle: 2 * CGFloat.pi,
                           clockwise: true)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor

--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -17,7 +17,7 @@ enum ActivityIndicatorShape {
   case Line
   case Pacman
 
-  func createLayerWith(size: CGSize, color: UIColor) -> CALayer {
+  func makeLayer(size: CGSize, color: UIColor) -> CALayer {
     let lineWidth: CGFloat = 2    
     switch self {
     case .Circle:

--- a/IBAnimatable/ActivityIndicatorType.swift
+++ b/IBAnimatable/ActivityIndicatorType.swift
@@ -4,76 +4,38 @@
 //
 
 import UIKit
-
-public enum ActivityIndicatorType: String {
-  case None
-  case AudioEqualizer
-  case BallBeat
-  case BallClipRotate
-  case BallClipRotateMultiple
-  case BallClipRotatePulse
-  case BallGridBeat
-  case BallGridPulse
-  case BallPulse
-  case BallPulseRise
-  case BallPulseSync
-  case BallRotate
-  case BallRotateChase
-  case BallScale
-  case BallScaleMultiple
-  case BallScaleRipple
-  case BallScaleRippleMultiple
-  case BallSpinFadeLoader
-  case BallTrianglePath
-  case BallZigZag
-  case BallZigZagDeflect
-  case CubeTransition
-  case LineScale
-  case LineScaleParty
-  case LineScalePulseOut
-  case LineScalePulseOutRapid
-  case LineSpinFadeLoader
-  case Orbit
-  case Pacman
-  case SemiCircleSpin
-  case SquareSpin
-  case TriangleSkewSpin
-
-  public static func fromString(string: String) -> ActivityIndicatorType {
-    switch string {
-    case "AudioEqualizer": return .AudioEqualizer
-    case "BallBeat": return .BallBeat
-    case "BallClipRotate": return .BallClipRotate
-    case "BallClipRotateMultiple": return .BallClipRotateMultiple
-    case "BallClipRotatePulse": return .BallClipRotatePulse
-    case "BallGridBeat": return .BallGridBeat
-    case "BallGridPulse": return .BallGridPulse
-    case "BallPulse": return .BallPulse
-    case "BallPulseRise": return .BallPulseRise
-    case "BallPulseSync": return .BallPulseSync
-    case "BallRotate": return .BallRotate
-    case "BallRotateChase": return .BallRotateChase
-    case "BallScale": return .BallScale
-    case "BallScaleMultiple": return .BallScaleMultiple
-    case "BallScaleRipple": return .BallScaleRipple
-    case "BallScaleRippleMultiple": return .BallScaleRippleMultiple
-    case "BallSpinFadeLoader": return .BallSpinFadeLoader
-    case "BallTrianglePath": return .BallTrianglePath
-    case "BallZigZag": return .BallZigZag
-    case "BallZigZagDeflect": return .BallZigZagDeflect
-    case "CubeTransition": return .CubeTransition
-    case "LineScale": return .LineScale
-    case "LineSpinFadeLoader": return .LineSpinFadeLoader
-    case "LineScaleParty": return .LineScaleParty
-    case "LineScalePulseOut": return .LineScalePulseOut
-    case "LineScalePulseOutRapid": return .LineScalePulseOutRapid
-    case "Orbit": return .Orbit
-    case "Pacman": return .Pacman
-    case "SemiCircleSpin": return .SemiCircleSpin
-    case "SquareSpin": return .SquareSpin
-    case "TriangleSkewSpin": return .TriangleSkewSpin
-    default: return .None
-    }    
-  }
-
+/// Activity indicator type: used to specify the animation for the activity indicator.
+public enum ActivityIndicatorType: String, IBEnum {
+  case none
+  case audioEqualizer
+  case ballBeat
+  case ballClipRotate
+  case ballClipRotateMultiple
+  case ballClipRotatePulse
+  case ballGridBeat
+  case ballGridPulse
+  case ballPulse
+  case ballPulseRise
+  case ballPulseSync
+  case ballRotate
+  case ballRotateChase
+  case ballScale
+  case ballScaleMultiple
+  case ballScaleRipple
+  case ballScaleRippleMultiple
+  case ballSpinFadeLoader
+  case ballTrianglePath
+  case ballZigZag
+  case ballZigZagDeflect
+  case cubeTransition
+  case lineScale
+  case lineScaleParty
+  case lineScalePulseOut
+  case lineScalePulseOutRapid
+  case lineSpinFadeLoader
+  case orbit
+  case pacman
+  case semiCircleSpin
+  case squareSpin
+  case triangleSkewSpin
 }

--- a/IBAnimatable/ActivityIndicatorType.swift
+++ b/IBAnimatable/ActivityIndicatorType.swift
@@ -4,6 +4,7 @@
 //
 
 import UIKit
+
 /// Activity indicator type: used to specify the animation for the activity indicator.
 public enum ActivityIndicatorType: String, IBEnum {
   case none

--- a/IBAnimatable/AnimatableActivityIndicatorView.swift
+++ b/IBAnimatable/AnimatableActivityIndicatorView.swift
@@ -11,9 +11,17 @@ import UIKit
 @IBDesignable public class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
 
   // MARK: ActivityIndicatorAnimatable
-  @IBInspectable public var animationType: String = "BallBeats"
+  open var animationType: ActivityIndicatorType = .none
+  @IBInspectable var _animationType: String? {
+    didSet {
+      if let type = _animationType, let animationType = ActivityIndicatorType(string: type) {
+        self.animationType = animationType
+      } else {
+        animationType = .none
+      }
+    }
+  }
   @IBInspectable public var color: UIColor = .black
   @IBInspectable public var hidesWhenStopped: Bool = true
   public var isAnimating: Bool = false
-
 }

--- a/IBAnimatable/AnimatableActivityIndicatorView.swift
+++ b/IBAnimatable/AnimatableActivityIndicatorView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@IBDesignable public class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
+@IBDesignable open class AnimatableActivityIndicatorView: UIView, ActivityIndicatorAnimatable {
 
   // MARK: ActivityIndicatorAnimatable
   open var animationType: ActivityIndicatorType = .none
@@ -21,7 +21,7 @@ import UIKit
       }
     }
   }
-  @IBInspectable public var color: UIColor = .black
-  @IBInspectable public var hidesWhenStopped: Bool = true
-  public var isAnimating: Bool = false
+  @IBInspectable open var color: UIColor = .black
+  @IBInspectable open var hidesWhenStopped: Bool = true
+  open var isAnimating: Bool = false
 }

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -8,11 +8,7 @@ import UIKit
  Animator Factory
  */
 public struct AnimatorFactory {
-  public static func generateAnimator(_ transitionAnimationType: TransitionAnimationType) -> AnimatedTransitioning? {
-    return generateAnimator(transitionAnimationType, transitionDuration: defaultTransitionDuration)
-  }
-
-  public static func generateAnimator(_ transitionAnimationType: TransitionAnimationType, transitionDuration: Duration) -> AnimatedTransitioning? {
+  public static func makeAnimator(transitionAnimationType: TransitionAnimationType, transitionDuration: Duration = defaultTransitionDuration) -> AnimatedTransitioning? {
     switch transitionAnimationType {
     case .systemRotate:
       return SystemRotateAnimator(transitionDuration: transitionDuration)

--- a/IBAnimatable/AnimatorFactory.swift
+++ b/IBAnimatable/AnimatorFactory.swift
@@ -53,7 +53,7 @@ public struct AnimatorFactory {
     }
   }
 
-  public static func generateAnimator(presentationAnimationType: PresentationAnimationType, transitionDuration: Duration) -> AnimatedPresenting {
+  public static func makeAnimator(presentationAnimationType: PresentationAnimationType, transitionDuration: Duration = defaultPresentationDuration) -> AnimatedPresenting {
     switch presentationAnimationType {
     case let .cover(direction):
       return CoverAnimator(from: direction, transitionDuration: transitionDuration)

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -42,12 +42,12 @@ public extension BlurDesignable where Self: UIView {
       return
     }
 
-    let blurEffectView = createVisualEffectView(effect: UIBlurEffect(style: blurEffectStyle))
+    let blurEffectView = makeVisualEffectView(effect: UIBlurEffect(style: blurEffectStyle))
     
     // If `vibrancyEffectStyle` has been set, add `vibrancyEffectView` into `blurEffectView`.
     if let vibrancyEffectStyle = vibrancyEffectStyle {
       let blurEffectStyleForVibrancy = UIBlurEffect(style: vibrancyEffectStyle)
-      let vibrancyEffectView = createVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffectStyleForVibrancy))
+      let vibrancyEffectView = makeVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffectStyleForVibrancy))
       subviews.forEach {
         vibrancyEffectView.contentView.addSubview($0)
       }
@@ -69,7 +69,7 @@ public extension BlurDesignable where Self: UIView {
 }
 
 private extension BlurDesignable where Self: UIView {
-  func createVisualEffectView(effect: UIVisualEffect) -> UIVisualEffectView {
+  func makeVisualEffectView(effect: UIVisualEffect) -> UIVisualEffectView {
     let visualEffectView = PrivateVisualEffectView(effect: effect)
     visualEffectView.alpha = blurOpacity.isNaN ? 1.0 : blurOpacity
     if layer.cornerRadius > 0 {

--- a/IBAnimatable/ContainerTransition.swift
+++ b/IBAnimatable/ContainerTransition.swift
@@ -61,7 +61,7 @@ public class ContainerTransition: NSObject {
     }
     
     parentViewController?.view.isUserInteractionEnabled = false
-    let animator = AnimatorFactory.generateAnimator(unwrappedAnimationType)
+    let animator = AnimatorFactory.makeAnimator(transitionAnimationType: unwrappedAnimationType)
     animator?.transitionDuration = transitionDuration
     animator?.animateTransition(using: self)
   }

--- a/IBAnimatable/ExplodeAnimator.swift
+++ b/IBAnimatable/ExplodeAnimator.swift
@@ -49,7 +49,7 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
     
     containerView.insertSubview(toView, at: 0)
     
-    let snapshots = createSnapshots(toView, fromView: fromView, containerView: containerView)
+    let snapshots = makeSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     containerView.sendSubview(toBack: fromView)
     animateSnapshotsExplode(snapshots) {
       if transitionContext.transitionWasCancelled {
@@ -64,7 +64,7 @@ extension ExplodeAnimator: UIViewControllerAnimatedTransitioning {
 
 private extension ExplodeAnimator {
   
-  func createSnapshots(_ toView: UIView, fromView: UIView, containerView: UIView) -> [UIView] {
+  func makeSnapshots(toView: UIView, fromView: UIView, containerView: UIView) -> [UIView] {
     let size = toView.frame.size
     var snapshots = [UIView]()
     let yFactor = xFactor * size.height / size.width
@@ -85,9 +85,9 @@ private extension ExplodeAnimator {
   func animateSnapshotsExplode(_ snapshots: [UIView], completion: @escaping AnimatableCompletion) {
     UIView.animate(withDuration: transitionDuration, animations: {
       snapshots.forEach {
-        let xOffset = self.randomFloatBetween(-100.0, upper: 100.0)
-        let yOffset = self.randomFloatBetween(-100.0, upper: 100.0)
-        let angle = self.randomFloatBetween(self.minAngle, upper: self.maxAngle)
+        let xOffset = self.randomFloat(from: -100.0, to: 100.0)
+        let yOffset = self.randomFloat(from: -100.0, to: 100.0)
+        let angle = self.randomFloat(from: self.minAngle, to: self.maxAngle)
 
         let translateTransform = CGAffineTransform(translationX: $0.frame.origin.x - xOffset, y: $0.frame.origin.y - yOffset)
         let angleTransform = translateTransform.rotated(by: angle)
@@ -103,7 +103,7 @@ private extension ExplodeAnimator {
     })
   }
   
-  func randomFloatBetween(_ lower: CGFloat, upper: CGFloat) -> CGFloat {
+  func randomFloat(from lower: CGFloat, to upper: CGFloat) -> CGFloat {
     return CGFloat(arc4random_uniform(UInt32(upper - lower))) + lower
   }
   

--- a/IBAnimatable/FlipAnimator.swift
+++ b/IBAnimatable/FlipAnimator.swift
@@ -60,7 +60,7 @@ extension FlipAnimator: UIViewControllerAnimatedTransitioning {
     containerView.layer.sublayerTransform = transform
     toView.frame = fromView.frame
     
-    let flipViews = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
+    let flipViews = makeSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     animateFlipTransition(flippedSectionOfFromView: flipViews.0, flippedSectionOfToView: flipViews.1) {
       if transitionContext.transitionWasCancelled {
         self.removeOtherViews(viewToKeep: fromView)
@@ -78,18 +78,18 @@ extension FlipAnimator: UIViewControllerAnimatedTransitioning {
 
 private extension FlipAnimator {
   
-  func createSnapshots(toView: UIView, fromView: UIView, containerView: UIView) -> ((UIView, UIView), (UIView, UIView)) {
-    let toViewSnapshots = createSnapshot(fromView: toView, afterUpdates: true)
+  func makeSnapshots(toView: UIView, fromView: UIView, containerView: UIView) -> ((UIView, UIView), (UIView, UIView)) {
+    let toViewSnapshots = makeSnapshot(from: toView, afterUpdates: true)
     var flippedSectionOfToView = toViewSnapshots[reverse ? 0 : 1]
 
-    let fromViewSnapshots = createSnapshot(fromView: fromView, afterUpdates: false)
+    let fromViewSnapshots = makeSnapshot(from: fromView, afterUpdates: false)
     var flippedSectionOfFromView = fromViewSnapshots[reverse ? 1 : 0]
 
-    flippedSectionOfFromView = addShadow(toView: flippedSectionOfFromView, reverse: !reverse)
+    flippedSectionOfFromView = addShadow(to: flippedSectionOfFromView, reverse: !reverse)
     let flippedSectionOfFromViewShadow = flippedSectionOfFromView.subviews[1]
     flippedSectionOfFromViewShadow.alpha = 0.0
 
-    flippedSectionOfToView = addShadow(toView: flippedSectionOfToView, reverse:reverse)
+    flippedSectionOfToView = addShadow(to: flippedSectionOfToView, reverse:reverse)
     let flippedSectionOfToViewShadow = flippedSectionOfToView.subviews[1]
     flippedSectionOfToViewShadow.alpha = 1.0
 
@@ -102,7 +102,7 @@ private extension FlipAnimator {
     return ((flippedSectionOfFromView, flippedSectionOfFromViewShadow), (flippedSectionOfToView, flippedSectionOfToViewShadow))
   }
   
-  func createSnapshot(fromView view: UIView, afterUpdates: Bool) -> [UIView] {
+  func makeSnapshot(from view: UIView, afterUpdates: Bool) -> [UIView] {
     let containerView = view.superview
 
     let width = valuesForAxe(initialValue: view.frame.size.width / 2, reverseValue: view.frame.size.width)
@@ -123,7 +123,7 @@ private extension FlipAnimator {
     return [leftHandView!, rightHandView!]
   }
   
-  func addShadow(toView view: UIView, reverse: Bool) -> UIView {
+  func addShadow(to view: UIView, reverse: Bool) -> UIView {
     let containerView = view.superview
     let viewWithShadow = UIView(frame: view.frame)
     containerView?.insertSubview(viewWithShadow, aboveSubview: view)

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -86,7 +86,7 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
     size = toView.frame.size
     foldSize = width * 0.5 / CGFloat(folds)
 
-    let viewFolds = createSnapshots(toView: toView, fromView: fromView, containerView: containerView)
+    let viewFolds = makeSnapshots(toView: toView, fromView: fromView, containerView: containerView)
     animateFoldTransition(fromView: fromView, toViewFolds: viewFolds[0], fromViewFolds: viewFolds[1], completion: {
       if !transitionContext.transitionWasCancelled {
         toView.frame = containerView.bounds
@@ -106,31 +106,31 @@ extension FoldAnimator: UIViewControllerAnimatedTransitioning {
 
 private extension FoldAnimator {
   
-  func createSnapshots(toView: UIView, fromView: UIView, containerView: UIView) -> [[UIView]] {
+  func makeSnapshots(toView: UIView, fromView: UIView, containerView: UIView) -> [[UIView]] {
     var fromViewFolds = [UIView]()
     var toViewFolds = [UIView]()
     for i in 0..<folds {
       let offset = CGFloat(i) * foldSize * 2
-      let leftFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset, left: true)
+      let leftFromViewFold = makeSnapshot(from: fromView, afterUpdates: false, offset: offset, left: true)
       var axesValues = valuesForAxe(initialValue: offset, reverseValue: height / 2)
       leftFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       fromViewFolds.append(leftFromViewFold)
       leftFromViewFold.subviews[1].alpha = 0.0
 
-      let rightFromViewFold = createSnapshot(fromView: fromView, afterUpdates: false, offset: offset + foldSize, left: false)
+      let rightFromViewFold = makeSnapshot(from: fromView, afterUpdates: false, offset: offset + foldSize, left: false)
       axesValues = valuesForAxe(initialValue: offset + foldSize * 2, reverseValue: height / 2)
       rightFromViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       fromViewFolds.append(rightFromViewFold)
       rightFromViewFold.subviews[1].alpha = 0.0
 
-      let leftToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset, left: true)
+      let leftToViewFold = makeSnapshot(from: toView, afterUpdates: true, offset: offset, left: true)
       axesValues = valuesForAxe(initialValue: self.reverse ? width : 0.0, reverseValue: height / 2)
       leftToViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       axesValues = valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
       leftToViewFold.layer.transform = CATransform3DMakeRotation(.pi * 2, axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(leftToViewFold)
 
-      let rightToViewFold = createSnapshot(fromView: toView, afterUpdates: true, offset: offset + foldSize, left: false)
+      let rightToViewFold = makeSnapshot(from: toView, afterUpdates: true, offset: offset + foldSize, left: false)
       axesValues = valuesForAxe(initialValue: self.reverse ? width : 0.0, reverseValue: height / 2)
       rightToViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       axesValues = valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
@@ -140,7 +140,7 @@ private extension FoldAnimator {
     return [toViewFolds, fromViewFolds]
   }
   
-  func createSnapshot(fromView view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView {
+  func makeSnapshot(from view: UIView, afterUpdates: Bool, offset: CGFloat, left: Bool) -> UIView {
     let containerView = view.superview
     var snapshotView: UIView
     var axesValues = valuesForAxe(initialValue: offset, reverseValue: 0.0)
@@ -156,14 +156,14 @@ private extension FoldAnimator {
       snapshotView.addSubview(subSnapshotView!)
     }
     
-    let snapshotWithShadowView = addShadow(toView: snapshotView, reverse: left)
+    let snapshotWithShadowView = addShadow(to: snapshotView, reverse: left)
     containerView?.addSubview(snapshotWithShadowView)
     axesValues = valuesForAxe(initialValue: left ? 0.0 : 1.0, reverseValue: 0.5)
     snapshotWithShadowView.layer.anchorPoint = CGPoint(x: axesValues.0, y: axesValues.1)
     return snapshotWithShadowView
   }
   
-  func addShadow(toView view: UIView, reverse: Bool) -> UIView {
+  func addShadow(to view: UIView, reverse: Bool) -> UIView {
     let viewWithShadow = UIView(frame: view.frame)
     let shadowView = UIView(frame: viewWithShadow.bounds)
     let gradient = CAGradientLayer()

--- a/IBAnimatable/GradientDesignable.swift
+++ b/IBAnimatable/GradientDesignable.swift
@@ -13,22 +13,23 @@ public protocol GradientDesignable {
 }
 
 public extension GradientDesignable where Self: UIView {
-
   public func configGradient() {
     let predefinedGradient = configPredefinedGradient()
     if let unwrappedStartColor = startColor, let unwrappedEndColor = endColor {
-      configGradientWithStartColor(unwrappedStartColor, endColor: unwrappedEndColor)
+      configGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
     } else if let unwrappedStartColor = predefinedGradient?.0, let unwrappedEndColor = predefinedGradient?.1 {
-      configGradientWithStartColor(unwrappedStartColor, endColor: unwrappedEndColor)
+      configGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
     }
   }
+}
 
-  fileprivate func configGradientWithStartColor(_ startColor: UIColor, endColor: UIColor) {
+fileprivate extension GradientDesignable where Self: UIView  {
+  func configGradient(startColor: UIColor, endColor: UIColor) {
     // Default value is `.Top`
     
     let gradientStartPoint = startPoint
-    let gradientLayer = createGradientLayer()
-    gradientLayer.colors = [startColor.cgColor, endColor.cgColor]    
+    let gradientLayer = makeGradientLayer()
+    gradientLayer.colors = [startColor.cgColor, endColor.cgColor]
     switch gradientStartPoint {
     case .top:
       gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
@@ -56,37 +57,35 @@ public extension GradientDesignable where Self: UIView {
       gradientLayer.endPoint = CGPoint(x: 1, y: 1)
     }
     
-    let gradientView = GradientView(frame: bounds, layer: gradientLayer)
-    let oldGradientView = viewWithTag(gradientView.tag)
-    oldGradientView?.removeFromSuperview()
-    self.insertSubview(gradientView, at: 0)
+    subviews.filter { $0 is PrivateGradientView }.forEach {
+      $0.removeFromSuperview()
+    }
+    
+    let gradientView = PrivateGradientView(frame: bounds, layer: gradientLayer)
+    insertSubview(gradientView, at: 0)
   }
   
-  fileprivate func createGradientLayer() -> CAGradientLayer {
+  func makeGradientLayer() -> CAGradientLayer {
     let gradientLayer: CAGradientLayer = CAGradientLayer()
-    gradientLayer.frame = self.bounds
+    gradientLayer.frame = bounds
     gradientLayer.cornerRadius = layer.cornerRadius
     return gradientLayer
   }
   
-  fileprivate func configPredefinedGradient() -> GradientColor? {
+  func configPredefinedGradient() -> GradientColor? {
     
     guard let gradientType = predefinedGradient else {
-        return nil
+      return nil
     }
     return gradientType.colors
   }
 }
 
-private class GradientView: UIView {
-
-  let viewTag = 999
-  
+private class PrivateGradientView: UIView {
   // MARK: - Life cycle
   
   init(frame: CGRect, layer: CAGradientLayer) {
     super.init(frame: frame)
-    tag = viewTag
     self.layer.insertSublayer(layer, at: 0)
     autoresizingMask = [.flexibleWidth, .flexibleHeight]
   }

--- a/IBAnimatable/InteractiveAnimator.swift
+++ b/IBAnimatable/InteractiveAnimator.swift
@@ -26,26 +26,26 @@ public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
   
   deinit {
     if let gestureRecognizer = gestureRecognizer, let view = viewController?.view {
-      gestureRecognizer.removeTarget(self, action: #selector(handleGesture(_:)))
+      gestureRecognizer.removeTarget(self, action: #selector(handleGesture(for:)))
       view.removeGestureRecognizer(gestureRecognizer)
     }
   }
   
-  func connectGestureRecognizer(_ viewController: UIViewController) {
+  func connectGestureRecognizer(to viewController: UIViewController) {
     self.viewController = viewController
-    let gestureRecognizerType = createGestureRecognizer()
+    let gestureRecognizerType = makeGestureRecognizer()
     gestureRecognizer = gestureRecognizerType
     if let gestureRecognizer = gestureRecognizer {
       self.viewController?.view.addGestureRecognizer(gestureRecognizer)
     }
   }
   
-  func handleGesture(_ gestureRecognizer: UIGestureRecognizer) {
-    let (progress, shouldFinishInteractiveTransition) = calculateProgress(gestureRecognizer)
+  func handleGesture(for gestureRecognizer: UIGestureRecognizer) {
+    let (progress, shouldFinishInteractiveTransition) = calculateProgress(for: gestureRecognizer)
     
     switch gestureRecognizer.state {
     case .began:
-      guard shouldBeginProgress(gestureRecognizer) else {
+      guard shouldBeginProgress(for: gestureRecognizer) else {
         return
       }
       
@@ -78,17 +78,17 @@ public class InteractiveAnimator: UIPercentDrivenInteractiveTransition {
   }
   
   // Because Swift doesn't support pure virtual method, need to throw error
-  func createGestureRecognizer() -> UIGestureRecognizer {
-    preconditionFailure("This method must be overridden")
+  func makeGestureRecognizer() -> UIGestureRecognizer {
+    fatalError("This method must be overridden")
   }
   
-  func shouldBeginProgress(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+  func shouldBeginProgress(for gestureRecognizer: UIGestureRecognizer) -> Bool {
     // return true by default
     return true
   }
   
-  func calculateProgress(_ gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
-    preconditionFailure("This method must be overridden")
+  func calculateProgress(for gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
+    fatalError("This method must be overridden")
   }
 
 }

--- a/IBAnimatable/InteractiveAnimatorFactory.swift
+++ b/IBAnimatable/InteractiveAnimatorFactory.swift
@@ -8,7 +8,7 @@ import UIKit
  Interactive Animator Factory
  */
 struct InteractiveAnimatorFactory {
-  static func generateInteractiveAnimator(_ interactiveGestureType: InteractiveGestureType, transitionType: TransitionType) -> InteractiveAnimator? {
+  static func makeInteractiveAnimator(interactiveGestureType: InteractiveGestureType, transitionType: TransitionType) -> InteractiveAnimator? {
     switch interactiveGestureType {
     case .pan:
       return PanInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: transitionType)

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -22,7 +22,7 @@ public class Navigator: NSObject {
     self.transitionDuration = transitionDuration
     super.init()
     
-    animator = AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
+    animator = AnimatorFactory.makeAnimator(transitionAnimationType: transitionAnimationType, transitionDuration: transitionDuration)
     
     // If interactiveGestureType has been set
     if let interactiveGestureType = interactiveGestureType {
@@ -50,7 +50,7 @@ extension Navigator: UINavigationControllerDelegate {
     } else if operation == .pop {
       // Use the reverse animation
       if let reverseTransitionAnimationType = animator?.reverseAnimationType {
-        return AnimatorFactory.generateAnimator(reverseTransitionAnimationType, transitionDuration: transitionDuration)
+        return AnimatorFactory.makeAnimator(transitionAnimationType: reverseTransitionAnimationType, transitionDuration: transitionDuration)
       }
     }
     return nil

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -30,10 +30,10 @@ public class Navigator: NSObject {
       switch interactiveGestureType {
       case .default:
         if let interactiveGestureType = animator?.interactiveGestureType {
-          interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .navigationTransition(.pop))
+          interactiveAnimator = InteractiveAnimatorFactory.makeInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .navigationTransition(.pop))
         }
       default:
-        interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .navigationTransition(.pop))
+        interactiveAnimator = InteractiveAnimatorFactory.makeInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .navigationTransition(.pop))
       }
     }
   }

--- a/IBAnimatable/Navigator.swift
+++ b/IBAnimatable/Navigator.swift
@@ -42,7 +42,7 @@ public class Navigator: NSObject {
 extension Navigator: UINavigationControllerDelegate {
   // MARK: - animation controller
   public func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationControllerOperation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    interactiveAnimator?.connectGestureRecognizer(toVC)
+    interactiveAnimator?.connectGestureRecognizer(to: toVC)
     
     if operation == .push {
       animator?.transitionDuration = transitionDuration

--- a/IBAnimatable/PanInteractiveAnimator.swift
+++ b/IBAnimatable/PanInteractiveAnimator.swift
@@ -8,11 +8,11 @@ import UIKit
 // Pan interactive animator: pan gesture transition controller
 public class PanInteractiveAnimator: InteractiveAnimator {
   
-  override func createGestureRecognizer() -> UIGestureRecognizer {
-    return UIPanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
+  override func makeGestureRecognizer() -> UIGestureRecognizer {
+    return UIPanGestureRecognizer(target: self, action: #selector(handleGesture(for:)))
   }
   
-  override func calculateProgress(_ gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
+  override func calculateProgress(for gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
     guard let  gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer,
       let superview = gestureRecognizer.view?.superview else {
       return (0, false)

--- a/IBAnimatable/PinchInteractiveAnimator.swift
+++ b/IBAnimatable/PinchInteractiveAnimator.swift
@@ -8,12 +8,12 @@ import UIKit
 public class PinchInteractiveAnimator: InteractiveAnimator {
   fileprivate var startScale: CGFloat = 0
   
-  override func createGestureRecognizer() -> UIGestureRecognizer {
-    let gestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
+  override func makeGestureRecognizer() -> UIGestureRecognizer {
+    let gestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handleGesture(for:)))
     return gestureRecognizer
   }
   
-  override func shouldBeginProgress(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+  override func shouldBeginProgress(for gestureRecognizer: UIGestureRecognizer) -> Bool {
     guard let gestureRecognizer = gestureRecognizer as? UIPinchGestureRecognizer else {
       return false
     }
@@ -33,7 +33,7 @@ public class PinchInteractiveAnimator: InteractiveAnimator {
     }
   }
   
-  override func calculateProgress(_ gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
+  override func calculateProgress(for gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
     guard let  gestureRecognizer = gestureRecognizer as? UIPinchGestureRecognizer,
       let _ = gestureRecognizer.view?.superview else {
         return (0, false)

--- a/IBAnimatable/PresentationPresenter.swift
+++ b/IBAnimatable/PresentationPresenter.swift
@@ -28,7 +28,7 @@ public class PresentationPresenter: NSObject {
 
     updateTransitionDuration()
     if presentationAnimationType.systemTransition == nil {
-      animator = AnimatorFactory.generateAnimator(presentationAnimationType: presentationAnimationType, transitionDuration: transitionDuration)
+      animator = AnimatorFactory.makeAnimator(presentationAnimationType: presentationAnimationType, transitionDuration: transitionDuration)
     }
   }
 
@@ -64,7 +64,7 @@ extension PresentationPresenter: UIViewControllerTransitioningDelegate {
     if dismissalAnimationType.systemTransition != nil {
       return nil
     }
-    return AnimatorFactory.generateAnimator(presentationAnimationType: dismissalAnimationType, transitionDuration: transitionDuration)
+    return AnimatorFactory.makeAnimator(presentationAnimationType: dismissalAnimationType, transitionDuration: transitionDuration)
   }
 
 }

--- a/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
+++ b/IBAnimatable/ScreenEdgePanInteractiveAnimator.swift
@@ -7,8 +7,8 @@ import UIKit
 
 public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
   
-  override func createGestureRecognizer() -> UIGestureRecognizer {
-    let gestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
+  override func makeGestureRecognizer() -> UIGestureRecognizer {
+    let gestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleGesture(for:)))
     switch interactiveGestureType {
     case let .screenEdgePan(direction):
       switch direction {
@@ -33,7 +33,7 @@ public class ScreenEdgePanInteractiveAnimator: InteractiveAnimator {
     return gestureRecognizer
   }
   
-  override func calculateProgress(_ gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
+  override func calculateProgress(for gestureRecognizer: UIGestureRecognizer) -> (progress: CGFloat, shouldFinishInteractiveTransition: Bool) {
     guard let  gestureRecognizer = gestureRecognizer as? UIScreenEdgePanGestureRecognizer,
       let superview = gestureRecognizer.view?.superview else {
         return (0, false)

--- a/IBAnimatable/SideImageDesignable.swift
+++ b/IBAnimatable/SideImageDesignable.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// Protocol for designing side image 
 public protocol SideImageDesignable {
   /**
    * The left image
@@ -48,33 +49,34 @@ public protocol SideImageDesignable {
 }
 
 public extension SideImageDesignable where Self: UITextField {
-
   public func configImages() {
     configLeftImage()
     configRightImage()
   }
-  
-  fileprivate func configLeftImage() {
+}
+
+fileprivate extension SideImageDesignable where Self: UITextField {
+  func configLeftImage() {
     guard let wrappedLeftImage = leftImage else {
       return
     }
     
-    let sideView = generateSideViewWithImage(image: wrappedLeftImage, leftPadding: leftImageLeftPadding, rightPadding: leftImageRightPadding, topPadding: leftImageTopPadding)
+    let sideView = makeSideView(with: wrappedLeftImage, leftPadding: leftImageLeftPadding, rightPadding: leftImageRightPadding, topPadding: leftImageTopPadding)
     leftViewMode = .always
     leftView = sideView
   }
   
-  fileprivate func configRightImage() {
+  func configRightImage() {
     guard let wrappedRightImage = rightImage else {
       return
     }
     
-    let sideView = generateSideViewWithImage(image: wrappedRightImage, leftPadding: rightImageLeftPadding, rightPadding: rightImageRightPadding, topPadding: rightImageTopPadding)
+    let sideView = makeSideView(with: wrappedRightImage, leftPadding: rightImageLeftPadding, rightPadding: rightImageRightPadding, topPadding: rightImageTopPadding)
     rightViewMode = .always
     rightView = sideView
   }
   
-  fileprivate func generateSideViewWithImage(image: UIImage, leftPadding: CGFloat, rightPadding: CGFloat, topPadding: CGFloat) -> UIView {
+  func makeSideView(with image: UIImage, leftPadding: CGFloat, rightPadding: CGFloat, topPadding: CGFloat) -> UIView {
     let imageView = UIImageView(image: image)
     
     // If not set, use 0 as default value
@@ -88,7 +90,7 @@ public extension SideImageDesignable where Self: UITextField {
     if !rightPadding.isNaN {
       rightPaddingValue = rightPadding
     }
-
+    
     // If does not specify `topPadding`, then center it in the middle
     if topPadding.isNaN {
       imageView.frame.origin = CGPoint(x: leftPaddingValue, y: (bounds.height - imageView.bounds.height) / 2)

--- a/IBAnimatable/TransitionPresenter.swift
+++ b/IBAnimatable/TransitionPresenter.swift
@@ -39,7 +39,7 @@ public class TransitionPresenter: NSObject {
     super.init()
     
     updateTransitionDuration()
-    animator = AnimatorFactory.generateAnimator(transitionAnimationType, transitionDuration: transitionDuration)
+    animator = AnimatorFactory.makeAnimator(transitionAnimationType: transitionAnimationType, transitionDuration: transitionDuration)
     
     self.interactiveGestureType = interactiveGestureType
     updateInteractiveAnimator()
@@ -82,7 +82,7 @@ extension TransitionPresenter: UIViewControllerTransitioningDelegate {
   public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
     // Use the reverse animation
     if let reverseTransitionAnimationType = animator?.reverseAnimationType {
-      return AnimatorFactory.generateAnimator(reverseTransitionAnimationType, transitionDuration: transitionDuration)
+      return AnimatorFactory.makeAnimator(transitionAnimationType: reverseTransitionAnimationType, transitionDuration: transitionDuration)
     }
     return nil
   }

--- a/IBAnimatable/TransitionPresenter.swift
+++ b/IBAnimatable/TransitionPresenter.swift
@@ -59,10 +59,10 @@ public class TransitionPresenter: NSObject {
       switch interactiveGestureType {
       case .default:
         if let interactiveGestureType = animator?.interactiveGestureType {
-          interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .presentationTransition(.dismissal))
+          interactiveAnimator = InteractiveAnimatorFactory.makeInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .presentationTransition(.dismissal))
         }
       default:
-        interactiveAnimator = InteractiveAnimatorFactory.generateInteractiveAnimator(interactiveGestureType, transitionType: .presentationTransition(.dismissal))
+        interactiveAnimator = InteractiveAnimatorFactory.makeInteractiveAnimator(interactiveGestureType: interactiveGestureType, transitionType: .presentationTransition(.dismissal))
       }
     } else {
       interactiveAnimator = nil

--- a/IBAnimatable/TransitionPresenter.swift
+++ b/IBAnimatable/TransitionPresenter.swift
@@ -75,7 +75,7 @@ extension TransitionPresenter: UIViewControllerTransitioningDelegate {
   // MARK: - animation controller
   public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
     animator?.transitionDuration = transitionDuration
-    interactiveAnimator?.connectGestureRecognizer(presented)
+    interactiveAnimator?.connectGestureRecognizer(to: presented)
     return animator
   }
 

--- a/IBAnimatableApp/ContainerTransitionViewController.swift
+++ b/IBAnimatableApp/ContainerTransitionViewController.swift
@@ -20,7 +20,7 @@ class ContainerTransitionViewController: UIViewController, UITabBarDelegate {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    createChildViewControllers()
+    makeChildViewControllers()
     tabBar.selectedItem = tabBar.items?.first
   }
   
@@ -30,7 +30,7 @@ class ContainerTransitionViewController: UIViewController, UITabBarDelegate {
 
 private extension ContainerTransitionViewController {
   
-  func createChildViewControllers() {
+  func makeChildViewControllers() {
     var viewController = AnimatableViewController()
     viewController.view.backgroundColor = .blue
     viewController.transitionAnimationType = TransitionAnimationType(string: "Explode")
@@ -52,7 +52,6 @@ private extension ContainerTransitionViewController {
     viewControllers.append(viewController)
     
     cycleFromViewController(containerView, fromViewController: nil, toViewController: viewControllers[0])
-
   }
   
   func cycleFromViewController(_ containerView: UIView, fromViewController: AnimatableViewController?, toViewController: AnimatableViewController) {

--- a/IBAnimatableApp/PresentationPresentedViewController.swift
+++ b/IBAnimatableApp/PresentationPresentedViewController.swift
@@ -14,7 +14,7 @@ class PresentationPresentedViewController: AnimatableModalViewController {
     super.viewDidLoad()
 
     if let animatableView = view as? AnimatableView {
-      animatableView.predefinedGradient = generateRandomGradient()
+      animatableView.predefinedGradient = makeRandomGradient()
     }
   }
 

--- a/IBAnimatableApp/TransitionPresentedViewController.swift
+++ b/IBAnimatableApp/TransitionPresentedViewController.swift
@@ -22,7 +22,7 @@ class TransitionPresentedViewController: AnimatableViewController {
     super.viewDidLoad()
     
     if let animatableView = view as? AnimatableView {
-      animatableView.predefinedGradient = generateRandomGradient()
+      animatableView.predefinedGradient = makeRandomGradient()
     }
     
     configureGestureLabel()

--- a/IBAnimatableApp/TransitionPushedViewController.swift
+++ b/IBAnimatableApp/TransitionPushedViewController.swift
@@ -14,7 +14,7 @@ class TransitionPushedViewController: UIViewController {
     super.viewDidLoad()
     
     if let animatableView = view as? AnimatableView {
-      animatableView.predefinedGradient = generateRandomGradient()
+      animatableView.predefinedGradient = makeRandomGradient()
     }
     configureGestureLabel()
   }

--- a/IBAnimatableApp/TransitionTableViewController.swift
+++ b/IBAnimatableApp/TransitionTableViewController.swift
@@ -14,7 +14,7 @@ class TransitionTableViewController: UITableViewController {
   // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    generateTransitionTypeData()
+    populateTransitionTypeData()
   }
 
   // MARK: - Navigation
@@ -44,7 +44,7 @@ class TransitionTableViewController: UITableViewController {
 
 private extension TransitionTableViewController {
   
-  func generateTransitionTypeData() {
+  func populateTransitionTypeData() {
     transitionAnimationsHeaders.append("Fade")
     transitionAnimations.append(["Fade", "Fade(In)", "Fade(Out)"])
     transitionAnimationsHeaders.append("SystemCube")

--- a/IBAnimatableApp/UIViewControllerExtension.swift
+++ b/IBAnimatableApp/UIViewControllerExtension.swift
@@ -8,7 +8,7 @@ import IBAnimatable
 
 extension UIViewController {
   
-  func generateRandomGradient() -> GradientType {
+  func makeRandomGradient() -> GradientType {
     var predefinedGradients = [GradientType]()
     iterateEnum(GradientType.self).forEach {
       predefinedGradients.append($0)

--- a/IBAnimatableApp/UIViewControllerExtension.swift
+++ b/IBAnimatableApp/UIViewControllerExtension.swift
@@ -22,7 +22,7 @@ extension UIViewController {
     switch interactiveGestureType {
     case .default:
       // Default gesture
-      let transitionAnimator = AnimatorFactory.generateAnimator(transitionAnimationType)
+      let transitionAnimator = AnimatorFactory.makeAnimator(transitionAnimationType: transitionAnimationType)
       if let interactiveGestureType = transitionAnimator?.interactiveGestureType {
         return String("or use \(interactiveGestureType.stringValueWithoutQualification) gesture to \(exit)")
       }

--- a/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
+++ b/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
@@ -27,7 +27,7 @@ class UserInterfaceActivityIndicatorViewController: UIViewController, UIPickerVi
   override func viewDidLoad() {
     super.viewDidLoad()
     if let animatableView = view as? AnimatableView {
-      animatableView.predefinedGradient = generateRandomGradient()
+      animatableView.predefinedGradient = makeRandomGradient()
     }
   }
 

--- a/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
+++ b/IBAnimatableApp/UserInterfaceActivityIndicatorViewController.swift
@@ -14,10 +14,10 @@ class UserInterfaceActivityIndicatorViewController: UIViewController, UIPickerVi
 
   // MARK: Properties
 
-  fileprivate var activityIndicatorsType: [String] {
-    var types = [String]()
+  fileprivate var activityIndicatorsType: [ActivityIndicatorType] {
+    var types = [ActivityIndicatorType]()
     iterateEnum(ActivityIndicatorType.self).forEach {
-      types.append($0.rawValue)
+      types.append($0)
     }
     return types
   }
@@ -45,7 +45,7 @@ extension UserInterfaceActivityIndicatorViewController {
 
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
     let title = activityIndicatorsType[row]
-    return NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName:UIColor.white])
+    return NSAttributedString(string: title.rawValue, attributes: [NSForegroundColorAttributeName:UIColor.white])
   }
 
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {


### PR DESCRIPTION
In this PR, we have done the following tasks.
1. Refactor enums to use `IBEnum`.
2. Refactor entire activity indicators feature to use Swift 3 APIs.
3. Refactor all factory method to use `make***` instead of  `generate***` or `create***`. According to [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)
4. Reactor all `M_PI`s.
5. Fix some `fileprivate` to `private`

related to #221 
@lastMove @tbaranes can you have a look when you have time? thanks.
