### PR TITLE
Allow to set a background image to table view and cells views

### DIFF
--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
 		AEE552B11C839EB7009CF623 /* TransitionPresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* TransitionPresenterManager.swift */; };
 		AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */; };
+		C4B4AD551E8645FD007A79A4 /* BackgroundImageDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		E20027171D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20027161D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift */; };
@@ -310,6 +311,7 @@
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		AEEF86BD1CA8E9E200899AAB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Playground.storyboard; sourceTree = "<group>"; };
+		C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundImageDesignable.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -740,6 +742,7 @@
 				AE81DB4F1C12E060000AEB20 /* RotationDesignable.swift */,
 				AED1A1111BFE983A001346FA /* ShadowDesignable.swift */,
 				AE74D6D61C166FB100718E0E /* SideImageDesignable.swift */,
+				C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */,
 				AE0FADAA1C20357C00B5289B /* StatusBarDesignable.swift */,
 				AE0B0FE91C25372200E36B78 /* TableViewCellDesignable.swift */,
 				AE299BDB1C03BB670018CCDC /* TintDesignable.swift */,
@@ -1156,6 +1159,7 @@
 				E28E282C1D6CCA5C0043D56E /* ActivityIndicatorAnimationBallScaleMultiple.swift in Sources */,
 				AE677B991CADCF6500D62273 /* SystemCameraIrisAnimator.swift in Sources */,
 				E299DF5C1CD6067C00EC30D4 /* PresentCardsSegue.swift in Sources */,
+				C4B4AD551E8645FD007A79A4 /* BackgroundImageDesignable.swift in Sources */,
 				731205811D28A3830009BCAC /* Utils.swift in Sources */,
 				E2E62B7B1D69B23E00294A73 /* ActivityIndicatorAnimatable.swift in Sources */,
 				E210ABC61D3A9713001D0362 /* AnimatedPresenting.swift in Sources */,

