### PR TITLE
Add support of dash border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ None
 
 #### Enhancements
 - New gradient `startPoint`: `.custom(startX, startY, endX, endY)`. [#380](https://github.com/IBAnimatable/IBAnimatable/pull/380)
+- Introducing `borderType`, find all the information in the documentation [#389](https://github.com/IBAnimatable/IBAnimatable/pull/380)
 
 #### Bugfixes
 

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -41,9 +41,10 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 #### `BorderDesignable`
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
+| borderType | Optional&lt;String> | border side: `solid`, `dash`, also can be found in emum [`BorderSide`](../IBAnimatable/BorderType.swift). If not specified, then display solid borders. **Please notice**: If we use `maskType` property then `borderType` will be ignored. |
 | borderColor | Optional&lt;UIColor> | border color |
 | borderWidth | CGFloat | border width. Default value is `CGFloat.NaN`, the value is greater than 0. |
-| borderSide | Optional&lt;String> | border side: `Top`, `Right`, `Bottom` or `Left`, also can be found in emum [`BorderSide`](../IBAnimatable/BorderSide.swift). Multiple sides can be configured with a comma separated list of sides (e.g. `Top,Bottom`). If not specified, then display four sides. **Please notice**: If we use `maskType` property then `borderSide` will be ignored. |
+| borderSide | Optional&lt;String> | border side: `top`, `right`, `bottom` or `left`, also can be found in emum [`BorderSide`](../IBAnimatable/BorderSide.swift). Multiple sides can be configured with a comma separated list of sides (e.g. `top,bottom`). If not specified, then display four sides. **Please notice**: If we use `maskType` property then `borderSide` will be ignored. |
 
 
 #### `CheckBoxDesignable`

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */; };
 		E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */; };
 		E2BCCD381CDCA15D00431DA0 /* ContainerTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BCCD371CDCA15D00431DA0 /* ContainerTransition.swift */; };
+		E2C5DCDD1E28BD12001E0E18 /* BorderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C5DCDC1E28BD12001E0E18 /* BorderType.swift */; };
 		E2D33E511D3A5418006F2492 /* Presentations.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2D33E501D3A5418006F2492 /* Presentations.storyboard */; };
 		E2D33E531D3A5490006F2492 /* PresentingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D33E521D3A5490006F2492 /* PresentingViewController.swift */; };
 		E2D33E551D3A5557006F2492 /* PresentationPresentedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D33E541D3A5557006F2492 /* PresentationPresentedViewController.swift */; };
@@ -388,6 +389,7 @@
 		E2A062B21CB19BB900C54B40 /* ExplodeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplodeAnimator.swift; sourceTree = "<group>"; };
 		E2A062B41CB1A60E00C54B40 /* PresentExplodeSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentExplodeSegue.swift; sourceTree = "<group>"; };
 		E2BCCD371CDCA15D00431DA0 /* ContainerTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransition.swift; sourceTree = "<group>"; };
+		E2C5DCDC1E28BD12001E0E18 /* BorderType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderType.swift; sourceTree = "<group>"; };
 		E2D33E501D3A5418006F2492 /* Presentations.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Presentations.storyboard; sourceTree = "<group>"; };
 		E2D33E521D3A5490006F2492 /* PresentingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentingViewController.swift; sourceTree = "<group>"; };
 		E2D33E541D3A5557006F2492 /* PresentationPresentedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationPresentedViewController.swift; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 				E22183BE1D3BD54B00866197 /* PresentationModalPosition.swift */,
 				E2DAD6381D5F4C2E00333ABF /* PresentationKeyboardTranslation.swift */,
 				E2E62B761D69B17900294A73 /* ActivityIndicatorType.swift */,
+				E2C5DCDC1E28BD12001E0E18 /* BorderType.swift */,
 			);
 			name = enum;
 			sourceTree = "<group>";
