### PR TITLE
Refactor repeat count

### DIFF
--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -121,9 +121,9 @@ public extension Animatable where Self: UIView {
     let values = computeValues(way: way, direction: direction, shouldScale: false)
     switch way {
     case .in:
-      animateIn(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateIn(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     case .out:
-      animateOut(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateOut(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     }
   }
   
@@ -131,9 +131,9 @@ public extension Animatable where Self: UIView {
     let values = computeValues(way: way, direction: direction, shouldScale: true)
     switch way {
     case .in:
-      animateIn(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateIn(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     case .out:
-      animateOut(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateOut(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     }
   }
   
@@ -178,9 +178,9 @@ public extension Animatable where Self: UIView {
     switch way {
     case .in:
       alpha = 0
-      animateIn(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateIn(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     case .out:
-      animateOut(values.x, values.y, values.scaleX, values.scaleY, 0, completion)
+      animateOut(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 0, completion: completion)
     }
   }
   
@@ -192,10 +192,10 @@ public extension Animatable where Self: UIView {
       fadeInOut(completion: completion)
     case .in:
       alpha = 0
-      animateIn(0, 0, 1, 1, 1, completion)
+      animateIn(x: 0, y: 0, scaleX: 1, scaleY: 1, alpha: 1, completion: completion)
     case .out:
       alpha = 1
-      animateOut(0, 0, 1, 1, 0, completion)
+      animateOut(x: 0, y: 0, scaleX: 1, scaleY: 1, alpha: 0, completion: completion)
     }
   }
   
@@ -204,9 +204,9 @@ public extension Animatable where Self: UIView {
     switch way {
     case .in:
       alpha = 0
-      animateIn(values.x, values.y, values.scaleX, values.scaleY, 1, completion)
+      animateIn(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 1, completion: completion)
     case .out:
-      animateOut(values.x, values.y, values.scaleX, values.scaleY, 0, completion)
+      animateOut(x: values.x, y: values.y, scaleX: values.scaleX, scaleY: values.scaleY, alpha: 0, completion: completion)
     }
   }
   
@@ -219,17 +219,17 @@ public extension Animatable where Self: UIView {
       alpha = 0
       toAlpha = 1
       transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-      animateIn(0, 0, scale / 2, scale / 2, toAlpha, completion)
+      animateIn(x: 0, y: 0, scaleX: scale / 2, scaleY: scale / 2, alpha: toAlpha, completion: completion)
     case .in:
       let scale = 2 * force
       alpha = 0
       toAlpha = 1
-      animateIn(0, 0, scale, scale, toAlpha, completion)
+      animateIn(x: 0, y: 0, scaleX: scale, scaleY: scale, alpha: toAlpha, completion: completion)
     case .out:
       let scale = (invert ? 0.1 :  2) * force
       alpha = 1
       toAlpha = 0
-      animateOut(0, 0, scale, scale, toAlpha, completion)
+      animateOut(x: 0, y: 0, scaleX: scale, scaleY: scale, alpha: toAlpha, completion: completion)
     }
   }
   
@@ -244,7 +244,7 @@ public extension Animatable where Self: UIView {
       scaleX = -1
       scaleY = 1
     }
-    animateIn(0, 0, scaleX, scaleY, 1, completion)
+    animateIn(x: 0, y: 0, scaleX: scaleX, scaleY: scaleY, alpha: 1, completion: completion)
   }
   
   public func shake(repeatCount: Int, completion: AnimatableCompletion? = nil) {
@@ -458,7 +458,7 @@ private extension Animatable where Self: UIView {
   }
   
   
-  func animateIn(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
+  func animateIn(x: CGFloat, y: CGFloat, scaleX: CGFloat, scaleY: CGFloat, alpha: CGFloat, completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     let scale = CGAffineTransform(scaleX: scaleX, y: scaleY)
     let translateAndScale = translate.concatenating(scale)
@@ -476,7 +476,7 @@ private extension Animatable where Self: UIView {
     })
   }
   
-  func animateOut(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
+  func animateOut(x: CGFloat, y: CGFloat, scaleX: CGFloat, scaleY: CGFloat, alpha: CGFloat, completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     let scale = CGAffineTransform(scaleX: scaleX, y: scaleY)
     let translateAndScale = translate.concatenating(scale)

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -68,19 +68,19 @@ public extension Animatable where Self: UIView {
   public func animate(animation: AnimationType? = nil, completion: AnimatableCompletion? = nil) {
     switch animation ?? animationType {
     case let .slide(way, direction):
-      slide(way: way, direction: direction, completion: completion)
+      slide(way, direction: direction, completion: completion)
     case let .squeeze(way, direction):
       squeeze(way, direction: direction, completion: completion)
     case let .squeezeFade(way, direction):
-      squeezeFade(way: way, direction: direction, completion: completion)
+      squeezeFade(way, direction: direction, completion: completion)
     case let .slideFade(way, direction):
       slideFade(way, direction: direction, completion: completion)
     case let .fade(way):
-      fade(way: way, completion: completion)
+      fade(way, completion: completion)
     case let .zoom(way):
-      zoom(way: way, completion: completion)
+      zoom(way, completion: completion)
     case let .zoomInvert(way):
-      zoom(way: way, invert: true, completion: completion)
+      zoom(way, invert: true, completion: completion)
     case let .shake(repeatCount):
       shake(repeatCount: repeatCount, completion: completion)
     case let .pop(repeatCount):
@@ -152,7 +152,7 @@ public extension Animatable where Self: UIView {
     
   }
   
-  public func slide(way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
+  public func slide(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
 
     let values = computeValues(way: way, direction: direction, shouldScale: false)
     switch way {
@@ -164,7 +164,7 @@ public extension Animatable where Self: UIView {
   }
   
   
-  public func squeeze( _ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
+  public func squeeze(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
   
     let values = computeValues(way: way, direction: direction, shouldScale: true)
     switch way {
@@ -212,7 +212,7 @@ public extension Animatable where Self: UIView {
       animateBy(x: xOffsetToMove, y: yOffsetToMove, completion: completion)
   }
   
-  public func slideFade( _ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
+  public func slideFade(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
     
     let values = computeValues(way: way, direction: direction, shouldScale: false)
     switch way {
@@ -223,7 +223,8 @@ public extension Animatable where Self: UIView {
       animateOut(values.x, values.y, values.scaleX, values.scaleY, 0, completion)
     }
   }
-  public func fade(way: AnimationType.FadeWay, completion: AnimatableCompletion? = nil) {
+  
+  public func fade(_ way: AnimationType.FadeWay, completion: AnimatableCompletion? = nil) {
     switch way {
     case .outIn:
       fadeOutIn(completion: completion)
@@ -238,7 +239,7 @@ public extension Animatable where Self: UIView {
     }
   }
   
-  public func squeezeFade(way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
+  public func squeezeFade(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
     
     let values = computeValues(way: way, direction: direction, shouldScale: true)
     switch way {
@@ -250,7 +251,7 @@ public extension Animatable where Self: UIView {
     }
   }
   
-  public func zoom(way: AnimationType.Way, invert: Bool = false, completion: AnimatableCompletion? = nil) {
+  public func zoom(_ way: AnimationType.Way, invert: Bool = false, completion: AnimatableCompletion? = nil) {
     let toAlpha: CGFloat
 
     switch way {
@@ -271,7 +272,6 @@ public extension Animatable where Self: UIView {
       toAlpha = 0
       animateOut(0, 0, scale, scale, toAlpha, completion)
     }
-    
   }
   
   public func flip(axis: AnimationType.Axis, completion: AnimatableCompletion? = nil) {

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -85,6 +85,8 @@ public extension Animatable where Self: UIView {
       shake(repeatCount: repeatCount, completion: completion)
     case let .pop(repeatCount):
       pop(repeatCount: repeatCount, completion: completion)
+    case let .squash(repeatCount):
+      squash(repeatCount: repeatCount, completion: completion)
     case let .flip(axis):
       flip(axis: axis, completion: completion)
     case let .morph(repeatCount):
@@ -272,6 +274,27 @@ public extension Animatable where Self: UIView {
       animation.repeatCount = Float(repeatCount)
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "pop")
+    }, completion: completion)
+  }
+  
+  public func squash(repeatCount: Int, completion: AnimatableCompletion? = nil) {
+    CALayer.animate({
+      let squashX = CAKeyframeAnimation(keyPath: "transform.scale.x")
+      squashX.values = [1, 1.5 * self.force, 0.5, 1.5 * self.force, 1]
+      squashX.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
+      squashX.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+      
+      let squashY = CAKeyframeAnimation(keyPath: "transform.scale.y")
+      squashY.values = [1, 0.5, 1, 0.5, 1]
+      squashY.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
+      squashY.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+      
+      let animationGroup = CAAnimationGroup()
+      animationGroup.animations = [squashX, squashY]
+      animationGroup.duration = CFTimeInterval(self.duration)
+      animationGroup.repeatCount = Float(repeatCount)
+      animationGroup.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
+      self.layer.add(animationGroup, forKey: "squash")
     }, completion: completion)
   }
   

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -42,11 +42,6 @@ public protocol Animatable: class {
    Animation force (default value should be 1)
    */
   var force: CGFloat { get set }
-  
-  /**
-   Repeat count for Shake, Pop, Morph, Squeeze, Flash, Wobble and Swing animations
-   */
-  var repeatCount: Float { get set }
 
 }
 
@@ -68,9 +63,6 @@ public extension Animatable where Self: UIView {
     if force.isNaN {
       force = 1
     }
-    if repeatCount.isNaN {
-      repeatCount = 1
-    }
   }
   
   public func animate(animation: AnimationType? = nil, completion: AnimatableCompletion? = nil) {
@@ -89,22 +81,22 @@ public extension Animatable where Self: UIView {
       zoom(way: way, completion: completion)
     case let .zoomInvert(way):
       zoom(way: way, invert: true, completion: completion)
-    case .shake:
-      shake(completion: completion)
-    case .pop:
-      pop(completion: completion)
-    case let .flip( axis):
+    case let .shake(repeatCount):
+      shake(repeatCount: repeatCount, completion: completion)
+    case let .pop(repeatCount):
+      pop(repeatCount: repeatCount, completion: completion)
+    case let .flip(axis):
       flip(axis: axis, completion: completion)
-    case .morph:
-      morph(completion: completion)
-    case .flash:
-      flash(completion: completion)
-    case .wobble:
-      wobble(completion: completion)
-    case .swing:
-      swing(completion: completion)
-    case let .rotate(direction):
-      rotate(direction: direction, completion: completion)
+    case let .morph(repeatCount):
+      morph(repeatCount: repeatCount, completion: completion)
+    case let .flash(repeatCount):
+      flash(repeatCount: repeatCount, completion: completion)
+    case let .wobble(repeatCount):
+      wobble(repeatCount: repeatCount, completion: completion)
+    case let .swing(repeatCount):
+      swing(repeatCount: repeatCount, completion: completion)
+    case let .rotate(direction, repeatCount):
+      rotate(direction: direction, repeatCount: repeatCount, completion: completion)
     case let .moveBy(x, y):
       moveBy(x: x, y: y, completion: completion)
     case let .moveTo(x, y):
@@ -183,14 +175,14 @@ public extension Animatable where Self: UIView {
     }
   }
   
-  public func rotate(direction: AnimationType.RotationDirection, completion: AnimatableCompletion? = nil) {
+  public func rotate(direction: AnimationType.RotationDirection, repeatCount: Int, completion: AnimatableCompletion? = nil) {
   
     CALayer.animate({
       let animation = CABasicAnimation(keyPath: "transform.rotation")
       animation.fromValue = direction == .cw ? 0 : CGFloat.pi * 2
       animation.toValue = direction == .cw  ? CGFloat.pi * 2 : 0
       animation.duration = CFTimeInterval(self.duration)
-      animation.repeatCount = self.repeatCount
+      animation.repeatCount = Float(repeatCount)
       animation.autoreverses = false
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "rotate")
@@ -283,7 +275,7 @@ public extension Animatable where Self: UIView {
   }
   
   public func flip(axis: AnimationType.Axis, completion: AnimatableCompletion? = nil) {
-     let scaleX: CGFloat
+    let scaleX: CGFloat
     let scaleY: CGFloat
     switch axis {
     case .x:
@@ -294,9 +286,9 @@ public extension Animatable where Self: UIView {
       scaleY = 1
     }
     animateIn(0, 0, scaleX, scaleY, 1, completion)
-  
   }
-  public func shake(completion: AnimatableCompletion? = nil) {
+  
+  public func shake(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "position.x")
       animation.values = [0, 30 * self.force, -30 * self.force, 30 * self.force, 0]
@@ -304,13 +296,13 @@ public extension Animatable where Self: UIView {
       animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
       animation.duration = CFTimeInterval(self.duration)
       animation.isAdditive = true
-      animation.repeatCount = self.repeatCount
+      animation.repeatCount = Float(repeatCount)
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "shake")
     }, completion: completion)
   }
   
-  public func pop(completion: AnimatableCompletion? = nil) {
+  public func pop(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "transform.scale")
       animation.values = [0, 0.2 * self.force, -0.2 * self.force, 0.2 * self.force, 0]
@@ -318,13 +310,13 @@ public extension Animatable where Self: UIView {
       animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
       animation.duration = CFTimeInterval(self.duration)
       animation.isAdditive = true
-      animation.repeatCount = self.repeatCount
+      animation.repeatCount = Float(repeatCount)
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "pop")
     }, completion: completion)
   }
   
-  public func morph(completion: AnimatableCompletion? = nil) {
+  public func morph(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let morphX = CAKeyframeAnimation(keyPath: "transform.scale.x")
       morphX.values = [1, 1.3 * self.force, 0.7, 1.3 * self.force, 1]
@@ -339,13 +331,13 @@ public extension Animatable where Self: UIView {
       let animationGroup = CAAnimationGroup()
       animationGroup.animations = [morphX, morphY]
       animationGroup.duration = CFTimeInterval(self.duration)
-      animationGroup.repeatCount = self.repeatCount
+      animationGroup.repeatCount = Float(repeatCount)
       animationGroup.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animationGroup, forKey: "morph")
     }, completion: completion)
   }
 
-  public func squeeze(completion: AnimatableCompletion? = nil) {
+  public func squeeze(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let squeezeX = CAKeyframeAnimation(keyPath: "transform.scale.x")
       squeezeX.values = [1, 1.5 * self.force, 0.5, 1.5 * self.force, 1]
@@ -360,26 +352,26 @@ public extension Animatable where Self: UIView {
       let animationGroup = CAAnimationGroup()
       animationGroup.animations = [squeezeX, squeezeY]
       animationGroup.duration = CFTimeInterval(self.duration)
-      animationGroup.repeatCount = self.repeatCount
+      animationGroup.repeatCount = Float(repeatCount)
       animationGroup.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animationGroup, forKey: "squeeze")
     }, completion: completion)
   }
   
-  public func flash(completion: AnimatableCompletion? = nil) {
+  public func flash(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 1
       animation.toValue = 0
       animation.duration = CFTimeInterval(self.duration)
-      animation.repeatCount = self.repeatCount * 2.0
+      animation.repeatCount = Float(repeatCount) * 2.0
       animation.autoreverses = true
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "flash")
     }, completion: completion)
   }
   
-  public func wobble(completion: AnimatableCompletion? = nil) {
+  public func wobble(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let rotation = CAKeyframeAnimation(keyPath: "transform.rotation")
       rotation.values = [0, 0.3 * self.force, -0.3 * self.force, 0.3 * self.force, 0]
@@ -396,19 +388,19 @@ public extension Animatable where Self: UIView {
       animationGroup.animations = [rotation, positionX]
       animationGroup.duration = CFTimeInterval(self.duration)
       animationGroup.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
-      animationGroup.repeatCount = self.repeatCount
+      animationGroup.repeatCount = Float(repeatCount)
       self.layer.add(animationGroup, forKey: "wobble")
     }, completion: completion)
   }
   
-  public func swing(completion: AnimatableCompletion? = nil) {
+  public func swing(repeatCount: Int, completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CAKeyframeAnimation(keyPath: "transform.rotation")
       animation.values = [0, 0.3 * self.force, -0.3 * self.force, 0.3 * self.force, 0]
       animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
       animation.duration = CFTimeInterval(self.duration)
       animation.isAdditive = true
-      animation.repeatCount = self.repeatCount
+      animation.repeatCount = Float(repeatCount)
       animation.beginTime = CACurrentMediaTime() + CFTimeInterval(self.delay)
       self.layer.add(animation, forKey: "swing")
     }, completion: completion)

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -117,43 +117,7 @@ public extension Animatable where Self: UIView {
   }
   
   // MARK: - Animation methods
-  fileprivate func computeValues(way: AnimationType.Way, direction: AnimationType.Direction, shouldScale: Bool) -> AnimationValues {
-    let yDistance = screenSize.height * force
-    let xDistance = screenSize.width * force
-    let scale = 3 * force
-    var scaleX: CGFloat = 1
-    var scaleY: CGFloat = 1
-    
-    var x: CGFloat = 0
-    var y: CGFloat = 0
-    switch direction {
-    case .left:
-      x = -xDistance
-    case .right:
-      x = xDistance
-    case .down:
-      y = -yDistance
-    case .up:
-      y = yDistance
-    }
-    if shouldScale && direction.isVertical() {
-      scaleY = scale
-    } else if shouldScale {
-      scaleX = scale
-    }
-    switch way {
-    case .in:
-      return (x: x, y: y, scaleX: scaleX, scaleY: scaleY)
-    case .out where direction.isVertical():
-      return (x: x, y: -y, scaleX: scaleX, scaleY: scaleY)
-    case .out:
-      return (x: x, y: y, scaleX: scaleX, scaleY: scaleY)
-    }
-    
-  }
-  
   public func slide(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
-
     let values = computeValues(way: way, direction: direction, shouldScale: false)
     switch way {
     case .in:
@@ -163,9 +127,7 @@ public extension Animatable where Self: UIView {
     }
   }
   
-  
   public func squeeze(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
-  
     let values = computeValues(way: way, direction: direction, shouldScale: true)
     switch way {
     case .in:
@@ -176,7 +138,6 @@ public extension Animatable where Self: UIView {
   }
   
   public func rotate(direction: AnimationType.RotationDirection, repeatCount: Int, completion: AnimatableCompletion? = nil) {
-  
     CALayer.animate({
       let animation = CABasicAnimation(keyPath: "transform.rotation")
       animation.fromValue = direction == .cw ? 0 : CGFloat.pi * 2
@@ -209,11 +170,10 @@ public extension Animatable where Self: UIView {
     } else {
       yOffsetToMove = CGFloat(y) - absolutePosition.y
     }
-      animateBy(x: xOffsetToMove, y: yOffsetToMove, completion: completion)
+    animateBy(x: xOffsetToMove, y: yOffsetToMove, completion: completion)
   }
   
   public func slideFade(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
-    
     let values = computeValues(way: way, direction: direction, shouldScale: false)
     switch way {
     case .in:
@@ -240,7 +200,6 @@ public extension Animatable where Self: UIView {
   }
   
   public func squeezeFade(_ way: AnimationType.Way, direction: AnimationType.Direction, completion: AnimatableCompletion? = nil) {
-    
     let values = computeValues(way: way, direction: direction, shouldScale: true)
     switch way {
     case .in:
@@ -415,9 +374,44 @@ public extension Animatable where Self: UIView {
     let yOffsetToMove = y.isNaN ? 0: CGFloat(y)
     animateBy(x: xOffsetToMove, y: yOffsetToMove, completion: completion)
   }
+}
+
+private extension Animatable where Self: UIView {
+  func computeValues(way: AnimationType.Way, direction: AnimationType.Direction, shouldScale: Bool) -> AnimationValues {
+    let yDistance = screenSize.height * force
+    let xDistance = screenSize.width * force
+    let scale = 3 * force
+    var scaleX: CGFloat = 1
+    var scaleY: CGFloat = 1
+    
+    var x: CGFloat = 0
+    var y: CGFloat = 0
+    switch direction {
+    case .left:
+      x = -xDistance
+    case .right:
+      x = xDistance
+    case .down:
+      y = -yDistance
+    case .up:
+      y = yDistance
+    }
+    if shouldScale && direction.isVertical() {
+      scaleY = scale
+    } else if shouldScale {
+      scaleX = scale
+    }
+    switch way {
+    case .in:
+      return (x: x, y: y, scaleX: scaleX, scaleY: scaleY)
+    case .out where direction.isVertical():
+      return (x: x, y: -y, scaleX: scaleX, scaleY: scaleY)
+    case .out:
+      return (x: x, y: y, scaleX: scaleX, scaleY: scaleY)
+    }
+  }
   
-  // MARK: - Private
-  fileprivate func fadeOutIn(completion: AnimatableCompletion? = nil) {
+  func fadeOutIn(completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 1
@@ -430,7 +424,7 @@ public extension Animatable where Self: UIView {
       }, completion: completion)
   }
   
-  fileprivate func fadeInOut(completion: AnimatableCompletion? = nil) {
+  func fadeInOut(completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let animation = CABasicAnimation(keyPath: "opacity")
       animation.fromValue = 0
@@ -442,13 +436,14 @@ public extension Animatable where Self: UIView {
       animation.isRemovedOnCompletion = false
       self.layer.add(animation, forKey: "fade")
       },
-                    completion: {
-                      self.alpha = 0
-                      completion?()
-    })
+      completion: {
+        self.alpha = 0
+        completion?()
+      }
+    )
   }
-
-  fileprivate func animateBy(x: CGFloat, y: CGFloat, completion: AnimatableCompletion? = nil) {
+  
+  func animateBy(x: CGFloat, y: CGFloat, completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     UIView.animate(withDuration: duration, delay: delay, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: [],
       animations: {
@@ -461,14 +456,14 @@ public extension Animatable where Self: UIView {
       }
     )
   }
- 
   
-  fileprivate func animateIn(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
+  
+  func animateIn(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     let scale = CGAffineTransform(scaleX: scaleX, y: scaleY)
     let translateAndScale = translate.concatenating(scale)
     transform = translateAndScale
-
+    
     UIView.animate(withDuration: duration, delay: delay, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: [],
       animations: {
         self.transform = CGAffineTransform.identity
@@ -478,14 +473,14 @@ public extension Animatable where Self: UIView {
         if completed {
           completion?()
         }
-      })
+    })
   }
-
-  fileprivate func animateOut(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
+  
+  func animateOut(_ x: CGFloat, _ y: CGFloat, _ scaleX: CGFloat, _ scaleY: CGFloat, _ alpha: CGFloat, _ completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     let scale = CGAffineTransform(scaleX: scaleX, y: scaleY)
     let translateAndScale = translate.concatenating(scale)
-
+    
     UIView.animate(withDuration: duration, delay: delay, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: [],
       animations: {
         self.transform = translateAndScale
@@ -498,9 +493,8 @@ public extension Animatable where Self: UIView {
       }
     )
   }
-  
-  // MARK: Private helper
-  fileprivate var screenSize: CGSize {
+
+  var screenSize: CGSize {
     return self.window?.screen.bounds.size ?? CGSize.zero
   }
 }

--- a/IBAnimatable/AnimatableBarButtonItem.swift
+++ b/IBAnimatable/AnimatableBarButtonItem.swift
@@ -40,7 +40,6 @@ import UIKit
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Private
   fileprivate func configureInspectableProperties() {

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -101,8 +101,8 @@ import UIKit
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -113,7 +113,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -117,8 +117,8 @@ import UIKit
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -129,7 +129,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -89,7 +89,6 @@ import UIKit
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -156,8 +156,8 @@ import UIKit
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -168,7 +168,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -58,8 +58,8 @@ import UIKit
     }
   }
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -70,7 +70,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - RotationDesignable
   @IBInspectable open var rotate: CGFloat = CGFloat.nan {

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -168,7 +168,6 @@ import UIKit
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -64,8 +64,8 @@ import UIKit
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -76,7 +76,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -129,8 +129,8 @@ import UIKit
   }
 
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -141,7 +141,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -67,8 +67,8 @@ open var startPoint: GradientStartPoint = .top
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -79,7 +79,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -70,8 +70,8 @@ open var startPoint: GradientStartPoint = .top
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -82,7 +82,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -120,8 +120,8 @@ import UIKit
   }
   
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -132,7 +132,6 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -71,8 +71,8 @@ import UIKit
   }
 
   // MARK: - Animatable
-open var animationType: AnimationType = .none
-@IBInspectable  var _animationType: String? {
+  open var animationType: AnimationType = .none
+  @IBInspectable  var _animationType: String? {
     didSet {
      animationType = AnimationType(string: _animationType)
     }
@@ -83,8 +83,7 @@ open var animationType: AnimationType = .none
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
- 
+  
   // MARK: Override properties
   override open var font: UIFont! {
     didSet {

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -169,7 +169,6 @@ import UIKit
   @IBInspectable open var damping: CGFloat = CGFloat.nan
   @IBInspectable open var velocity: CGFloat = CGFloat.nan
   @IBInspectable open var force: CGFloat = CGFloat.nan
-  @IBInspectable open var repeatCount: Float = Float.nan
   
   // MARK: - Lifecycle
   open override func prepareForInterfaceBuilder() {

--- a/IBAnimatable/AnimationType.swift
+++ b/IBAnimatable/AnimationType.swift
@@ -20,6 +20,7 @@ public enum AnimationType {
   case zoomInvert(way: Way)
   case shake(repeatCount: Int)
   case pop(repeatCount: Int)
+  case squash(repeatCount: Int)
   case flip(along: Axis)
   case morph(repeatCount: Int)
   case flash(repeatCount: Int)
@@ -83,6 +84,9 @@ extension AnimationType: IBEnum {
     case "pop":
       let repeatCount = retrieveRepeatCount(string:params[safe: 0])
       self = .pop(repeatCount: repeatCount)
+    case "squash":
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .squash(repeatCount: repeatCount)
     case "flip":
       let axis = Axis(raw: params[safe: 0], defaultValue: .x)
       self = .flip(along: axis)

--- a/IBAnimatable/AnimationType.swift
+++ b/IBAnimatable/AnimationType.swift
@@ -11,11 +11,11 @@ import UIKit
  */
 
 public enum AnimationType {
-  case slide(way: Way, direction: Direction)
-  case squeeze(way: Way, direction: Direction) // miss squeeze
-  case slideFade(way: Way, direction: Direction)
+  case slide(way: Way, from: Direction)
+  case squeeze(way: Way, from: Direction) // miss squeeze
+  case slideFade(way: Way, from: Direction)
+  case squeezeFade(way: Way, from: Direction)
   case fade(way: FadeWay)
-  case squeezeFade(way: Way, direction: Direction)
   case zoom(way: Way)
   case zoomInvert(way: Way)
   case shake(repeatCount: Int)
@@ -64,15 +64,15 @@ extension AnimationType: IBEnum {
     
     switch name {
     case "slide":
-      self = .slide(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .slide(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
     case "squeeze":
-      self = .squeeze(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .squeeze(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
     case "fade":
       self = .fade(way: FadeWay(raw: params[safe: 0], defaultValue: .in))
     case "slidefade":
-      self = .slideFade(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .slideFade(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
     case "squeezefade":
-      self = .squeezeFade(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .squeezeFade(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
     case "zoom":
       self = .zoom(way: Way(raw: params[safe: 0], defaultValue: .in))
     case "zoominvert":

--- a/IBAnimatable/AnimationType.swift
+++ b/IBAnimatable/AnimationType.swift
@@ -18,14 +18,14 @@ public enum AnimationType {
   case squeezeFade(way: Way, direction: Direction)
   case zoom(way: Way)
   case zoomInvert(way: Way)
-  case shake
-  case pop
+  case shake(repeatCount: Int)
+  case pop(repeatCount: Int)
   case flip(along: Axis)
-  case morph
-  case flash
-  case wobble
-  case swing
-  case rotate(direction: RotationDirection)
+  case morph(repeatCount: Int)
+  case flash(repeatCount: Int)
+  case wobble(repeatCount: Int)
+  case swing(repeatCount: Int)
+  case rotate(direction: RotationDirection, repeatCount: Int)
   case moveTo(x: Double, y: Double)
   case moveBy(x: Double, y: Double)
   case none
@@ -78,21 +78,29 @@ extension AnimationType: IBEnum {
     case "zoominvert":
       self = .zoomInvert(way: Way(raw: params[safe: 0], defaultValue: .in))
     case "shake":
-      self = .shake
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .shake(repeatCount: repeatCount)
     case "pop":
-      self = .pop
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .pop(repeatCount: repeatCount)
     case "flip":
-      self = .flip(along: Axis(raw: params[safe: 0], defaultValue: .x))
+      let axis = Axis(raw: params[safe: 0], defaultValue: .x)
+      self = .flip(along: axis)
     case "morph":
-      self = .morph
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .morph(repeatCount: repeatCount)
     case "flash":
-      self = .flash
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .flash(repeatCount: repeatCount)
     case "wobble":
-      self = .wobble
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .wobble(repeatCount: repeatCount)
     case "swing":
-      self = .swing
+      let repeatCount = retrieveRepeatCount(string:params[safe: 0])
+      self = .swing(repeatCount: repeatCount)
     case "rotate":
-      self = .rotate(direction: RotationDirection(raw: params[safe: 0], defaultValue: .cw))
+      let repeatCount = retrieveRepeatCount(string:params[safe: 1])
+      self = .rotate(direction: RotationDirection(raw: params[safe: 0], defaultValue: .cw), repeatCount: repeatCount)
     case "moveto":
       self = .moveTo(x: params[safe: 0]?.toDouble() ?? 0, y: params[safe: 1]?.toDouble() ?? 0)
     case "moveby":
@@ -101,4 +109,13 @@ extension AnimationType: IBEnum {
       self = .none
     }
   }
+}
+
+private func retrieveRepeatCount(string: String?) -> Int {
+  // Default value for repeat count is `1`
+  guard let string = string, let repeatCount = Int(string) else {
+    return 1
+  }
+  
+  return repeatCount
 }

--- a/IBAnimatableApp/Animations.storyboard
+++ b/IBAnimatableApp/Animations.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11198.2" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="6fu-hw-r8W">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="6fu-hw-r8W">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -70,7 +70,7 @@
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
-                        <outlet property="aView" destination="Xh0-cF-cXI" id="J7B-P5-zGb"/>
+                        <outlet property="animatableView" destination="Xh0-cF-cXI" id="KAc-EI-RH8"/>
                         <outlet property="pickerView" destination="HGl-88-fhe" id="9xg-L7-mWu"/>
                     </connections>
                 </viewController>

--- a/IBAnimatableApp/AnimationsViewController.swift
+++ b/IBAnimatableApp/AnimationsViewController.swift
@@ -16,12 +16,12 @@ private let axisParams = ParamType(fromEnum: AnimationType.Axis.self)
 private let rotationDirectionParams = ParamType(fromEnum: AnimationType.RotationDirection.self)
 private let positiveNumberParam = ParamType.number(min: 0, max: 50, interval: 2, ascending: true, unit:"")
 private let numberParam = ParamType.number(min: -50, max: 50, interval: 5, ascending: true, unit: "")
+private let repeatCountParam = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit:"")
 
 class AnimationsViewController: UIViewController {
   
-  @IBOutlet weak var aView: AnimatableView!
+  @IBOutlet weak var animatableView: AnimatableView!
   @IBOutlet weak var pickerView: UIPickerView!
-  
   
   // prebuit common params
   let entries: [PickerEntry] = [
@@ -33,10 +33,13 @@ class AnimationsViewController: UIViewController {
     PickerEntry(params: [wayParam], name: "zoom"),
     PickerEntry(params: [wayParam], name: "zoomInvert"),
     PickerEntry(params: [axisParams], name: "flip"),
-    PickerEntry(params: [], name: "flash"),
-    PickerEntry(params: [], name: "wobble"),
-    PickerEntry(params: [], name: "swing"),
-    PickerEntry(params: [rotationDirectionParams], name: "rotate"),
+    PickerEntry(params: [repeatCountParam], name: "shake"),
+    PickerEntry(params: [repeatCountParam], name: "pop"),
+    PickerEntry(params: [repeatCountParam], name: "morph"),
+    PickerEntry(params: [repeatCountParam], name: "flash"),
+    PickerEntry(params: [repeatCountParam], name: "wobble"),
+    PickerEntry(params: [repeatCountParam], name: "swing"),
+    PickerEntry(params: [rotationDirectionParams, repeatCountParam], name: "rotate"),
     PickerEntry(params: [positiveNumberParam, positiveNumberParam], name: "moveby"),
     PickerEntry(params: [numberParam, numberParam], name: "moveto")
     ]
@@ -44,7 +47,6 @@ class AnimationsViewController: UIViewController {
   
   var selectedEntry: PickerEntry!
   override func viewDidLoad() {
-  
     super.viewDidLoad()
     selectedEntry = entries[0]
     pickerView.dataSource = self
@@ -65,6 +67,7 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   func numberOfComponents(in pickerView: UIPickerView) -> Int {
     return 3
   }
+  
   func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
     switch component {
     case 0:
@@ -77,6 +80,7 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
       return 0
     }
   }
+  
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
     
     if component == 0 {
@@ -87,6 +91,7 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
     }
     return param.title(at: row).colorize(.white)
   }
+  
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     if component == 0 {
       if selectedEntry.name != entries[row].name {
@@ -95,15 +100,15 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
         pickerView.reloadComponent(2)
       }
     }
-    let animString = selectedEntry.toString(selectedIndexes: pickerView.selectedRow(inComponent: 1), pickerView.selectedRow(inComponent: 2))
-    let animType = AnimationType(string: animString)
+    let animationString = selectedEntry.toString(selectedIndexes: pickerView.selectedRow(inComponent: 1), pickerView.selectedRow(inComponent: 2))
+    let animationType = AnimationType(string: animationString)
     pickerView.isUserInteractionEnabled = false
-    aView.animate(animation: animType) {
+    animatableView.animate(animation: animationType) {
       if #available(iOS 10.0, *) {
-        if !self.aView.transform.isIdentity {
-          Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { timer in
-            self.aView.alpha = 1
-            self.aView.transform = CGAffineTransform.identity
+        if !self.animatableView.transform.isIdentity {
+          Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
+            self.animatableView.alpha = 1
+            self.animatableView.transform = CGAffineTransform.identity
             self.pickerView.isUserInteractionEnabled = true
           }
         } else {

--- a/IBAnimatableApp/AnimationsViewController.swift
+++ b/IBAnimatableApp/AnimationsViewController.swift
@@ -35,6 +35,7 @@ class AnimationsViewController: UIViewController {
     PickerEntry(params: [axisParams], name: "flip"),
     PickerEntry(params: [repeatCountParam], name: "shake"),
     PickerEntry(params: [repeatCountParam], name: "pop"),
+    PickerEntry(params: [repeatCountParam], name: "squash"),
     PickerEntry(params: [repeatCountParam], name: "morph"),
     PickerEntry(params: [repeatCountParam], name: "flash"),
     PickerEntry(params: [repeatCountParam], name: "wobble"),

--- a/IBAnimatableApp/ParamType.swift
+++ b/IBAnimatableApp/ParamType.swift
@@ -1,7 +1,4 @@
 //
-//  ParamType.swift
-//  IBAnimatableApp
-//
 //  Created by jason akakpo on 27/07/16.
 //  Copyright © 2016 IBAnimatable. All rights reserved.
 //

--- a/IBAnimatableApp/PresentingViewController.swift
+++ b/IBAnimatableApp/PresentingViewController.swift
@@ -192,16 +192,16 @@ extension PresentingViewController {
   func showPicker() {
     pickerView.reloadAllComponents()
     resetSelectedItemPicker()
-    dimmingPickerView.fade(way: .in)
-    containerPickerView.slide(way: .in, direction: .up)
+    dimmingPickerView.fade(.in)
+    containerPickerView.slide(.in, direction: .up)
     dimmingPickerView.isHidden = false
   }
 
   @IBAction func hidePicker() {
-    dimmingPickerView.fade(way: .out, completion: {
+    dimmingPickerView.fade(.out, completion: {
       self.dimmingPickerView.isHidden = true
     })
-    containerPickerView.slide(way: .out, direction: .down)
+    containerPickerView.slide(.out, direction: .down)
     selectedButton = nil
   }
 


### PR DESCRIPTION
In this PR, we have done some API improvements for Swift 3
1. We remove `repeatCount` from `Animatable` protocol and add it in `AnimationType` enum. 
2. Remove `way` from some animations like `slide`, it reads better like `containerPickerView.slide(.in, direction: .up)`
3. Make `animateIn` and `animateOut` methods more Swifty.
4. Group `private` methods in a private extension.
5. Add `squash` animation for version 3. Same as `squeeze` in version 2.
6. Update the animation playground demo. I really like @lastMove 's demo app, very flexible to add new animations to the demo.

@lastMove can you have a look since you made most of changes for `Animatable` an`AnimationType`

@tbaranes please have a look as well. 

Related to #221
