### PR TITLE
Add public intializer to PresentationDesignable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ None
 - Fix `No such module IBAnimatable` when attempting to run the Playground [#251](https://github.com/IBAnimatable/IBAnimatable/issues/251)
 - Fix custom presentation animations [#393](https://github.com/IBAnimatable/IBAnimatable/pull/393)
 - Fix border state when trying to reset a valid border [#398](https://github.com/IBAnimatable/IBAnimatable/pull/398)
-- Add the missing `PresentationConfiguration` initializer in order to make `PresentationDesignable` usable outside of IBAnimatable [#402](https://github.com/IBAnimatable/IBAnimatable/pull/402)
+- Make `PresentationDesignable` usable outside of IBAnimatable [#402](https://github.com/IBAnimatable/IBAnimatable/pull/402)
  
 ### [3.1.2](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ None
 - Fix `No such module IBAnimatable` when attempting to run the Playground [#251](https://github.com/IBAnimatable/IBAnimatable/issues/251)
 - Fix custom presentation animations [#393](https://github.com/IBAnimatable/IBAnimatable/pull/393)
 - Fix border state when trying to reset a valid border [#398](https://github.com/IBAnimatable/IBAnimatable/pull/398)
+- Add the missing `PresentationConfiguration` initializer in order to make `PresentationDesignable` usable outside of IBAnimatable [#402](https://github.com/IBAnimatable/IBAnimatable/pull/402)
  
 ### [3.1.2](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.2)
 

--- a/IBAnimatable/AnimatableModalViewController.swift
+++ b/IBAnimatable/AnimatableModalViewController.swift
@@ -19,7 +19,7 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
   public var presentationAnimationType: PresentationAnimationType = .cover(from: .bottom) {
     didSet {
       if oldValue.stringValue != presentationAnimationType.stringValue {
-        setupPresenter()
+        configurePresenter()
       }
     }
   }
@@ -34,7 +34,7 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
   public var dismissalAnimationType: PresentationAnimationType = .cover(from: .bottom) {
     didSet {
       if oldValue.stringValue != dismissalAnimationType.stringValue {
-        setupPresenter()
+        configurePresenter()
       }
     }
   }
@@ -146,23 +146,22 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
   }
   public var keyboardTranslation: ModalKeyboardTranslation = .none {
     didSet {
-      presenter?.presentationConfiguration?.keyboardTranslation = keyboardTranslation    }
+      presenter?.presentationConfiguration?.keyboardTranslation = keyboardTranslation
+    }
   }
 
-  // MARK: Private
-
-  fileprivate var presenter: PresentationPresenter?
+  public var presenter: PresentationPresenter?
 
   // MARK: Life cycle
 
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    setupPresenter()
+    configurePresenter()
   }
 
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    setupPresenter()
+    configurePresenter()
   }
 
   // MARK: Life cycle
@@ -177,34 +176,5 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
     if let dismissalSystemTransition = animationType.systemTransition {
       modalTransitionStyle = dismissalSystemTransition
     }
-  }
-}
-
-private extension AnimatableModalViewController {
-  func setupPresenter() {
-
-    presenter = PresentationPresenterManager.shared.retrievePresenter(presentationAnimationType: presentationAnimationType, transitionDuration: transitionDuration)
-    presenter?.dismissalAnimationType = dismissalAnimationType
-    transitioningDelegate = presenter
-    modalPresentationStyle = .custom
-    if let systemTransition = presentationAnimationType.systemTransition {
-      modalTransitionStyle = systemTransition
-    }
-
-    var presentationConfiguration = PresentationConfiguration()
-    presentationConfiguration.modalPosition = modalPosition
-    presentationConfiguration.modalSize = modalSize
-    presentationConfiguration.cornerRadius = cornerRadius
-    presentationConfiguration.dismissOnTap = dismissOnTap
-    presentationConfiguration.backgroundColor = backgroundColor
-    presentationConfiguration.opacity = opacity
-    presentationConfiguration.blurEffectStyle = blurEffectStyle
-    presentationConfiguration.blurOpacity = blurOpacity
-    presentationConfiguration.shadowColor = shadowColor
-    presentationConfiguration.shadowOpacity = shadowOpacity
-    presentationConfiguration.shadowRadius = shadowRadius
-    presentationConfiguration.shadowOffset = shadowOffset
-    presentationConfiguration.keyboardTranslation = keyboardTranslation
-    presenter?.presentationConfiguration = presentationConfiguration
   }
 }

--- a/IBAnimatable/AnimatableModalViewController.swift
+++ b/IBAnimatable/AnimatableModalViewController.swift
@@ -171,10 +171,6 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
 
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-
-    let animationType = dismissalAnimationType
-    if let dismissalSystemTransition = animationType.systemTransition {
-      modalTransitionStyle = dismissalSystemTransition
-    }
+    configureDismissalTransition()
   }
 }

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -60,6 +60,8 @@ public protocol PresentationDesignable: class {
 
 }
 
+// MARK: - Configuration
+
 public extension PresentationDesignable where Self: UIViewController {
 
   public func configurePresenter() {
@@ -88,7 +90,16 @@ public extension PresentationDesignable where Self: UIViewController {
     presenter?.presentationConfiguration = presentationConfiguration
   }
 
+  public func configureDismissalTransition() {
+    let animationType = dismissalAnimationType
+    if let dismissalSystemTransition = animationType.systemTransition {
+      modalTransitionStyle = dismissalSystemTransition
+    }
+  }
+
 }
+
+// MARK: - PresentationConfiguration
 
 /// `PresentationConfiguration` a struct is used for specifying the dimming view and modal view for `AnimatablePresentationController`
 public struct PresentationConfiguration {

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -9,6 +9,8 @@ public typealias ModalSize = (width: PresentationModalSize, height: Presentation
 /// PresentationDesignable is a protocol to define customised modal view controller which is used as the `presentedViewController` for `UIPresentationController`
 public protocol PresentationDesignable: class {
 
+  var presenter: PresentationPresenter? { get set }
+
   /// Presentation animation type, all supported animation type can be found in `PresentationAnimationType`
   var presentationAnimationType: PresentationAnimationType { get set }
 
@@ -58,6 +60,36 @@ public protocol PresentationDesignable: class {
 
 }
 
+public extension PresentationDesignable where Self: UIViewController {
+
+  public func configurePresenter() {
+    presenter = PresentationPresenterManager.shared.retrievePresenter(presentationAnimationType: presentationAnimationType, transitionDuration: transitionDuration)
+    presenter?.dismissalAnimationType = dismissalAnimationType
+    transitioningDelegate = presenter
+    modalPresentationStyle = .custom
+    if let systemTransition = presentationAnimationType.systemTransition {
+      modalTransitionStyle = systemTransition
+    }
+
+    var presentationConfiguration = PresentationConfiguration()
+    presentationConfiguration.modalPosition = modalPosition
+    presentationConfiguration.modalSize = modalSize
+    presentationConfiguration.cornerRadius = cornerRadius
+    presentationConfiguration.dismissOnTap = dismissOnTap
+    presentationConfiguration.backgroundColor = backgroundColor
+    presentationConfiguration.opacity = opacity
+    presentationConfiguration.blurEffectStyle = blurEffectStyle
+    presentationConfiguration.blurOpacity = blurOpacity
+    presentationConfiguration.shadowColor = shadowColor
+    presentationConfiguration.shadowOpacity = shadowOpacity
+    presentationConfiguration.shadowRadius = shadowRadius
+    presentationConfiguration.shadowOffset = shadowOffset
+    presentationConfiguration.keyboardTranslation = keyboardTranslation
+    presenter?.presentationConfiguration = presentationConfiguration
+  }
+
+}
+
 /// `PresentationConfiguration` a struct is used for specifying the dimming view and modal view for `AnimatablePresentationController`
 public struct PresentationConfiguration {
   var cornerRadius: CGFloat = .nan
@@ -74,7 +106,5 @@ public struct PresentationConfiguration {
   var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   var keyboardTranslation = ModalKeyboardTranslation.none
 
-  public init() {
-
-  }
+  public init() {}
 }

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -103,19 +103,19 @@ public extension PresentationDesignable where Self: UIViewController {
 
 /// `PresentationConfiguration` a struct is used for specifying the dimming view and modal view for `AnimatablePresentationController`
 public struct PresentationConfiguration {
-  var cornerRadius: CGFloat = .nan
-  var dismissOnTap: Bool = true
-  var backgroundColor: UIColor = .black
-  var opacity: CGFloat = 0.7
-  var blurEffectStyle: UIBlurEffectStyle?
-  var blurOpacity: CGFloat = .nan
-  var shadowColor: UIColor?
-  var shadowRadius: CGFloat = .nan
-  var shadowOpacity: CGFloat = 0.7
-  var shadowOffset: CGPoint = .zero
-  var modalPosition: PresentationModalPosition = .center
-  var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
-  var keyboardTranslation = ModalKeyboardTranslation.none
+  public var cornerRadius: CGFloat = .nan
+  public var dismissOnTap: Bool = true
+  public var backgroundColor: UIColor = .black
+  public var opacity: CGFloat = 0.7
+  public var blurEffectStyle: UIBlurEffectStyle?
+  public var blurOpacity: CGFloat = .nan
+  public var shadowColor: UIColor?
+  public var shadowRadius: CGFloat = .nan
+  public var shadowOpacity: CGFloat = 0.7
+  public var shadowOffset: CGPoint = .zero
+  public var modalPosition: PresentationModalPosition = .center
+  public var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
+  public var keyboardTranslation = ModalKeyboardTranslation.none
 
   public init() {}
 }

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -116,6 +116,4 @@ public struct PresentationConfiguration {
   public var modalPosition: PresentationModalPosition = .center
   public var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   public var keyboardTranslation = ModalKeyboardTranslation.none
-
-  public init() {}
 }

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -73,4 +73,8 @@ public struct PresentationConfiguration {
   var modalPosition: PresentationModalPosition = .center
   var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   var keyboardTranslation = ModalKeyboardTranslation.none
+
+  public init() {
+
+  }
 }

--- a/IBAnimatable/PresentationPresenter.swift
+++ b/IBAnimatable/PresentationPresenter.swift
@@ -7,10 +7,10 @@ import UIKit
 
 public class PresentationPresenter: NSObject {
   private var presentationAnimationType: PresentationAnimationType
-  var dismissalAnimationType: PresentationAnimationType?
+  public var dismissalAnimationType: PresentationAnimationType?
 
-  var presentationConfiguration: PresentationConfiguration?
-  var transitionDuration: Duration {
+  public var presentationConfiguration: PresentationConfiguration?
+  public var transitionDuration: Duration {
     didSet {
       if oldValue != transitionDuration {
         updateTransitionDuration()


### PR DESCRIPTION
Follow up of #401 
Since the philosophy of `IBAnimatable` is to use protocols for everything in order to reuse them in our own components, it's quite sad that we are blocking that usage for `PresentationDesignable`. 

I think we just missed that case, and  it's probably an implementation error.