--- a/IBAnimatable/AnimatableCollectionViewCell.swift
+++ b/IBAnimatable/AnimatableCollectionViewCell.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 @IBDesignable
-open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable, FillDesignable, BorderDesignable, ShadowDesignable, TableViewCellDesignable, GradientDesignable, Animatable {
+open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable, FillDesignable, BorderDesignable, ShadowDesignable, TableViewCellDesignable, GradientDesignable, BackgroundImageDesignable, Animatable {
 
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
@@ -128,6 +128,13 @@ open class AnimatableCollectionViewCell: UICollectionViewCell, CornerDesignable,
   @IBInspectable var _startPoint: String? {
     didSet {
       startPoint = GradientStartPoint(string: _startPoint, default: .top)
+    }
+  }
+
+  // MARK: - BackgroundImageDesignable
+  @IBInspectable open var backgroundImage: UIImage? {
+    didSet {
+      configureBackgroundImage()
     }
   }
 

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 @IBDesignable
-open class AnimatableTableView: UITableView, FillDesignable, BorderDesignable, GradientDesignable, Animatable {
+open class AnimatableTableView: UITableView, FillDesignable, BorderDesignable, GradientDesignable, BackgroundImageDesignable, BlurDesignable, Animatable {
 
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
@@ -81,6 +81,42 @@ open var startPoint: GradientStartPoint = .top
   @IBInspectable var _startPoint: String? {
     didSet {
       startPoint = GradientStartPoint(string: _startPoint, default: .top)
+    }
+  }
+
+  // MARK: - BackgroundImageDesignable
+  @IBInspectable open var backgroundImage: UIImage? {
+    didSet {
+      configureBackgroundImage()
+      configureBackgroundBlurEffectStyle()
+    }
+  }
+
+  // MARK: - BlurDesignable
+  open var blurEffectStyle: UIBlurEffectStyle? {
+    didSet {
+      configureBackgroundBlurEffectStyle()
+    }
+  }
+  @IBInspectable var _blurEffectStyle: String? {
+    didSet {
+      blurEffectStyle = UIBlurEffectStyle(string: _blurEffectStyle)
+    }
+  }
+  open var vibrancyEffectStyle: UIBlurEffectStyle? {
+    didSet {
+      configureBackgroundBlurEffectStyle()
+    }
+  }
+  @IBInspectable var _vibrancyEffectStyle: String? {
+    didSet {
+      vibrancyEffectStyle = UIBlurEffectStyle(string: _vibrancyEffectStyle)
+    }
+  }
+
+  @IBInspectable open var blurOpacity: CGFloat = CGFloat.nan {
+    didSet {
+      configureBackgroundBlurEffectStyle()
     }
   }
 

--- a/IBAnimatable/AnimatableTableViewCell.swift
+++ b/IBAnimatable/AnimatableTableViewCell.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 @IBDesignable
-open class AnimatableTableViewCell: UITableViewCell, CornerDesignable, FillDesignable, BorderDesignable, TableViewCellDesignable, GradientDesignable, Animatable {
+open class AnimatableTableViewCell: UITableViewCell, CornerDesignable, FillDesignable, BorderDesignable, TableViewCellDesignable, GradientDesignable, BackgroundImageDesignable, Animatable {
 
   // MARK: - CornerDesignable
   @IBInspectable open var cornerRadius: CGFloat = CGFloat.nan {
@@ -103,6 +103,13 @@ open var startPoint: GradientStartPoint = .top
   @IBInspectable var _startPoint: String? {
     didSet {
       startPoint = GradientStartPoint(string: _startPoint, default: .top)
+    }
+  }
+
+  // MARK: - BackgroundImageDesignable
+  @IBInspectable open var backgroundImage: UIImage? {
+    didSet {
+      configureBackgroundImage()
     }
   }
 

--- a/IBAnimatable/BackgroundImageDesignable.swift
+++ b/IBAnimatable/BackgroundImageDesignable.swift
@@ -1,0 +1,61 @@
+//
+//  Created by phimage on 25/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+
+/// Protocol for designing background image
+public protocol BackgroundImageDesignable {
+
+  /**
+   * The background image
+   */
+  var backgroundImage: UIImage? { get set }
+
+}
+
+/// Protocol for designing background
+public protocol BackgroundDesignable: class {
+
+  /**
+   * The background view
+   */
+  var backgroundView: UIView? { get set }
+
+}
+
+extension UITableViewCell: BackgroundDesignable {}
+extension UITableViewHeaderFooterView: BackgroundDesignable {}
+extension UITableView: BackgroundDesignable {}
+extension UICollectionViewCell: BackgroundDesignable {}
+extension UICollectionView: BackgroundDesignable {}
+
+fileprivate typealias BackgroundImageView = AnimatableImageView
+
+public extension BackgroundImageDesignable where Self: BackgroundDesignable {
+  public func configureBackgroundImage() {
+    if let image = backgroundImage {
+      if let imageView = self.backgroundView as? AnimatableImageView {
+        imageView.image = image
+      } else {
+        backgroundView = BackgroundImageView(image: image)
+      }
+    } else {
+      if self.backgroundView is BackgroundImageView {
+        backgroundView = nil
+      }
+    }
+  }
+
+  public var backgroundImageView: UIImageView? {
+    get {
+      return self.backgroundView as? UIImageView
+    }
+    set {
+      self.backgroundView = newValue
+    }
+  }
+}

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -28,11 +28,14 @@ public extension BlurDesignable where Self: UIView {
    configureBlurEffectStyle method, should be called in layoutSubviews() method
    */
   public func configureBlurEffectStyle() {
+    configureBlurEffectStyle(self)
+  }
+  public func configureBlurEffectStyle(_ blurableView: UIView) {
     // Used for caching the previous visual effect view
     var privateVisualEffectView: PrivateVisualEffectView?
 
     // Remove the existing visual effect view
-    subviews.flatMap { $0 as? PrivateVisualEffectView }
+    blurableView.subviews.flatMap { $0 as? PrivateVisualEffectView }
       .forEach {
         privateVisualEffectView = $0 // Cache it for the subviews
         $0.removeFromSuperview()
@@ -48,7 +51,7 @@ public extension BlurDesignable where Self: UIView {
     if let vibrancyEffectStyle = vibrancyEffectStyle {
       let blurEffectStyleForVibrancy = UIBlurEffect(style: vibrancyEffectStyle)
       let vibrancyEffectView = makeVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffectStyleForVibrancy))
-      subviews.forEach {
+      blurableView.subviews.forEach {
         vibrancyEffectView.contentView.addSubview($0)
       }
 
@@ -60,11 +63,11 @@ public extension BlurDesignable where Self: UIView {
     } else {
       // If privateVisualEffectView is not `nil`, re-add them back to the subviews of original UI element.
       privateVisualEffectView?.contentView.subviews.forEach {
-        addSubview($0)
+        blurableView.addSubview($0)
       }
     }
 
-    insertSubview(blurEffectView, at: 0)
+    blurableView.insertSubview(blurEffectView, at: 0)
   }
 }
 
@@ -80,6 +83,24 @@ private extension BlurDesignable where Self: UIView {
     visualEffectView.frame = bounds
     visualEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     return visualEffectView
+  }
+}
+
+public extension BlurDesignable where Self: UITableView {
+  public func configureBackgroundBlurEffectStyle() {
+    guard let blurableView = backgroundView else {
+      self.separatorEffect = nil
+      return
+    }
+    configureBlurEffectStyle(blurableView)
+    guard let blurEffectStyle = blurEffectStyle else {
+      return
+    }
+    if let style = vibrancyEffectStyle {
+      self.separatorEffect = UIVibrancyEffect(blurEffect: UIBlurEffect(style: style))
+    } else {
+      self.separatorEffect = UIBlurEffect(style: blurEffectStyle)
+    }
   }
 }
 


### PR DESCRIPTION
i.e. view with `backgroundView` attribute
Add also `BlurDesignable` to table view to blur the `backgroundView`


- A lot of time I need to put a background image on this ui components without adding a specific `UIImageView`. With the same principle of `BlurDesignable` a view is added. But this time not in subviews hierarchy, with crapping things like scroll view, etc... but the special attribute  `backgroundView`

- to see background of a table, each cell view must be configured with clear color (or some transparency )

- `UICollectionView` could also conform to `BackgroundImageDesignable` but there is no `AnimatableCollectionView` yet, any reason? 

- I must edit the change log on my own? could be weird with conflicts when there is multiple PR