### PR TITLE
Fix `AnimationType`

### DIFF
--- a/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
+++ b/IBAnimatable.playground/Pages/Animation Properties.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ let view = CircleView()
 iPhoneView.addSubview(view)
 
 //: animationType: all supported predefined animations can be found in `enum AnimationType`
-view.animationType = .squeeze(way: .in, from: .left)
+view.animationType = .squeeze(way: .in, direction: .left)
 
 //: duration: used to specify the duration of animation. Default value is 0.7
 view.duration = 0.8

--- a/IBAnimatable/AnimationType.swift
+++ b/IBAnimatable/AnimationType.swift
@@ -11,10 +11,10 @@ import UIKit
  */
 
 public enum AnimationType {
-  case slide(way: Way, from: Direction)
-  case squeeze(way: Way, from: Direction) // miss squeeze
-  case slideFade(way: Way, from: Direction)
-  case squeezeFade(way: Way, from: Direction)
+  case slide(way: Way, direction: Direction)
+  case squeeze(way: Way, direction: Direction)
+  case slideFade(way: Way, direction: Direction)
+  case squeezeFade(way: Way, direction: Direction)
   case fade(way: FadeWay)
   case zoom(way: Way)
   case zoomInvert(way: Way)
@@ -65,15 +65,15 @@ extension AnimationType: IBEnum {
     
     switch name {
     case "slide":
-      self = .slide(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .slide(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
     case "squeeze":
-      self = .squeeze(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .squeeze(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
     case "fade":
       self = .fade(way: FadeWay(raw: params[safe: 0], defaultValue: .in))
     case "slidefade":
-      self = .slideFade(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .slideFade(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
     case "squeezefade":
-      self = .squeezeFade(way: Way(raw: params[safe: 0], defaultValue: .in), from: Direction(raw: params[safe: 1], defaultValue: .left))
+      self = .squeezeFade(way: Way(raw: params[safe: 0], defaultValue: .in), direction: Direction(raw: params[safe: 1], defaultValue: .left))
     case "zoom":
       self = .zoom(way: Way(raw: params[safe: 0], defaultValue: .in))
     case "zoominvert":

--- a/IBAnimatableApp/AnimationsViewController.swift
+++ b/IBAnimatableApp/AnimationsViewController.swift
@@ -1,9 +1,6 @@
 //
-//  AnimationsViewController.swift
-//  IBAnimatableApp
-//
 //  Created by jason akakpo on 12/07/16.
-//  Copyright © 2016 Jake Lin. All rights reserved.
+//  Copyright © 2016 IBAnimatable. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
Fix `AnimationType` since `from` doesn't make sense for `.out` like `slide(.out, from: .left)`. It should be `.slide(.out, direction: .left)`.

It is a small PR, I made a mistake for changing `AnimationType`. Sometimes, `from` is wrong, it is better to use `direction`. 
