### PR TITLE
Make AnimatableSlider inherit from UISlider and add designable images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ All notable changes to this project will be documented in this file.
 
 #### API breaking changes
 - `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programatically a cornerSide to your view, you will just have to lowercase the A. [#409](https://github.com/IBAnimatable/IBAnimatable/pull/409) by [@tbaranes](https://github.com/tbaranes)
+- `AnimatableSlider` inherit from `UISlider`
 
 #### Enhancements
 - Conserve custom layer mask when using `Animatable*` instead of removing them
 [#407](https://github.com/IBAnimatable/IBAnimatable/pull/407) by [@DanielAsher](https://github.com/DanielAsher)
 - Add support for corner on AnimatableTableViewCell.
-[#368](https://github.com/IBAnimatable/IBAnimatable/pull/403) by [@tbaranes](https://github.com/tbaranes)
+[#403](https://github.com/IBAnimatable/IBAnimatable/pull/403) by [@tbaranes](https://github.com/tbaranes)
+- Make images of `AnimatableSlider` designable.
+[#417](https://github.com/IBAnimatable/IBAnimatable/pull/417) by [@phimage](https://github.com/phimage)
+
 
 #### Bugfixes
 - Make corner sides case insensitive.
@@ -160,7 +164,7 @@ None
 #### Enhancements
 
 - Add `vibrancyBlurEffect` to `BlurDesignable`. Once specify the Vibrancy effect style, all subviews will apply this vibrancy effect [#245](https://github.com/IBAnimatable/IBAnimatable/pull/245)
-- New animations: `ZoomInvertIn` and ``ZoomInvertOut` [#249](https://github.com/IBAnimatable/IBAnimatable/pull/249)
+- New animations: `ZoomInvertIn` and `ZoomInvertOut` [#249](https://github.com/IBAnimatable/IBAnimatable/pull/249)
 
 #### Bugfixes
 None
@@ -188,7 +192,7 @@ None
 
 - Change `PanFromLeft`, `PanFromRight`, `PanFromTop`, `PanFromBottom`, `PanHorizontally` and `PanVertically` to `Pan(Left)`, `Pan(Right)`, `Pan(Top)`, `Pan(Bottom)`, `Pan(Horizontal)` and `Pan(Vertical)` for `Pan` gesture transition controller. [#125](https://github.com/IBAnimatable/IBAnimatable/issues/125)
 - Refactor `direction` to `fromDirection` for system transition animators.  Refactor `TransitionFromDirection` to `TransitionDirection`. [#206](https://github.com/IBAnimatable/IBAnimatable/pull/206)
-- Refactor `Fade`, `FadeIn` and `FadeOut` to `Fade(direction: TransitionDirection)` in `TransitionAnimationType`. Use `Fade(In)` to replace `FadeIn` and use `Fade(Out) to replace `FadeOut`.[#209](https://github.com/IBAnimatable/IBAnimatable/pull/209)
+- Refactor `Fade`, `FadeIn` and `FadeOut` to `Fade(direction: TransitionDirection)` in `TransitionAnimationType`. Use `Fade(In)` to replace `FadeIn` and use `Fade(Out)` to replace `FadeOut`.[#209](https://github.com/IBAnimatable/IBAnimatable/pull/209)
 - Remove `PresentFadeInSegue`, `PresentFadeInWithDismissInteractionSegue`, `PresentFadeOutSegue` and `PresentFadeOutWithDismissInteractionSegue`, use  `PresentFadeSegue` and `PresentFadeWithDismissInteractionSegue` instead. [#209](https://github.com/IBAnimatable/IBAnimatable/pull/209)
 - Remove `degree` for `SystemRotate` since it only supports 90 degrees. [#210](https://github.com/IBAnimatable/IBAnimatable/pull/210)
 

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
 		AEE552B11C839EB7009CF623 /* TransitionPresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* TransitionPresenterManager.swift */; };
 		AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */; };
+		C47A737C1E86A9BD0044EFF8 /* SliderImagesDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		E20027171D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20027161D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift */; };
@@ -310,6 +311,7 @@
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		AEEF86BD1CA8E9E200899AAB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Playground.storyboard; sourceTree = "<group>"; };
+		C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderImagesDesignable.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -745,6 +747,7 @@
 				AE299BDB1C03BB670018CCDC /* TintDesignable.swift */,
 				AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */,
 				E21E840F1D3A36C600C742E7 /* PresentationDesignable.swift */,
+				C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */,
 			);
 			name = Designable;
 			sourceTree = "<group>";
@@ -1139,6 +1142,7 @@
 				E29F35101CDF6C5400312FD4 /* PresentSlideWithDismissInteractionSegue.swift in Sources */,
 				AE6B016B1C2A444900950BB2 /* CornerDesignable.swift in Sources */,
 				E28E28401D6CCB5F0043D56E /* ActivityIndicatorAnimationBallBeat.swift in Sources */,
+				C47A737C1E86A9BD0044EFF8 /* SliderImagesDesignable.swift in Sources */,
 				E28E283A1D6CCA5C0043D56E /* ActivityIndicatorAnimationSemiCircleSpin.swift in Sources */,
 				AE6B01631C2A444000950BB2 /* BlurEffectStyle.swift in Sources */,
 				AE6B016E1C2A444900950BB2 /* NavigationBarDesginable.swift in Sources */,

--- a/IBAnimatable/AnimatableSlider.swift
+++ b/IBAnimatable/AnimatableSlider.swift
@@ -6,7 +6,45 @@
 import UIKit
 
 @IBDesignable
-open class AnimatableSlider: UIView, BorderDesignable, RotationDesignable, ShadowDesignable, Animatable {
+open class AnimatableSlider: UISlider, SliderImagesDesignable, BorderDesignable, RotationDesignable, ShadowDesignable, Animatable {
+
+  // MARK: - SliderImagesDesignable
+
+  @IBInspectable open var thumbImage: UIImage? {
+    didSet {
+      configureThumbImage()
+    }
+  }
+
+  @IBInspectable open var thumbHighlightedImage: UIImage? {
+    didSet {
+      configureThumbImage()
+    }
+  }
+
+  @IBInspectable open var minimumTrackImage: UIImage? {
+    didSet {
+      configureMinimumTrackImage()
+    }
+  }
+
+  @IBInspectable open var minimumTrackHighlightedImage: UIImage? {
+    didSet {
+      configureMinimumTrackImage()
+    }
+  }
+
+  @IBInspectable open var maximumTrackImage: UIImage? {
+    didSet {
+      configureMaximumTrackImage()
+    }
+  }
+
+  @IBInspectable open var maximumTrackHighlightedImage: UIImage? {
+    didSet {
+      configureMaximumTrackImage()
+    }
+  }
 
   // MARK: - BorderDesignable
   open var borderType: BorderType  = .solid {

--- a/IBAnimatable/SliderImagesDesignable.swift
+++ b/IBAnimatable/SliderImagesDesignable.swift
@@ -42,32 +42,32 @@ public protocol SliderImagesDesignable {
 
 }
 
-extension SliderImagesDesignable where Self: UISlider {
+public extension SliderImagesDesignable where Self: UISlider {
 
   func configureThumbImage() {
-    self.setThumbImage(thumbImage, for: .normal)
+    setThumbImage(thumbImage, for: .normal)
     if let highlighted = thumbHighlightedImage {
-      self.setThumbImage(highlighted, for: .highlighted)
+      setThumbImage(highlighted, for: .highlighted)
     } else {
-      self.setThumbImage(thumbImage, for: .highlighted)
+      setThumbImage(thumbImage, for: .highlighted)
     }
   }
 
   func configureMinimumTrackImage() {
-    self.setMinimumTrackImage(minimumTrackImage, for: .normal)
+    setMinimumTrackImage(minimumTrackImage, for: .normal)
     if let highlighted = minimumTrackHighlightedImage {
-      self.setMinimumTrackImage(highlighted, for: .highlighted)
+      setMinimumTrackImage(highlighted, for: .highlighted)
     } else {
-      self.setMinimumTrackImage(minimumTrackImage, for: .highlighted)
+      setMinimumTrackImage(minimumTrackImage, for: .highlighted)
     }
   }
 
   func configureMaximumTrackImage() {
-    self.setMaximumTrackImage(maximumTrackImage, for: .normal)
+    setMaximumTrackImage(maximumTrackImage, for: .normal)
     if let highlighted = maximumTrackHighlightedImage {
-      self.setMaximumTrackImage(highlighted, for: .highlighted)
+      setMaximumTrackImage(highlighted, for: .highlighted)
     } else {
-      self.setMaximumTrackImage(maximumTrackImage, for: .highlighted)
+      setMaximumTrackImage(maximumTrackImage, for: .highlighted)
     }
   }
 

--- a/IBAnimatable/SliderImagesDesignable.swift
+++ b/IBAnimatable/SliderImagesDesignable.swift
@@ -1,0 +1,74 @@
+//
+//  Created by phimage on 25/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+
+/// Protocol for designing slider image
+public protocol SliderImagesDesignable {
+
+  /**
+   * The thumb image when slider state is `normal`
+   */
+  var thumbImage: UIImage? { get set }
+
+  /**
+   * The thumb image when slider state is `highlighted`
+   */
+  var thumbHighlightedImage: UIImage? { get set }
+
+  /**
+   * The minimum track image when slider state is `normal`
+   */
+  var minimumTrackImage: UIImage? { get set }
+
+  /**
+   * The minimum track image when slider state is `highlighted`
+   */
+  var minimumTrackHighlightedImage: UIImage? { get set }
+
+  /**
+   * The maximum track image when slider state is `normal`
+   */
+  var maximumTrackImage: UIImage? { get set }
+
+  /**
+   * The maximum track image when slider state is `highlighted`
+   */
+  var maximumTrackHighlightedImage: UIImage? { get set }
+
+}
+
+extension SliderImagesDesignable where Self: UISlider {
+
+  func configureThumbImage() {
+    self.setThumbImage(thumbImage, for: .normal)
+    if let highlighted = thumbHighlightedImage {
+      self.setThumbImage(highlighted, for: .highlighted)
+    } else {
+      self.setThumbImage(thumbImage, for: .highlighted)
+    }
+  }
+
+  func configureMinimumTrackImage() {
+    self.setMinimumTrackImage(minimumTrackImage, for: .normal)
+    if let highlighted = minimumTrackHighlightedImage {
+      self.setMinimumTrackImage(highlighted, for: .highlighted)
+    } else {
+      self.setMinimumTrackImage(minimumTrackImage, for: .highlighted)
+    }
+  }
+
+  func configureMaximumTrackImage() {
+    self.setMaximumTrackImage(maximumTrackImage, for: .normal)
+    if let highlighted = maximumTrackHighlightedImage {
+      self.setMaximumTrackImage(highlighted, for: .highlighted)
+    } else {
+      self.setMaximumTrackImage(maximumTrackImage, for: .highlighted)
+    }
+  }
+
+}


### PR DESCRIPTION
`AnimatableSlider` do not extends `UISlider`, only `UIView`

thumb, minimum and maximum track images added has designable objects in storyboard


PS: 
I try some experiment on slider size by overriding `trackRect()`

```
 @IBInspectable var trackHeight: CGFloat = CGFloat.nan
    
    override func trackRect(forBounds bounds: CGRect) -> CGRect {
       // add here if not trackHeight.isNan
        return CGRect(origin: bounds.origin, size: CGSize(width:bounds.width, height:trackHeight))
    }
 // or
    override func trackRect(forBounds bounds: CGRect) -> CGRect {
       let rect = super.trackRect(forBounds: bounds)
       return ...
    }
```
There is some bug when using maximum and minimum images
to fix some other bugs in storyboard  I use in `trackRect()`
```

#if TARGET_INTERFACE_BUILDER
 // do some stuff to adjust storyboard
#endif
```
