### PR TITLE
Potential BUGFIX InteractiveGestureType - ScreenEdgePan 

### DIFF
--- a/IBAnimatable/InteractiveGestureType.swift
+++ b/IBAnimatable/InteractiveGestureType.swift
@@ -57,7 +57,7 @@ extension InteractiveGestureType: IBEnum {
     case "pan":
       let direction = GestureDirection(raw: params[safe: 0], defaultValue: .left)
       self = .pan(from: direction)
-    case "screenedgePan":
+    case "screenedgepan":
       let direction = GestureDirection(raw: params[safe: 0], defaultValue: .left)
       self = .screenEdgePan(from: direction)
     case "pinch":


### PR DESCRIPTION
since `extractNameAndParams` lowercase name and params, the case should be lowerCased to match the case.
