### PR TITLE
Fix corner breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Next
 
 #### API breaking changes
-- Change the rawValue for `CornerSide` enum. Since we fix an issue to make corner sides case insensitive [#394]. If we use `CornerSide` in code, we need to change `.topLeft` to `.topleft`, `.topRight` to `.topright`, `.bottomLeft` to `.bottomleft` and `.bottomRight` to `.bottomright`. If we use `CornerSide` in Interface Builder, there is not breaking change for it.
+- `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programatically a cornerSide to your view, you will just have to lowercase the A.
 
 #### Enhancements
 - Add support for corner on AnimatableTableViewCell.

--- a/IBAnimatable/AnimatableButton.swift
+++ b/IBAnimatable/AnimatableButton.swift
@@ -15,7 +15,7 @@ open class AnimatableButton: UIButton, CornerDesignable, FillDesignable, BorderD
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableCheckBox.swift
+++ b/IBAnimatable/AnimatableCheckBox.swift
@@ -34,7 +34,7 @@ open class AnimatableCheckBox: UIButton, CheckBoxDesignable, CornerDesignable, F
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -15,7 +15,7 @@ open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable,
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableImageView.swift
+++ b/IBAnimatable/AnimatableImageView.swift
@@ -15,7 +15,7 @@ open class AnimatableImageView: UIImageView, CornerDesignable, FillDesignable, B
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableLabel.swift
+++ b/IBAnimatable/AnimatableLabel.swift
@@ -15,7 +15,7 @@ open class AnimatableLabel: UILabel, CornerDesignable, FillDesignable, Animatabl
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableScrollView.swift
+++ b/IBAnimatable/AnimatableScrollView.swift
@@ -15,7 +15,7 @@ open class AnimatableScrollView: UIScrollView, CornerDesignable, FillDesignable,
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableStackView.swift
+++ b/IBAnimatable/AnimatableStackView.swift
@@ -17,7 +17,7 @@ open class AnimatableStackView: UIStackView, CornerDesignable, FillDesignable, B
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -15,7 +15,7 @@ open class AnimatableTableViewCell: UITableViewCell, CornerDesignable, FillDesig
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -15,7 +15,7 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableTextView.swift
+++ b/IBAnimatable/AnimatableTextView.swift
@@ -15,7 +15,7 @@ open class AnimatableTextView: UITextView, CornerDesignable, FillDesignable, Bor
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/AnimatableView.swift
+++ b/IBAnimatable/AnimatableView.swift
@@ -15,7 +15,7 @@ open class AnimatableView: UIView, CornerDesignable, FillDesignable, BorderDesig
     }
   }
 
-  open var cornerSides: CornerSides  = .AllSides {
+  open var cornerSides: CornerSides  = .allSides {
     didSet {
       configureCornerRadius()
     }

--- a/IBAnimatable/CornerDesignable.swift
+++ b/IBAnimatable/CornerDesignable.swift
@@ -27,7 +27,7 @@ public extension CornerDesignable where Self: UICollectionViewCell {
       }
       layer.cornerRadius = 0.0
 
-      if cornerSides == .AllSides {
+      if cornerSides == .allSides {
         contentView.layer.cornerRadius = cornerRadius
       } else {
         contentView.layer.cornerRadius = 0.0
@@ -48,7 +48,7 @@ public extension CornerDesignable where Self: UICollectionViewCell {
 public extension CornerDesignable where Self: UIView {
   public func configureCornerRadius() {
     if !cornerRadius.isNaN && cornerRadius > 0 {
-      if cornerSides == .AllSides {
+      if cornerSides == .allSides {
         layer.cornerRadius = cornerRadius
       } else {
         layer.cornerRadius = 0.0
@@ -69,16 +69,16 @@ public extension CornerDesignable where Self: UIView {
     let cornerRadii = CGSize(width: cornerRadius, height: cornerRadius)
 
     var roundingCorners: UIRectCorner = []
-    if cornerSides.contains(.topleft) {
+    if cornerSides.contains(.topLeft) {
       roundingCorners.insert(.topLeft)
     }
-    if cornerSides.contains(.topright) {
+    if cornerSides.contains(.topRight) {
       roundingCorners.insert(.topRight)
     }
-    if cornerSides.contains(.bottomleft) {
+    if cornerSides.contains(.bottomLeft) {
       roundingCorners.insert(.bottomLeft)
     }
-    if cornerSides.contains(.bottomright) {
+    if cornerSides.contains(.bottomRight) {
       roundingCorners.insert(.bottomRight)
     }
 

--- a/IBAnimatable/CornerSide.swift
+++ b/IBAnimatable/CornerSide.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 public enum CornerSide: String {
-  case topleft
-  case topright
-  case bottomleft
-  case bottomright
+  case topLeft = "topleft"
+  case topRight = "topright"
+  case bottomLeft = "bottomleft"
+  case bottomRight = "bottomright"
 }
 
 public struct CornerSides: OptionSet {
@@ -20,10 +20,10 @@ public struct CornerSides: OptionSet {
 
   public static let unknown = CornerSides(rawValue: 0)
 
-  public static let topleft = CornerSides(rawValue: 1)
-  public static let topright = CornerSides(rawValue: 1 << 1)
-  public static let bottomleft = CornerSides(rawValue: 1 << 2)
-  public static let bottomright = CornerSides(rawValue: 1 << 3)
+  public static let topLeft = CornerSides(rawValue: 1)
+  public static let topRight = CornerSides(rawValue: 1 << 1)
+  public static let bottomLeft = CornerSides(rawValue: 1 << 2)
+  public static let bottomRight = CornerSides(rawValue: 1 << 3)
 
   public static let AllSides: CornerSides = [.topleft, .topright, .bottomleft, .bottomright]
 
@@ -57,10 +57,10 @@ public struct CornerSides: OptionSet {
     }
 
     switch side {
-    case .topleft: self = .topleft
-    case .topright: self = .topright
-    case .bottomleft: self = .bottomleft
-    case .bottomright: self = .bottomright
+    case .topLeft: self = .topLeft
+    case .topRight: self = .topRight
+    case .bottomLeft: self = .bottomLeft
+    case .bottomRight: self = .bottomRight
     }
   }
 }

--- a/IBAnimatable/CornerSide.swift
+++ b/IBAnimatable/CornerSide.swift
@@ -25,7 +25,7 @@ public struct CornerSides: OptionSet {
   public static let bottomLeft = CornerSides(rawValue: 1 << 2)
   public static let bottomRight = CornerSides(rawValue: 1 << 3)
 
-  public static let AllSides: CornerSides = [.topleft, .topright, .bottomleft, .bottomright]
+  public static let allSides: CornerSides = [.topLeft, .topRight, .bottomLeft, .bottomRight]
 
   public init(rawValue: Int) {
     self.rawValue = rawValue
@@ -33,7 +33,7 @@ public struct CornerSides: OptionSet {
 
   init(rawValue: String?) {
     guard let rawValue = rawValue, !rawValue.isEmpty else {
-      self = .AllSides
+      self = .allSides
       return
     }
 
@@ -43,7 +43,7 @@ public struct CornerSides: OptionSet {
       .map { CornerSides(side: $0) }
 
     guard !sideElements.contains(.unknown) else {
-      self = .AllSides
+      self = .allSides
       return
     }
 

--- a/IBAnimatableApp/CornerViewController.swift
+++ b/IBAnimatableApp/CornerViewController.swift
@@ -22,13 +22,13 @@ class CornerViewController: UIViewController {
 
     switch sender {
     case topLeftCheckBox:
-      corner = .topleft
+      corner = .topLeft
     case topRightCheckBox:
-      corner = .topright
+      corner = .topRight
     case bottomLeftCheckBox:
-      corner = .bottomleft
+      corner = .bottomLeft
     case bottomRightCheckBox:
-      corner = .bottomright
+      corner = .bottomRight
     default:
       return
     }


### PR DESCRIPTION
Follow up of #408 

Also introducing a new breaking change, a leftover from the swift3 migration: `.AllSides` -> `.allSides`.

I think that one is ok since it's already the default value, users can just remove the set for most of the cases by setting a simple `cornerRadius`.

Does that seem ok to you? Should I revert that commit?