### PR TITLE
Refator configure*** methods

### DIFF
--- a/IBAnimatable.playground/Sources/common.swift
+++ b/IBAnimatable.playground/Sources/common.swift
@@ -34,7 +34,7 @@ public class CircleView: AnimatableView {
     let frame = CGRect(x: animatableViewX, y: animatableViewY, width: animatableViewWidth, height: animatableViewWidth)
     super.init(frame: frame)
     
-    configAnimatableProperties()
+    configureAnimatableProperties()
     fillColor = #colorLiteral(red: 0.7098039216, green: 0.4549019608, blue: 0.9607843137, alpha: 1)
     borderWidth = 2
     borderColor = .purple()

--- a/IBAnimatable/ActivityIndicatorAnimatable.swift
+++ b/IBAnimatable/ActivityIndicatorAnimatable.swift
@@ -22,7 +22,7 @@ public extension ActivityIndicatorAnimatable where Self: UIView {
   /// Start animating the activity indicator
   public func startAnimating() {
     isHidden = false
-    configLayer()
+    configureLayer()
     isAnimating = true
   }
 
@@ -39,7 +39,7 @@ public extension ActivityIndicatorAnimatable where Self: UIView {
 
 private extension ActivityIndicatorAnimatable where Self: UIView {
 
-  func configLayer() {
+  func configureLayer() {
     guard layer.sublayers == nil else {
       return
     }
@@ -49,7 +49,7 @@ private extension ActivityIndicatorAnimatable where Self: UIView {
     }
 
     let activityIndicator = ActivityIndicatorFactory.makeActivityIndicator(activityIndicatorType: animationType)
-    activityIndicator.configAnimation(in: layer, size: bounds.size, color: color)
+    activityIndicator.configureAnimation(in: layer, size: bounds.size, color: color)
     layer.speed = 1
   }
 

--- a/IBAnimatable/ActivityIndicatorAnimating.swift
+++ b/IBAnimatable/ActivityIndicatorAnimating.swift
@@ -14,5 +14,5 @@ public protocol ActivityIndicatorAnimating {
    - Parameter size: The size of the activity indicator.
    - Parameter color: The color of the activity indicator.
    */
-  func configAnimation(in layer: CALayer, size: CGSize, color: UIColor)
+  func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor)
 }

--- a/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationAudioEqualizer.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationAudioEqualizer: ActivityIndicatorAnimatin
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     self.size = size
     lineSize = size.width / 9
     let x = (layer.bounds.size.width - lineSize * 7) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallBeat.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallBeat: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSpacing: CGFloat = 2
     let circleSize = (size.width - circleSpacing * 2) / 3
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotate.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallClipRotate: ActivityIndicatorAnimatin
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
 
     // Draw circle

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotateMultiple.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallClipRotateMultiple: ActivityIndicator
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let bigCircleSize: CGFloat = size.width
     let smallCircleSize: CGFloat = size.width / 2
     let longDuration: CFTimeInterval = 1

--- a/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallClipRotatePulse.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationBallClipRotatePulse: ActivityIndicatorAni
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     animateSmallCircle(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
     animateBigCircle(duration: duration, timingFunction: timingFunction, layer: layer, size: size, color: color)
   }

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSpacing: CGFloat = 2
     let circleSize = (size.width - circleSpacing * 2) / 3
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridPulse.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSpacing: CGFloat = 2
     let circleSize = (size.width - circleSpacing * 2) / 3
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
@@ -9,7 +9,7 @@ public class ActivityIndicatorAnimationBallPulse: ActivityIndicatorAnimating {
   
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
 
         let circleSpacing: CGFloat = 2
         let circleSize: CGFloat = (size.width - 2 * circleSpacing) / 3

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseRise.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationBallPulseRise: ActivityIndicatorAnimating
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSpacing: CGFloat = 2
     let circleSize = (size.width - 4 * circleSpacing) / 5
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSpacing: CGFloat = 2
     self.size = size
     circleSize = (size.width - circleSpacing * 2) / 3

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotate.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationBallRotate: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSize: CGFloat = size.width / 5
     let animation = self.animation
 

--- a/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallRotateChase.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallRotateChase: ActivityIndicatorAnimati
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSize = size.width / 5
     for i in 0 ..< 5 {
       let factor = Float(i) * 1.0 / 5

--- a/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScale.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallScale: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
     let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
     circle.frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleMultiple.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
         let beginTime = CACurrentMediaTime()
         let beginTimes = [0, 0.2, 0.4]
         let animation = self.animation

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRipple.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationBallScaleRipple: ActivityIndicatorAnimati
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
     let circle = ActivityIndicatorShape.ring.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,

--- a/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
         let beginTime = CACurrentMediaTime()
         let beginTimes = [0.0, 0.2, 0.4]
         let animation = self.animation

--- a/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnim
   
   // MARK: ActivityIndicatorAnimating
   
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     
     let circleSpacing: CGFloat = -2
     let circleSize = (size.width - 4 * circleSpacing) / 5

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSize = size.width / 5
     let deltaX = size.width / 2 - circleSize / 2
     let deltaY = size.height / 2 - circleSize / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZag.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallZigZag: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let circleSize: CGFloat = size.width / 5    
     let deltaX = size.width / 2 - circleSize / 2
     let deltaY = size.height / 2 - circleSize / 2

--- a/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallZigZagDeflect.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationBallZigZagDeflect: ActivityIndicatorAnima
   
   // MARK: ActivityIndicatorAnimating
   
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     
     let circleSize: CGFloat = size.width / 5
     let duration: CFTimeInterval = 0.75

--- a/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationCubeTransition.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationCubeTransition: ActivityIndicatorAnimatin
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
 
     let squareSize = size.width / 5
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let lineSize = size.width / 9
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let lineSize = size.width / 7
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let lineSize = size.width / 9
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -15,7 +15,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let lineSize = size.width / 9
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -14,7 +14,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let lineSpacing: CGFloat = 2
     let lineSize = CGSize(width: (size.width - 4 * lineSpacing) / 5, height: (size.height - 2 * lineSpacing) / 3)
     let x = (layer.bounds.size.width - size.width) / 2

--- a/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationOrbit.swift
@@ -18,7 +18,7 @@ public class ActivityIndicatorAnimationOrbit: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     self.size = size
 
     coreSize = size.width / (1 + satelliteCoreRatio + distanceRatio)

--- a/IBAnimatable/ActivityIndicatorAnimationPacman.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationPacman.swift
@@ -16,7 +16,7 @@ public class ActivityIndicatorAnimationPacman: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     self.size = size
     animateCircle(in: layer, color: color)
     animatePacman(in: layer, color: color)

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let animation = self.animation
     let circle = ActivityIndicatorShape.circleSemi.makeLayer(size: size, color: color)
     let frame = CGRect(

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
 
     let animation = self.animation
     let square = ActivityIndicatorShape.rectangle.makeLayer(size: size, color: color)

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -13,7 +13,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
 
   // MARK: ActivityIndicatorAnimating
 
-  public func configAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+  public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
     let triangle = ActivityIndicatorShape.triangle.makeLayer(size: size, color: color)

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -51,7 +51,7 @@ public protocol Animatable: class {
 }
 
 public extension Animatable where Self: UIView {
-  public func configAnimatableProperties() {
+  public func configureAnimatableProperties() {
     // Apply default values
     if duration.isNaN {
       duration = 0.7

--- a/IBAnimatable/AnimatableBarButtonItem.swift
+++ b/IBAnimatable/AnimatableBarButtonItem.swift
@@ -12,12 +12,12 @@ import UIKit
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
 
   // TODO: animations
@@ -43,8 +43,8 @@ import UIKit
   @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-//    configAnimatableProperties()
+  fileprivate func configureInspectableProperties() {
+//    configureAnimatableProperties()
     confingBarButtonItemImage()
   }
 }

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
 
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
    open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -62,34 +62,34 @@ import UIKit
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
 
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
 
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
 
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
-      configMaskShadow()
+      configureMask()
+      configureBorder()
+      configureMaskShadow()
     }
   }
   
@@ -118,28 +118,28 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
-    configMaskShadow()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
+    configureMaskShadow()
   }
 }

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -10,64 +10,64 @@ import UIKit
   // MARK: - CheckBoxDesignable
   @IBInspectable open var checked: Bool = false {
     didSet {
-      configCheckBoxChecked()
+      configureCheckBoxChecked()
     }
   }
   
   @IBInspectable open var checkedImage: UIImage? = nil {
     didSet {
-      configCheckBoxCheckedImage()
+      configureCheckBoxCheckedImage()
     }
   }
   
   @IBInspectable open var uncheckedImage: UIImage? = nil {
     didSet {
-      configCheckBoxUncheckedImage()
+      configureCheckBoxUncheckedImage()
     }
   }
   
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -79,33 +79,33 @@ import UIKit
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
+      configureMask()
+      configureBorder()
     }
   }
   
@@ -135,18 +135,18 @@ open var animationType: AnimationType = .none
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
     setup()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
     setup()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
@@ -165,12 +165,12 @@ open var animationType: AnimationType = .none
     tintColor = .clear
   }
   
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
   }
 }

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -94,28 +94,28 @@ import UIKit
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configOpacity()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureOpacity()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
 
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
 
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -60,38 +60,38 @@ import UIKit
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   // MARK: - BlurDesignable
   open var blurEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _blurEffectStyle: String? {
@@ -101,7 +101,7 @@ import UIKit
   }
   open var vibrancyEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _vibrancyEffectStyle: String? {
@@ -112,7 +112,7 @@ import UIKit
 
   @IBInspectable open var blurOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   
@@ -142,9 +142,9 @@ import UIKit
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
-      configMaskShadow()
+      configureMask()
+      configureBorder()
+      configureMaskShadow()
     }
   }
   
