### PR TITLE
Fix view translate {x,y} for {slide, squeeze} animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ None
 None
 
 #### Bugfixes
-None
+
+- Fix `slide(.out, *)` and `squeeze(.out, *)` translation coordinates [#379](https://github.com/IBAnimatable/IBAnimatable/issues/379)
 
 ### [3.1.2](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.2)
 

--- a/IBAnimatable/Animatable.swift
+++ b/IBAnimatable/Animatable.swift
@@ -406,8 +406,6 @@ public extension Animatable where Self: UIView {
 
 private extension Animatable where Self: UIView {
   func computeValues(way: AnimationType.Way, direction: AnimationType.Direction, shouldScale: Bool) -> AnimationValues {
-    let yDistance = screenSize.height * force
-    let xDistance = screenSize.width * force
     let scale = 3 * force
     var scaleX: CGFloat = 1
     var scaleY: CGFloat = 1
@@ -416,14 +414,17 @@ private extension Animatable where Self: UIView {
     var y: CGFloat = 0
     switch direction {
     case .left:
-      x = -xDistance
+      x = -(screenSize.width - frame.maxX + frame.width)
     case .right:
-      x = xDistance
+      x = frame.maxX
     case .down:
-      y = -yDistance
+      y = -(screenSize.height - frame.maxY + frame.height)
     case .up:
-      y = yDistance
+      y = frame.maxY
     }
+
+    x *= force
+    y *= force
     if shouldScale && direction.isVertical() {
       scaleY = scale
     } else if shouldScale {


### PR DESCRIPTION
Since the final x, y were wrong, some animations was _failing_. In my case, on iPad, since my view was at the bottom of the screen, doing a `slide(.out, .down)` the view was going out of the screen way too fast (distance = iPad height). 

Less talk, more example:

Before the fix, after a `slide(.out, .down)`:

![screen shot 2016-12-22 at 09 34 18](https://cloud.githubusercontent.com/assets/1402212/21420278/1820dd2a-c82d-11e6-95fe-161113a4a5c1.png)

With the fix:

![screen shot 2016-12-22 at 09 44 57](https://cloud.githubusercontent.com/assets/1402212/21420282/1f7247e4-c82d-11e6-8ce1-d3356ceed610.png)