@@ -1068,6 +1071,7 @@
 				E28E282A1D6CCA5C0043D56E /* ActivityIndicatorAnimationBallRotateChase.swift in Sources */,
 				AE677B981CADCF5900D62273 /* SystemSuckEffectAnimator.swift in Sources */,
 				E28E28321D6CCA5C0043D56E /* ActivityIndicatorAnimationBallZigZagDeflect.swift in Sources */,
+				E2C5DCDD1E28BD12001E0E18 /* BorderType.swift in Sources */,
 				AE154B061C787DDE0093C05B /* AnimatableNavigationController.swift in Sources */,
 				E28E282F1D6CCA5C0043D56E /* ActivityIndicatorAnimationBallSpinFadeLoader.swift in Sources */,
 				AE8964DB1C2CC0D100D3E9F0 /* RootWindowDesignable.swift in Sources */,

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -60,7 +60,7 @@ open class AnimatableButton: UIButton, CornerDesignable, FillDesignable, BorderD
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -52,6 +52,18 @@ open class AnimatableButton: UIButton, CornerDesignable, FillDesignable, BorderD
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -71,6 +71,18 @@ open class AnimatableCheckBox: UIButton, CheckBoxDesignable, CornerDesignable, F
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -79,7 +79,7 @@ open class AnimatableCheckBox: UIButton, CheckBoxDesignable, CornerDesignable, F
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -85,7 +85,7 @@ open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable,
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -77,6 +77,18 @@ open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable,
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -60,7 +60,7 @@ open class AnimatableImageView: UIImageView, CornerDesignable, FillDesignable, B
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -52,6 +52,18 @@ open class AnimatableImageView: UIImageView, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -60,7 +60,7 @@ open class AnimatableLabel: UILabel, CornerDesignable, FillDesignable, Animatabl
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -52,6 +52,18 @@ open class AnimatableLabel: UILabel, CornerDesignable, FillDesignable, Animatabl
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -52,6 +52,18 @@ open class AnimatableScrollView: UIScrollView, CornerDesignable, FillDesignable,
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -60,7 +60,7 @@ open class AnimatableScrollView: UIScrollView, CornerDesignable, FillDesignable,
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -9,6 +9,18 @@ import UIKit
 open class AnimatableSlider: UIView, BorderDesignable, RotationDesignable, ShadowDesignable, Animatable {
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -17,7 +17,7 @@ open class AnimatableSlider: UIView, BorderDesignable, RotationDesignable, Shado
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -54,6 +54,18 @@ open class AnimatableStackView: UIStackView, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -62,7 +62,7 @@ open class AnimatableStackView: UIStackView, CornerDesignable, FillDesignable, B
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -33,6 +33,18 @@ open class AnimatableTableView: UITableView, FillDesignable, BorderDesignable, G
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -41,7 +41,7 @@ open class AnimatableTableView: UITableView, FillDesignable, BorderDesignable, G
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -33,6 +33,18 @@ open class AnimatableTableViewCell: UITableViewCell, FillDesignable, BorderDesig
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -41,7 +41,7 @@ open class AnimatableTableViewCell: UITableViewCell, FillDesignable, BorderDesig
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -52,6 +52,18 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -60,7 +60,7 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -52,6 +52,18 @@ open class AnimatableTextView: UITextView, CornerDesignable, FillDesignable, Bor
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -60,7 +60,7 @@ open class AnimatableTextView: UITextView, CornerDesignable, FillDesignable, Bor
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -52,6 +52,18 @@ open class AnimatableView: UIView, CornerDesignable, FillDesignable, BorderDesig
   }
 
   // MARK: - BorderDesignable