@@ -173,30 +173,30 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configTintedColor()    
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureTintedColor()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
-    configMaskShadow()
-    configGradient()    
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
+    configureMaskShadow()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -75,34 +75,34 @@ open var animationType: AnimationType = .none
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configBorder()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureBorder()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
   }
 }

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -11,45 +11,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -61,38 +61,38 @@ import UIKit
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   // MARK: - BlurDesignable
   open var blurEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _blurEffectStyle: String? {
@@ -103,7 +103,7 @@ import UIKit
   
   open var vibrancyEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _vibrancyEffectStyle: String? {
@@ -114,7 +114,7 @@ import UIKit
   
   @IBInspectable open var blurOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   
@@ -143,8 +143,8 @@ import UIKit
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
+      configureMask()
+      configureBorder()
     }
   }
   
@@ -173,29 +173,29 @@ import UIKit
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configTintedColor()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureTintedColor()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -10,19 +10,19 @@ import UIKit
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -34,32 +34,32 @@ import UIKit
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
@@ -81,26 +81,26 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
   }
 }

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -12,45 +12,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -62,32 +62,32 @@ import UIKit
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
@@ -116,8 +116,8 @@ import UIKit
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
+      configureMask()
+      configureBorder()
     }
   }
   
@@ -146,29 +146,29 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configTintedColor()    
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureTintedColor()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -10,38 +10,38 @@ import UIKit
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -84,29 +84,29 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
     autoRunAnimation()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configOpacity()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureOpacity()
     
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -10,38 +10,38 @@ import UIKit
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
 
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -87,29 +87,29 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configOpacity()
-    configSeparatorMargins()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureOpacity()
+    configureSeparatorMargins()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -60,44 +60,44 @@ import UIKit
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
   // MARK: - PaddingDesignable
   @IBInspectable open var paddingLeft: CGFloat = CGFloat.nan {
     didSet {
-      configPaddingLeft()
+      configurePaddingLeft()
     }
   }
   
   @IBInspectable open var paddingRight: CGFloat = CGFloat.nan {
     didSet {
-      configPaddingRight()
+      configurePaddingRight()
     }
   }
 
   @IBInspectable open var paddingSide: CGFloat = CGFloat.nan {
     didSet {
-      configPaddingSide()
+      configurePaddingSide()
     }
   }
   
@@ -115,7 +115,7 @@ import UIKit
   // MARK: - CSSPlaceholderable
   @IBInspectable open var placeholderColor: UIColor? {
     didSet {
-      configPlaceholderColor()
+      configurePlaceholderColor()
     }
   }
   
@@ -137,27 +137,27 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configImages()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureImages()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configBorder()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureBorder()
   }
 }

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
 
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -123,17 +123,17 @@ open var animationType: AnimationType = .none
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
 
@@ -142,9 +142,9 @@ open var animationType: AnimationType = .none
   }
   
   // MARK: - Private
-  private func configInspectableProperties() {
-    configAnimatableProperties()
-    config(placeholder: placeholderLabel, placeholderLabelConstraints: &placeholderLabelConstraints)
+  private func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configure(placeholderLabel: placeholderLabel, placeholderLabelConstraints: &placeholderLabelConstraints)
     NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: NSNotification.Name.UITextViewTextDidChange, object: nil)
   }
 
@@ -152,8 +152,8 @@ open var animationType: AnimationType = .none
     placeholderLabel.isHidden = !text.isEmpty
   }
 
-  private func configAfterLayoutSubviews() {
-    configBorder()
+  private func configureAfterLayoutSubviews() {
+    configureBorder()
     placeholderLabel.preferredMaxLayoutWidth = textContainer.size.width - textContainer.lineFragmentPadding * 2.0
   }
 }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -10,45 +10,45 @@ import UIKit
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
     didSet {
-      configCornerRadius()
+      configureCornerRadius()
     }
   }
   
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var predefinedColor: String? {
     didSet {
-      configFillColor()
+      configureFillColor()
     }
   }
   
   @IBInspectable open var opacity: CGFloat = CGFloat.nan {
     didSet {
-      configOpacity()
+      configureOpacity()
     }
   }
   
   // MARK: - BorderDesignable
   @IBInspectable open var borderColor: UIColor? {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   @IBInspectable open var borderWidth: CGFloat = CGFloat.nan {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
   open var borderSides: BorderSides  = .AllSides {
     didSet {
-      configBorder()
+      configureBorder()
     }
   }
   
@@ -60,39 +60,39 @@ import UIKit
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {
     didSet {
-      configRotate()
+      configureRotate()
     }
   }
   
   // MARK: - ShadowDesignable
   @IBInspectable open var shadowColor: UIColor? {
     didSet {
-      configShadowColor()
+      configureShadowColor()
     }
   }
   
   @IBInspectable open var shadowRadius: CGFloat = CGFloat.nan {
     didSet {
-      configShadowRadius()
+      configureShadowRadius()
     }
   }
   
   @IBInspectable open var shadowOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configShadowOpacity()
+      configureShadowOpacity()
     }
   }
   
   @IBInspectable open var shadowOffset: CGPoint = CGPoint(x: CGFloat.nan, y: CGFloat.nan) {
     didSet {
-      configShadowOffset()
+      configureShadowOffset()
     }
   }
   
   // MARK: - BlurDesignable
   open var blurEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _blurEffectStyle: String? {
@@ -103,7 +103,7 @@ import UIKit
   
   open var vibrancyEffectStyle: UIBlurEffectStyle? {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   @IBInspectable var _vibrancyEffectStyle: String? {
@@ -114,7 +114,7 @@ import UIKit
   
   @IBInspectable open var blurOpacity: CGFloat = CGFloat.nan {
     didSet {
-      configBlurEffectStyle()
+      configureBlurEffectStyle()
     }
   }
   
@@ -143,9 +143,9 @@ import UIKit
   // MARK: - MaskDesignable
   open var maskType: MaskType = .none {
     didSet {
-      configMask()
-      configBorder()
-      configMaskShadow()
+      configureMask()
+      configureBorder()
+      configureMaskShadow()
     }
   }
   
@@ -174,30 +174,30 @@ import UIKit
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func layoutSubviews() {
     super.layoutSubviews()
-    configAfterLayoutSubviews()
+    configureAfterLayoutSubviews()
     autoRunAnimation()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configAnimatableProperties()
-    configTintedColor()
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+    configureTintedColor()
   }
   
-  fileprivate func configAfterLayoutSubviews() {
-    configMask()
-    configBorder()
-    configMaskShadow()
-    configGradient()
+  fileprivate func configureAfterLayoutSubviews() {
+    configureMask()
+    configureBorder()
+    configureMaskShadow()
+    configureGradient()
   }
 }

--- a/IBAnimatable/AnimatableViewController.swift
+++ b/IBAnimatable/AnimatableViewController.swift
@@ -39,8 +39,8 @@ import UIKit
   // MARK: - Lifecylce
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    confingHideNavigationBar()
-    configRootWindowBackgroundColor()
+    configureHideNavigationBar()
+    configureRootWindowBackgroundColor()
   }
   
   open override func viewWillDisappear(_ animated: Bool) {

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -25,9 +25,9 @@ public protocol BlurDesignable {
 
 public extension BlurDesignable where Self: UIView {
   /**
-   configBlurEffectStyle method, should be called in layoutSubviews() method
+   configureBlurEffectStyle method, should be called in layoutSubviews() method
    */
-  public func configBlurEffectStyle() {
+  public func configureBlurEffectStyle() {
     // Used for caching the previous visual effect view
     var privateVisualEffectView: PrivateVisualEffectView?
     

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -24,7 +24,7 @@ public protocol BorderDesignable {
 }
 
 public extension BorderDesignable where Self: UITextField {
-  public func configBorder() {
+  public func configureBorder() {
     // set the borderSytle to `.None` to support single side of border
     borderStyle = .none
     commonConfigBorder()
@@ -32,7 +32,7 @@ public extension BorderDesignable where Self: UITextField {
 }
 
 public extension BorderDesignable where Self: UIView {
-  public func configBorder() {
+  public func configureBorder() {
     commonConfigBorder()
   }
 }

--- a/IBAnimatable/CheckBoxDesignable.swift
+++ b/IBAnimatable/CheckBoxDesignable.swift
@@ -12,11 +12,11 @@ public protocol CheckBoxDesignable {
 }
 
 public extension CheckBoxDesignable where Self: UIButton {
-  public func configCheckBoxChecked() {
+  public func configureCheckBoxChecked() {
     isSelected = checked
   }
   
-  public func configCheckBoxCheckedImage() {
+  public func configureCheckBoxCheckedImage() {
     guard let unwrappedCheckedImage = checkedImage else {
       return
     }
@@ -25,7 +25,7 @@ public extension CheckBoxDesignable where Self: UIButton {
     setBackgroundImage(unwrappedCheckedImage, for: [.selected, .highlighted])
   }
   
-  public func configCheckBoxUncheckedImage() {
+  public func configureCheckBoxUncheckedImage() {
     guard let unwrappedUncheckedImage = uncheckedImage else {
       return
     }

--- a/IBAnimatable/CornerDesignable.swift
+++ b/IBAnimatable/CornerDesignable.swift
@@ -13,7 +13,7 @@ public protocol CornerDesignable {
 }
 
 public extension CornerDesignable where Self: UIView {
-  public func configCornerRadius() {
+  public func configureCornerRadius() {
     if !cornerRadius.isNaN && cornerRadius > 0 {
       layer.cornerRadius = cornerRadius
     }

--- a/IBAnimatable/DesignableNavigationBar.swift
+++ b/IBAnimatable/DesignableNavigationBar.swift
@@ -11,16 +11,16 @@ import UIKit
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   open override func awakeFromNib() {
     super.awakeFromNib()
-    configInspectableProperties()
+    configureInspectableProperties()
   }
   
   // MARK: - Private
-  fileprivate func configInspectableProperties() {
-    configNavigationBar()
+  fileprivate func configureInspectableProperties() {
+    configureNavigationBar()
   }
 }

--- a/IBAnimatable/FillDesignable.swift
+++ b/IBAnimatable/FillDesignable.swift
@@ -12,7 +12,7 @@ public protocol FillDesignable {
 }
 
 public extension FillDesignable where Self: UIView {
-  public func configFillColor() {
+  public func configureFillColor() {
     if let unwrappedFillColor = fillColor {
       backgroundColor = unwrappedFillColor
     } else if let unwrappedPredefinedColor = predefinedColorFromString(predefinedColor: predefinedColor) {
@@ -20,7 +20,7 @@ public extension FillDesignable where Self: UIView {
     }
   }
 
-  public func configOpacity() {
+  public func configureOpacity() {
     if !opacity.isNaN && opacity >= 0 && opacity <= 1 {
       alpha = opacity
 
@@ -33,7 +33,7 @@ public extension FillDesignable where Self: UIView {
 }
 
 public extension FillDesignable where Self: UITableViewCell {
-  public func configFillColor() {
+  public func configureFillColor() {
     if let unwrappedFillColor = fillColor {
       backgroundColor = unwrappedFillColor
       contentView.backgroundColor = unwrappedFillColor

--- a/IBAnimatable/GradientDesignable.swift
+++ b/IBAnimatable/GradientDesignable.swift
@@ -13,18 +13,18 @@ public protocol GradientDesignable {
 }
 
 public extension GradientDesignable where Self: UIView {
-  public func configGradient() {
-    let predefinedGradient = configPredefinedGradient()
+  public func configureGradient() {
+    let predefinedGradient = configurePredefinedGradient()
     if let unwrappedStartColor = startColor, let unwrappedEndColor = endColor {
-      configGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
+      configureGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
     } else if let unwrappedStartColor = predefinedGradient?.0, let unwrappedEndColor = predefinedGradient?.1 {
-      configGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
+      configureGradient(startColor: unwrappedStartColor, endColor: unwrappedEndColor)
     }
   }
 }
 
 fileprivate extension GradientDesignable where Self: UIView  {
-  func configGradient(startColor: UIColor, endColor: UIColor) {
+  func configureGradient(startColor: UIColor, endColor: UIColor) {
     // Default value is `.Top`
     
     let gradientStartPoint = startPoint
@@ -72,7 +72,7 @@ fileprivate extension GradientDesignable where Self: UIView  {
     return gradientLayer
   }
   
-  func configPredefinedGradient() -> GradientColor? {
+  func configurePredefinedGradient() -> GradientColor? {
     
     guard let gradientType = predefinedGradient else {
       return nil

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -15,8 +15,8 @@ public protocol MaskDesignable {
    ```
    public var maskType: MaskType = .none {
      didSet {
-       configMask()
-       configBorder()
+       configureMask()
+       configureBorder()
      }
    }
    ```
@@ -35,7 +35,7 @@ public protocol MaskDesignable {
 
 public extension MaskDesignable where Self: UIView {
   /// Mask the IBAnimatable UI element with provided `maskType`
-  public func configMask() {
+  public func configureMask() {
     switch maskType {
     case .circle:
       maskCircle()

--- a/IBAnimatable/NavigationBarDesginable.swift
+++ b/IBAnimatable/NavigationBarDesginable.swift
@@ -13,7 +13,7 @@ public protocol NavigationBarDesignable {
 }
 
 public extension NavigationBarDesignable where Self: UINavigationBar {
-  public func configNavigationBar() {
+  public func configureNavigationBar() {
     if solidColor {
       let emptyImage = UIImage()
       setBackgroundImage(emptyImage, for: .any, barMetrics: .default)

--- a/IBAnimatable/PaddingDesignable.swift
+++ b/IBAnimatable/PaddingDesignable.swift
@@ -23,7 +23,7 @@ public protocol PaddingDesignable {
 }
 
 public extension PaddingDesignable where Self: UITextField {
-  public func configPaddingLeft() {
+  public func configurePaddingLeft() {
     if paddingLeft.isNaN {
       return
     }
@@ -33,7 +33,7 @@ public extension PaddingDesignable where Self: UITextField {
     leftView = padding
   }
   
-  public func configPaddingRight() {
+  public func configurePaddingRight() {
     if paddingRight.isNaN {
       return
     }
@@ -43,7 +43,7 @@ public extension PaddingDesignable where Self: UITextField {
     rightView = padding
   }
 
-  public func configPaddingSide() {
+  public func configurePaddingSide() {
     if paddingSide.isNaN {
       return
     }

--- a/IBAnimatable/PlaceholderDesignable.swift
+++ b/IBAnimatable/PlaceholderDesignable.swift
@@ -17,7 +17,7 @@ public extension PlaceholderDesignable where Self: UITextField {
 
   var placeholderText: String? { get { return "" } set {} }
 
-  public func configPlaceholderColor() {
+  public func configurePlaceholderColor() {
     if let unwrappedPlaceholderColor = placeholderColor {
       attributedPlaceholder = NSAttributedString(string: placeholder!, attributes: [NSForegroundColorAttributeName: unwrappedPlaceholderColor])
     }
@@ -26,7 +26,7 @@ public extension PlaceholderDesignable where Self: UITextField {
 
 public extension PlaceholderDesignable where Self: UITextView {
 
-  public func config(placeholder placeholderLabel: UILabel, placeholderLabelConstraints: inout [NSLayoutConstraint]) {
+  public func configure(placeholderLabel: UILabel, placeholderLabelConstraints: inout [NSLayoutConstraint]) {
     placeholderLabel.font = font
     placeholderLabel.textColor = placeholderColor
     placeholderLabel.textAlignment = textAlignment

--- a/IBAnimatable/RootWindowDesignable.swift
+++ b/IBAnimatable/RootWindowDesignable.swift
@@ -14,7 +14,7 @@ public protocol RootWindowDesignable {
 
 public extension RootWindowDesignable where Self: UIViewController {
   
-  public func configRootWindowBackgroundColor() {
+  public func configureRootWindowBackgroundColor() {
     #if NS_EXTENSION_UNAVAILABLE_IOS
       
       if let wrappedRootWindowBackgroundColor = rootWindowBackgroundColor,

--- a/IBAnimatable/RotationDesignable.swift
+++ b/IBAnimatable/RotationDesignable.swift
@@ -14,7 +14,7 @@ public protocol RotationDesignable {
 }
 
 public extension RotationDesignable where Self: UIView {
-  public func configRotate() {
+  public func configureRotate() {
     if !rotate.isNaN && rotate > -360 && rotate < 360 {
       self.transform = CGAffineTransform(rotationAngle: .pi * rotate / 180)
     }

--- a/IBAnimatable/ShadowDesignable.swift
+++ b/IBAnimatable/ShadowDesignable.swift
@@ -33,28 +33,28 @@ public protocol ShadowDesignable {
 }
 
 public extension ShadowDesignable where Self: UIView {
-  public func configShadowColor() {
+  public func configureShadowColor() {
     if let unwrappedShadowColor = shadowColor {
       commonSetup()
       layer.shadowColor = unwrappedShadowColor.cgColor
     }
   }
 
-  public func configShadowRadius() {
+  public func configureShadowRadius() {
     if !shadowRadius.isNaN && shadowRadius > 0 {
       commonSetup()
       layer.shadowRadius = shadowRadius
     }
   }
 
-  public func configShadowOpacity() {
+  public func configureShadowOpacity() {
     if !shadowOpacity.isNaN && shadowOpacity >= 0 && shadowOpacity <= 1 {
       commonSetup()
       layer.shadowOpacity = Float(shadowOpacity)
     }
   }
 
-  public func configShadowOffset() {
+  public func configureShadowOffset() {
     if !shadowOffset.x.isNaN {
       commonSetup()
       layer.shadowOffset.width = shadowOffset.x
@@ -66,7 +66,7 @@ public extension ShadowDesignable where Self: UIView {
     }
   }
   
-  public func configMaskShadow() {
+  public func configureMaskShadow() {
     commonSetup()
     
     // if a `layer.mask` is specified, add a new shadow layer to display the shadow to match the mask shape.

--- a/IBAnimatable/SideImageDesignable.swift
+++ b/IBAnimatable/SideImageDesignable.swift
@@ -49,14 +49,14 @@ public protocol SideImageDesignable {
 }
 
 public extension SideImageDesignable where Self: UITextField {
-  public func configImages() {
-    configLeftImage()
-    configRightImage()
+  public func configureImages() {
+    configureLeftImage()
+    configureRightImage()
   }
 }
 
 fileprivate extension SideImageDesignable where Self: UITextField {
-  func configLeftImage() {
+  func configureLeftImage() {
     guard let wrappedLeftImage = leftImage else {
       return
     }
@@ -66,7 +66,7 @@ fileprivate extension SideImageDesignable where Self: UITextField {
     leftView = sideView
   }
   
-  func configRightImage() {
+  func configureRightImage() {
     guard let wrappedRightImage = rightImage else {
       return
     }

--- a/IBAnimatable/TableViewCellDesignable.swift
+++ b/IBAnimatable/TableViewCellDesignable.swift
@@ -10,7 +10,7 @@ public protocol TableViewCellDesignable {
 }
 
 public extension TableViewCellDesignable where Self: UITableViewCell {
-  public func configSeparatorMargins() {
+  public func configureSeparatorMargins() {
     if removeSeparatorMargins {
       if responds(to: #selector(setter: UITableViewCell.separatorInset)) {
         separatorInset = .zero

--- a/IBAnimatable/TintDesignable.swift
+++ b/IBAnimatable/TintDesignable.swift
@@ -30,9 +30,9 @@ public protocol TintDesignable {
 
 public extension TintDesignable where Self: UIView {
   /**
-   configTintedColor method, should be called in layoutSubviews() method
+   configureTintedColor method, should be called in layoutSubviews() method
    */
-  public func configTintedColor() {
+  public func configureTintedColor() {
     if !tintOpacity.isNaN && tintOpacity >= 0 && tintOpacity <= 1 {
       addColorSubview(color: .white, opacity: tintOpacity)
     }

--- a/IBAnimatable/ViewControllerDesignable.swift
+++ b/IBAnimatable/ViewControllerDesignable.swift
@@ -10,7 +10,7 @@ public protocol ViewControllerDesignable {
 }
 
 public extension ViewControllerDesignable where Self: UIViewController {
-  public func confingHideNavigationBar() {
+  public func configureHideNavigationBar() {
     navigationController?.isNavigationBarHidden = hideNavigationBar
   }
   

--- a/IBAnimatableApp/GradientViewController.swift
+++ b/IBAnimatableApp/GradientViewController.swift
@@ -60,6 +60,6 @@ extension GradientViewController : UIPickerViewDelegate, UIPickerViewDataSource 
       gView.startPoint = GradientStartPoint(rawValue: startPointValues.value(at: pickerView.selectedRow(inComponent: 2))) ?? .top
 
     }
-    gView.configGradient()
+    gView.configureGradient()
   }
 }


### PR DESCRIPTION
In this PR, we refactor all `config***` ethods to `configure***` according to **Clarity is more important than brevity** in  [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)

related to #221 