+  open var borderType: BorderType  = .solid {
+    didSet {
+      configureBorder()
+    }
+  }
+
+  @IBInspectable var _borderType: String? {
+    didSet {
+      borderType = BorderType(string: _borderType) ?? .solid
+    }
+  }
+
   @IBInspectable open var borderColor: UIColor? {
     didSet {
       configureBorder()

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -60,7 +60,7 @@ open class AnimatableView: UIView, CornerDesignable, FillDesignable, BorderDesig
 
   @IBInspectable var _borderType: String? {
     didSet {
-      borderType = BorderType(string: _borderType) ?? .solid
+      borderType = BorderType(string: _borderType)
     }
   }
 

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -88,9 +88,12 @@ fileprivate extension BorderDesignable where Self: UIView {
     shapeLayer.strokeColor = borderColor!.cgColor
     shapeLayer.lineWidth = borderWidth
     shapeLayer.frame = bounds
-    if borderType == .dash {
+    switch borderType {
+    case let .dash(dashLength, spaceLength):
       shapeLayer.lineJoin = kCALineJoinRound
-      shapeLayer.lineDashPattern = [6, 3]
+      shapeLayer.lineDashPattern = [dashLength as NSNumber, spaceLength as NSNumber]
+    case .solid, .none:
+      break
     }
     layer.insertSublayer(shapeLayer, at: 0)
   }

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -56,7 +56,6 @@ fileprivate extension BorderDesignable where Self: UIView {
     } else {
       drawBorders()
     }
-    configureBorderType()
   }
 
   private func clearLayer() {
@@ -82,23 +81,6 @@ fileprivate extension BorderDesignable where Self: UIView {
 
 fileprivate extension BorderDesignable where Self: UIView {
   func drawBorders() {
-    if borderSides == .AllSides {
-      drawBorders()
-    } else {
-      drawBorderSides()
-    }
-  }
-
-  // MARK: All Borders
-
-  private func drawAllBorders() {
-    layer.borderColor = borderColor!.cgColor
-    layer.borderWidth = borderWidth
-  }
-
-  // MARK: Sides
-
-  private func drawBorderSides() {
     let shapeLayer = CAShapeLayer()
     shapeLayer.name = "borderSideLayer"
     shapeLayer.path = makeBorderPath().cgPath
@@ -106,6 +88,10 @@ fileprivate extension BorderDesignable where Self: UIView {
     shapeLayer.strokeColor = borderColor!.cgColor
     shapeLayer.lineWidth = borderWidth
     shapeLayer.frame = bounds
+    if borderType == .dash {
+      shapeLayer.lineJoin = kCALineJoinRound
+      shapeLayer.lineDashPattern = [6, 3]
+    }
     layer.insertSublayer(shapeLayer, at: 0)
   }
 

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -7,6 +7,11 @@ import UIKit
 
 public protocol BorderDesignable {
   /**
+   `border-type`, border type
+   */
+  var borderType: BorderType { get set }
+
+  /**
     `border-color`, border color
   */
   var borderColor: UIColor? { get set }

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public protocol BorderDesignable {
   /**
-   `border-type`, border type
+   `bordertype: solid, dash, if not specified, solid will be used
    */
   var borderType: BorderType { get set }
 
@@ -42,46 +42,86 @@ public extension BorderDesignable where Self: UIView {
   }
 }
 
-private extension BorderDesignable where Self: UIView {
+// MARK: - Layer
+
+fileprivate extension BorderDesignable where Self: UIView {
   func commonConfigBorder() {
-    guard let borderColor = borderColor, borderWidth > 0 else {
+    guard borderColor != nil, borderWidth > 0 else {
       return
     }
 
-    // Clear borders
+    clearLayer()
+    if let mask = layer.mask as? CAShapeLayer {
+      applyBorderOnMask(mask)
+    } else {
+      drawBorders()
+    }
+    configureBorderType()
+  }
+
+  private func clearLayer() {
     layer.borderColor = nil
     layer.borderWidth = 0
     layer.sublayers?.filter { $0.name == "borderSideLayer" || $0.name == "borderAllSides" }
       .forEach { $0.removeFromSuperlayer() }
+  }
 
-    // if a layer mask is specified, only border the mask
-    if let mask = layer.mask as? CAShapeLayer {
-      let borderLayer = CAShapeLayer()
-      borderLayer.name = "borderAllSides"
-      borderLayer.path = mask.path
-      borderLayer.fillColor = UIColor.clear.cgColor
-      borderLayer.strokeColor = borderColor.cgColor
-      borderLayer.lineWidth = borderWidth
-      borderLayer.frame = bounds
-      layer.insertSublayer(borderLayer, at: 0)
-      return
-    }
+  private func applyBorderOnMask(_ mask: CAShapeLayer) {
+    let borderLayer = CAShapeLayer()
+    borderLayer.name = "borderAllSides"
+    borderLayer.path = mask.path
+    borderLayer.fillColor = UIColor.clear.cgColor
+    borderLayer.strokeColor = borderColor!.cgColor
+    borderLayer.lineWidth = borderWidth
+    borderLayer.frame = bounds
+    layer.insertSublayer(borderLayer, at: 0)
+  }
+}
 
-    //let sides = BorderSides(rawValue: BorderSides)
+// MARK: - Drawing
 
+fileprivate extension BorderDesignable where Self: UIView {
+  func drawBorders() {
     if borderSides == .AllSides {
-      layer.borderColor = borderColor.cgColor
-      layer.borderWidth = borderWidth
-      return
+      drawBorders()
+    } else {
+      drawBorderSides()
     }
+  }
 
-    // configure border for specified sides
-    let border = CAShapeLayer()
-    border.name = "borderSideLayer"
+  // MARK: All Borders
 
+  private func drawAllBorders() {
+    layer.borderColor = borderColor!.cgColor
+    layer.borderWidth = borderWidth
+  }
+
+  // MARK: Sides
+
+  private func drawBorderSides() {
+    let shapeLayer = CAShapeLayer()
+    shapeLayer.name = "borderSideLayer"
+    shapeLayer.path = makeBorderPath().cgPath
+    shapeLayer.fillColor = UIColor.clear.cgColor
+    shapeLayer.strokeColor = borderColor!.cgColor
+    shapeLayer.lineWidth = borderWidth
+    shapeLayer.frame = bounds
+    layer.insertSublayer(shapeLayer, at: 0)
+  }
+
+  func makeBorderPath() -> UIBezierPath {
+    let lines = makeLines()
     let borderPath = UIBezierPath()
+    lines.forEach {
+      borderPath.move(to: $0.start)
+      borderPath.addLine(to: $0.end)
+    }
+    return borderPath
+  }
+
+  func makeLines() -> [(start: CGPoint, end: CGPoint)] {
     let shift = borderWidth / 2
-    var lines: [(start: CGPoint, end: CGPoint)] = []
+    var lines = [(start: CGPoint, end: CGPoint)]()
     if borderSides.contains(.top) {
       lines.append((start: CGPoint(x: 0, y: shift), end: CGPoint(x: bounds.size.width, y: shift)))
     }
@@ -94,17 +134,6 @@ private extension BorderDesignable where Self: UIView {
     if borderSides.contains(.left) {
       lines.append((start: CGPoint(x: shift, y: 0), end: CGPoint(x: shift, y: bounds.size.height)))
     }
-
-    for linePoints in lines {
-      borderPath.move(to: linePoints.start)
-      borderPath.addLine(to: linePoints.end)
-    }
-
-    border.path = borderPath.cgPath
-    border.fillColor = UIColor.clear.cgColor
-    border.strokeColor = borderColor.cgColor
-    border.lineWidth = borderWidth
-    border.frame = bounds
-    layer.insertSublayer(border, at: 0)
+    return lines
   }
 }

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -81,6 +81,15 @@ fileprivate extension BorderDesignable where Self: UIView {
 
 fileprivate extension BorderDesignable where Self: UIView {
   func drawBorders() {
+    if borderType == .solid, borderSides == .AllSides {
+      layer.borderColor = borderColor!.cgColor
+      layer.borderWidth = borderWidth
+    } else {
+      drawBordersSides()
+    }
+  }
+
+  func drawBordersSides() {
     let shapeLayer = CAShapeLayer()
     shapeLayer.name = "borderSideLayer"
     shapeLayer.path = makeBorderPath().cgPath

--- a/IBAnimatable/BorderType.swift
+++ b/IBAnimatable/BorderType.swift
@@ -33,3 +33,17 @@ extension BorderType {
     }
   }
 }
+
+extension BorderType: Equatable {
+}
+
+public func == (lhs: BorderType, rhs: BorderType) -> Bool {
+  switch (lhs, rhs) {
+  case (.solid, .solid):
+    return true
+  case (.dash, .dash):
+    return true
+  default:
+    return false
+  }
+}

--- a/IBAnimatable/BorderType.swift
+++ b/IBAnimatable/BorderType.swift
@@ -8,8 +8,28 @@
 
 import Foundation
 
-public enum BorderType: String, IBEnum {
+public enum BorderType: IBEnum {
   case solid
-  case dash
+  case dash(dashLength: Int, spaceLength: Int)
   case none
+}
+
+extension BorderType {
+
+  public init(string: String?) {
+    guard let string = string else {
+      self = .none
+      return
+    }
+
+    let (name, params) = AnimationType.extractNameAndParams(from: string)
+    switch name {
+    case "solid":
+      self = .solid
+    case "dash":
+      self = .dash(dashLength: params[safe: 0]?.toInt() ?? 1, spaceLength: params[safe: 1]?.toInt() ?? 1)
+    default:
+      self = .none
+    }
+  }
 }

--- a/IBAnimatable/BorderType.swift
+++ b/IBAnimatable/BorderType.swift
@@ -1,0 +1,15 @@
+//
+//  BorderType.swift
+//  IBAnimatable
+//
+//  Created by Tom Baranes on 13/01/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import Foundation
+
+public enum BorderType: String, IBEnum {
+  case Solid
+  case Dash
+  case none
+}

--- a/IBAnimatable/BorderType.swift
+++ b/IBAnimatable/BorderType.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum BorderType: String, IBEnum {
-  case Solid
-  case Dash
+  case solid
+  case dash
   case none
 }

--- a/IBAnimatableApp/BorderViewController.swift
+++ b/IBAnimatableApp/BorderViewController.swift
@@ -75,19 +75,6 @@ extension BorderViewController: UIPickerViewDelegate, UIPickerViewDataSource {
     return 3
   }
 
-//  func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
-//    switch component {
-//    case 0:
-//      return self.view.frame.size.width * 0.5
-//    case 1:
-//      return self.view.frame.size.width * 0.25
-//    case 2:
-//      return self.view.frame.size.width * 0.25
-//    default:
-//      return 0
-//    }
-//  }
-
   func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
     if component == 0 {
       return entries[safe: row]?.name.colorize(.white)

--- a/IBAnimatableApp/BorderViewController.swift
+++ b/IBAnimatableApp/BorderViewController.swift
@@ -6,13 +6,38 @@
 import UIKit
 import IBAnimatable
 
+fileprivate let dashLength = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit: "")
+fileprivate let dashSpaceLength = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit: "")
+
 class BorderViewController: UIViewController {
+
+  // MARK: IBOutlets
 
   @IBOutlet weak var viewToBorder: AnimatableView!
   @IBOutlet weak var topCheckBox: AnimatableCheckBox!
   @IBOutlet weak var botCheckBox: AnimatableCheckBox!
   @IBOutlet weak var leftCheckBox: AnimatableCheckBox!
   @IBOutlet weak var rightCheckBox: AnimatableCheckBox!
+  @IBOutlet weak var pickerView: UIPickerView!
+
+  // MARK: Properties
+
+  var selectedEntry: PickerEntry!
+  let entries: [PickerEntry] = [
+    PickerEntry(params: [], name: "solid"),
+    PickerEntry(params: [dashLength, dashSpaceLength], name: "dash")
+  ]
+
+  // MARK: Life cycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    selectedEntry = entries[0]
+    pickerView.dataSource = self
+    pickerView.delegate = self
+  }
+
+  // MARK: IBAction
 
   @IBAction func boxChecked(_ sender: AnimatableCheckBox) {
     let border: BorderSides
@@ -33,7 +58,56 @@ class BorderViewController: UIViewController {
     } else {
       viewToBorder.borderSides.remove(border)
     }
-
   }
 
+}
+
+extension BorderViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    if component == 0 {
+      return entries.count
+    }
+    return selectedEntry.params[safe: component - 1]?.count() ?? 0
+  }
+
+  func numberOfComponents(in pickerView: UIPickerView) -> Int {
+    return 3
+  }
+
+//  func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+//    switch component {
+//    case 0:
+//      return self.view.frame.size.width * 0.5
+//    case 1:
+//      return self.view.frame.size.width * 0.25
+//    case 2:
+//      return self.view.frame.size.width * 0.25
+//    default:
+//      return 0
+//    }
+//  }
+
+  func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+    if component == 0 {
+      return entries[safe: row]?.name.colorize(.white)
+    }
+    guard let param = selectedEntry.params[safe: component - 1] else {
+      return nil
+    }
+    return param.title(at: row).colorize(.white)
+  }
+
+  func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    if component == 0 {
+      if selectedEntry.name != entries[row].name {
+        selectedEntry = entries[row]
+        pickerView.reloadComponent(1)
+        pickerView.reloadComponent(2)
+      }
+    }
+
+    let animationString = selectedEntry.toString(selectedIndexes: pickerView.selectedRow(inComponent: 1), pickerView.selectedRow(inComponent: 2))
+    viewToBorder.borderType = BorderType(string: animationString)
+  }
 }

--- a/IBAnimatableApp/UserInterface.storyboard
+++ b/IBAnimatableApp/UserInterface.storyboard
@@ -475,10 +475,10 @@ Opacity</string>
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XfI-vs-Klt" userLabel="Content">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="433"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="303"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5YH-3K-Z6I" customClass="AnimatableView" customModule="IBAnimatable">
-                                                <rect key="frame" x="88" y="167" width="200" height="100"/>
+                                                <rect key="frame" x="88" y="102" width="200" height="100"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="100" id="R7j-Se-AUb"/>
                                                     <constraint firstAttribute="width" constant="200" id="onv-aW-yww"/>
@@ -503,135 +503,196 @@ Opacity</string>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pif-t8-9Jy" userLabel="Bottom Panel" customClass="AnimatableView" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="433" width="375" height="170"/>
+                                        <rect key="frame" x="0.0" y="303" width="375" height="300"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="75u-pF-Sy6">
-                                                <rect key="frame" x="10" y="10" width="355" height="150"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="75u-pF-Sy6">
+                                                <rect key="frame" x="10" y="10" width="355" height="70"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="wXB-Ve-Nx8">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="WOE-cS-aCZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="355" height="30"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G0B-Jv-kmo" customClass="AnimatableCheckBox" customModule="IBAnimatable">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="wXB-Ve-Nx8">
+                                                                <rect key="frame" x="0.0" y="0.0" width="176" height="30"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G0B-Jv-kmo" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" secondItem="G0B-Jv-kmo" secondAttribute="height" id="IXX-5w-Pqc"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                        <connections>
+                                                                            <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="qYA-tx-78w"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Top" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qkf-AH-sgw">
+                                                                        <rect key="frame" x="50" y="0.0" width="126" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="G0B-Jv-kmo" secondAttribute="height" id="IXX-5w-Pqc"/>
+                                                                    <constraint firstAttribute="height" constant="30" id="FcK-Z8-jTw"/>
                                                                 </constraints>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
-                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="qYA-tx-78w"/>
-                                                                </connections>
-                                                            </button>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Top" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qkf-AH-sgw">
-                                                                <rect key="frame" x="50" y="0.0" width="305" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="WJt-th-N1Y">
+                                                                <rect key="frame" x="176" y="0.0" width="179" height="30"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GpR-xE-BpF" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" secondItem="GpR-xE-BpF" secondAttribute="height" id="1v5-dx-sXj"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                        <connections>
+                                                                            <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="DOP-rn-NsG"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ery-U0-7n4">
+                                                                        <rect key="frame" x="50" y="0.0" width="129" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="zE2-v2-aoc"/>
+                                                                </constraints>
+                                                            </stackView>
                                                         </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="FcK-Z8-jTw"/>
-                                                        </constraints>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="WJt-th-N1Y">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="fo4-1F-ZNq">
                                                         <rect key="frame" x="0.0" y="40" width="355" height="30"/>
                                                         <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GpR-xE-BpF" customClass="AnimatableCheckBox" customModule="IBAnimatable">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="2Gl-ke-oiy">
+                                                                <rect key="frame" x="0.0" y="0.0" width="136.5" height="30"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1WE-rk-t4D" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" secondItem="1WE-rk-t4D" secondAttribute="height" id="pM7-dI-q5F"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                        <connections>
+                                                                            <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="fAe-iT-Es4"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Right" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zdN-WX-lYa">
+                                                                        <rect key="frame" x="50" y="0.0" width="86.5" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="GpR-xE-BpF" secondAttribute="height" id="1v5-dx-sXj"/>
+                                                                    <constraint firstAttribute="height" constant="30" id="aSG-ho-4jm"/>
                                                                 </constraints>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
-                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="DOP-rn-NsG"/>
-                                                                </connections>
-                                                            </button>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ery-U0-7n4">
-                                                                <rect key="frame" x="50" y="0.0" width="305" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="zE2-v2-aoc"/>
-                                                        </constraints>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="2Gl-ke-oiy">
-                                                        <rect key="frame" x="0.0" y="80" width="355" height="30"/>
-                                                        <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1WE-rk-t4D" customClass="AnimatableCheckBox" customModule="IBAnimatable">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ojc-jR-F4A">
+                                                                <rect key="frame" x="176.5" y="0.0" width="178.5" height="30"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a5p-Qm-Tx2" customClass="AnimatableCheckBox" customModule="IBAnimatable">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" secondItem="a5p-Qm-Tx2" secondAttribute="height" id="KAM-N8-nt8"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
+                                                                            <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                        <connections>
+                                                                            <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="U0Z-BG-mKq"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Bottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VCe-5b-zdS">
+                                                                        <rect key="frame" x="50" y="0.0" width="128.5" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="1WE-rk-t4D" secondAttribute="height" id="pM7-dI-q5F"/>
+                                                                    <constraint firstAttribute="height" constant="30" id="qOq-2s-TIf"/>
                                                                 </constraints>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
-                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="fAe-iT-Es4"/>
-                                                                </connections>
-                                                            </button>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Right" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zdN-WX-lYa">
-                                                                <rect key="frame" x="50" y="0.0" width="305" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            </stackView>
                                                         </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="aSG-ho-4jm"/>
-                                                        </constraints>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ojc-jR-F4A">
-                                                        <rect key="frame" x="0.0" y="120" width="355" height="30"/>
-                                                        <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a5p-Qm-Tx2" customClass="AnimatableCheckBox" customModule="IBAnimatable">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" secondItem="a5p-Qm-Tx2" secondAttribute="height" id="KAM-N8-nt8"/>
-                                                                </constraints>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="checkedImage" value="checked"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="uncheckedImage" value="unchecked"/>
-                                                                    <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="Pop"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="checked" value="YES"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="boxChecked:" destination="yzd-wU-DRz" eventType="touchUpInside" id="U0Z-BG-mKq"/>
-                                                                </connections>
-                                                            </button>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" text="Bottom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VCe-5b-zdS">
-                                                                <rect key="frame" x="50" y="0.0" width="305" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="qOq-2s-TIf"/>
-                                                        </constraints>
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yzf-TH-izK" userLabel="Picker Stack View" customClass="AnimatableStackView" customModule="IBAnimatable">
+                                                <rect key="frame" x="10" y="110" width="355" height="180"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="TQ2-z6-ZXR">
+                                                        <rect key="frame" x="0.0" y="0.0" width="355" height="60"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BorderType" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1F-4M-pVa">
+                                                                <rect key="frame" x="10" y="0.0" width="167.5" height="60"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="17"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Aee-jA-jYp">
+                                                                <rect key="frame" x="177.5" y="0.0" width="167.5" height="60"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Parameters" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sRw-p2-G0C">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="167.5" height="43"/>
+                                                                        <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="17"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="(length, space)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1wP-dG-gVK">
+                                                                        <rect key="frame" x="0.0" y="43" width="167.5" height="17"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                        </subviews>
+                                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="60" id="WS7-h6-UZO"/>
+                                                        </constraints>
+                                                        <edgeInsets key="layoutMargins" top="0.0" left="10" bottom="0.0" right="10"/>
+                                                    </stackView>
+                                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HUW-7m-I9b">
+                                                        <rect key="frame" x="0.0" y="60" width="355" height="120"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </pickerView>
+                                                </subviews>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                        <color key="value" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </stackView>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="yzf-TH-izK" firstAttribute="leading" secondItem="75u-pF-Sy6" secondAttribute="leading" id="bhq-WK-jw9"/>
                                             <constraint firstItem="75u-pF-Sy6" firstAttribute="leading" secondItem="Pif-t8-9Jy" secondAttribute="leading" constant="10" id="cwn-6x-vrp"/>
-                                            <constraint firstAttribute="bottom" secondItem="75u-pF-Sy6" secondAttribute="bottom" constant="10" id="euW-Le-T71"/>
                                             <constraint firstAttribute="trailing" secondItem="75u-pF-Sy6" secondAttribute="trailing" constant="10" id="ezg-o2-Xj4"/>
                                             <constraint firstItem="75u-pF-Sy6" firstAttribute="top" secondItem="Pif-t8-9Jy" secondAttribute="top" constant="10" id="kpG-tX-V6P"/>
+                                            <constraint firstItem="yzf-TH-izK" firstAttribute="trailing" secondItem="75u-pF-Sy6" secondAttribute="trailing" id="n9n-6i-nkt"/>
+                                            <constraint firstAttribute="bottom" secondItem="yzf-TH-izK" secondAttribute="bottom" constant="10" id="oYB-Bo-sbz"/>
+                                            <constraint firstItem="yzf-TH-izK" firstAttribute="top" secondItem="75u-pF-Sy6" secondAttribute="bottom" constant="30" id="xq3-nY-SZv"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
@@ -653,6 +714,7 @@ Opacity</string>
                     <connections>
                         <outlet property="botCheckBox" destination="a5p-Qm-Tx2" id="N3D-gH-7ba"/>
                         <outlet property="leftCheckBox" destination="GpR-xE-BpF" id="BHt-3E-Toa"/>
+                        <outlet property="pickerView" destination="HUW-7m-I9b" id="t9v-Mg-bXJ"/>
                         <outlet property="rightCheckBox" destination="1WE-rk-t4D" id="AE3-Zw-Bs5"/>
                         <outlet property="topCheckBox" destination="G0B-Jv-kmo" id="xDx-hv-xxK"/>
                         <outlet property="viewToBorder" destination="5YH-3K-Z6I" id="I7p-ec-DdY"/>


### PR DESCRIPTION
Close #387 
Implemented on #388 (must be merged first)

This PR add a new a `BorderType`, currently supporting:
- Solid (default)
- Dash: support exactly the same configuration as `borderSides`

<img width="191" alt="screen shot 2017-01-13 at 10 06 16" src="https://cloud.githubusercontent.com/assets/1402212/21924133/f678f05c-d977-11e6-8c45-7c1651f2c90d.png">
<img width="184" alt="screen shot 2017-01-13 at 10 06 25" src="https://cloud.githubusercontent.com/assets/1402212/21924132/f67817fe-d977-11e6-82c1-a4103aab913e.png">

_I also used that PR to make some refactoring to `BorderDesignable`..._
