### PR TITLE
Add `overCurrentContext` to `PresentationDesignable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 #### API breaking changes
 - `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programatically a cornerSide to your view, you will just have to lowercase the A. [#409](https://github.com/IBAnimatable/IBAnimatable/pull/409) by [@tbaranes](https://github.com/tbaranes)
 - `AnimatableSlider` inherit from `UISlider`
-- `PresentationDesignable` now supports `overCurrentScreen` which allow you to present a controller with a custom configuration over another instead of being in fullscreen.
+- `PresentationDesignable` now supports `contextFrameForPresentation` which allow you to present a controller with a custom configuration over another instead of being in fullscreen. Imitates `UIModalPresentationStyle.currentContext`
 
 #### Enhancements
 - Conserve custom layer mask when using `Animatable*` instead of removing them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### API breaking changes
 - `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programatically a cornerSide to your view, you will just have to lowercase the A. [#409](https://github.com/IBAnimatable/IBAnimatable/pull/409) by [@tbaranes](https://github.com/tbaranes)
 - `AnimatableSlider` inherit from `UISlider`
+- `PresentationDesignable` now supports `overCurrentScreen` which allow you to present a controller with a custom configuration over another instead of being in fullscreen.
 
 #### Enhancements
 - Conserve custom layer mask when using `Animatable*` instead of removing them

--- a/Documentation/Presentations.md
+++ b/Documentation/Presentations.md
@@ -15,7 +15,6 @@ Then we can configure the **Presentation Animations**, **Transition Duration** a
 
 | Property | Description |
 | ------------- | ------------- |
-| Over Current Context | If true, the presentation will have the same size as the controller doing the presentation. If false, the presentation will be in fullscreen. In both cases, the others parameters will be applied. |
 | Presentation Animation | The animation effect when *Present* a `ViewController`, you can find all supported transition animations in [Presentation Animators](#presentation-animators) section. |
 | Dismissal Animation | The animation effect when *Dismiss* a `ViewController`, you can find all supported transition animations in [Presentation Animators](#presentation-animators) section. By default, it will use the Presentation animation value. For example, if the Presentation animation is cover down from the top, then the default Dismissal Animation is cover up to the top. |
 | Transition Duration | The duration of the transition animation in seconds. The default value is `0.4` |
@@ -211,6 +210,40 @@ If your modal contains a `UITextField` or `UITextView`, you can adjust its posit
 ![Transition - Fade Transition](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/KeyboardTranslationAboveKeyboard.gif)
 
 You can see all supported Keyboard Translation in the demo App, open the App and tap on "Playground" button, then tap on "presentations", then play with the different options.
+
+## Presenting over current context
+
+Using the above configuration, you can't have the same result as using `UIModalPresentationStyle.currentContext`, but `IBAnimatable` have a workaround to support it while supporting *all the above customisation*.
+
+That can be useful in a few cases, for example: having a split view controller, but you may want to present a controller over the first one, and let the second one clickable. You can see an example in the demo app: Playground -> Presentation -> Over context.
+
+![Presentation - Over Current Context](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/PresentationOverCurrentContext.gif)
+
+### Using storyboards and segues
+
+In order to use this feature in storyboards, you have to use a custom segue. To use custom Segue, we can **control drag** from one `ViewController` to another `ViewController`, then select a custom Segue and set its class to `PresentOverCurrentContextSegue`.
+
+Using that usage allow you to use all the features of a custom presentation while writing 0 lines of code.
+
+You can see an example in "Presentation.storyboard".
+
+### Programatically
+
+For this special case, `AnimatableModalViewController` has another property that's not designable:
+
+| Property | Description |
+| ------------- | ------------- |
+| context frame for presentation | If not nil, the presented view controller will have use this frame, imitates `UIModalPresentationStyle.currentContext`  If nil, the presented view controller will be in fullscreen. *Note:* The modal position / size will be calculated based on this if not nil. |
+
+Anywhere before `presenting` your viewController, just set the `contextFrameForPresentation` that it should have.
+For example, if you want your presented view controller to have the same frame as the `viewController` presenting it, you will just have to do:
+
+```
+modalViewController.contextFrameForPresentation = presentingVC.view.frame
+modalViewController.present(presentingVC, animated: true)
+```
+
+That's all. You have presented a controller over the current context with a custom configuration!
 
 ## Contribution
 

--- a/Documentation/Presentations.md
+++ b/Documentation/Presentations.md
@@ -15,6 +15,7 @@ Then we can configure the **Presentation Animations**, **Transition Duration** a
 
 | Property | Description |
 | ------------- | ------------- |
+| Over Current Context | If true, the presentation will have the same size as the controller doing the presentation. If false, the presentation will be in fullscreen. In both cases, the others parameters will be applied. |
 | Presentation Animation | The animation effect when *Present* a `ViewController`, you can find all supported transition animations in [Presentation Animators](#presentation-animators) section. |
 | Dismissal Animation | The animation effect when *Dismiss* a `ViewController`, you can find all supported transition animations in [Presentation Animators](#presentation-animators) section. By default, it will use the Presentation animation value. For example, if the Presentation animation is cover down from the top, then the default Dismissal Animation is cover up to the top. |
 | Transition Duration | The duration of the transition animation in seconds. The default value is `0.4` |

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		E27691EB1CAFC91A004A725C /* SystemPushAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */; };
 		E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */; };
 		E27691F31CAFCD67004A725C /* SystemRotateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */; };
+		E28760EA1E8D0BDE003B324E /* PresentOverCurrentContextSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28760E91E8D0BDE003B324E /* PresentOverCurrentContextSegue.swift */; };
 		E28E28211D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28051D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift */; };
 		E28E28221D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28061D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift */; };
 		E28E28231D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28071D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift */; };
@@ -354,6 +355,7 @@
 		E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPushAnimator.swift; sourceTree = "<group>"; };
 		E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRevealAnimator.swift; sourceTree = "<group>"; };
 		E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRotateAnimator.swift; sourceTree = "<group>"; };
+		E28760E91E8D0BDE003B324E /* PresentOverCurrentContextSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentOverCurrentContextSegue.swift; sourceTree = "<group>"; };
 		E28E28051D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationAudioEqualizer.swift; sourceTree = "<group>"; };
 		E28E28061D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallClipRotate.swift; sourceTree = "<group>"; };
 		E28E28071D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallClipRotateMultiple.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 			isa = PBXGroup;
 			children = (
 				AE0FAD3C1C1ED1EC00B5289B /* DismissSegue.swift */,
+				E28760E91E8D0BDE003B324E /* PresentOverCurrentContextSegue.swift */,
 				AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */,
 				AE65CF911C96E35600A723F8 /* PresentFadeWithDismissInteractionSegue.swift */,
 				E20078A21CB912E1002B2C16 /* PresentFoldSegue.swift */,
@@ -1078,6 +1081,7 @@
 				E20078A51CB91307002B2C16 /* PresentFoldWithDismissInteractionSegue.swift in Sources */,
 				E2A062B31CB19BB900C54B40 /* ExplodeAnimator.swift in Sources */,
 				AE65CF931C96E35600A723F8 /* PresentFadeWithDismissInteractionSegue.swift in Sources */,
+				E28760EA1E8D0BDE003B324E /* PresentOverCurrentContextSegue.swift in Sources */,
 				E28E282A1D6CCA5C0043D56E /* ActivityIndicatorAnimationBallRotateChase.swift in Sources */,
 				AE677B981CADCF5900D62273 /* SystemSuckEffectAnimator.swift in Sources */,
 				E28E28321D6CCA5C0043D56E /* ActivityIndicatorAnimationBallZigZagDeflect.swift in Sources */,

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		E24848AC1CDF65F7003DB9C2 /* SlideAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24848AB1CDF65F7003DB9C2 /* SlideAnimator.swift */; };
 		E25EC6E71CDE034300743DB8 /* ContainerTransitionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */; };
 		E2614B611D23C94300BBBAFA /* AnimatableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2614B601D23C94300BBBAFA /* AnimatableScrollView.swift */; };
+		E2623F8A1E8A98D6004FDFE2 /* PresentationBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2623F891E8A98D6004FDFE2 /* PresentationBackgroundView.swift */; };
 		E26B3EDA1CCD4C1D00BFD0AB /* NatGeoAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */; };
 		E26B3EDC1CCD579200BFD0AB /* PresentNatGeoSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */; };
 		E27691E91CAFC72C004A725C /* SystemMoveInAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */; };
@@ -346,6 +347,7 @@
 		E24848AB1CDF65F7003DB9C2 /* SlideAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideAnimator.swift; sourceTree = "<group>"; };
 		E25EC6E61CDE034300743DB8 /* ContainerTransitionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransitionViewController.swift; sourceTree = "<group>"; };
 		E2614B601D23C94300BBBAFA /* AnimatableScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableScrollView.swift; sourceTree = "<group>"; };
+		E2623F891E8A98D6004FDFE2 /* PresentationBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationBackgroundView.swift; sourceTree = "<group>"; };
 		E26B3ED91CCD4C1D00BFD0AB /* NatGeoAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NatGeoAnimator.swift; sourceTree = "<group>"; };
 		E26B3EDB1CCD579200BFD0AB /* PresentNatGeoSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentNatGeoSegue.swift; sourceTree = "<group>"; };
 		E27691E81CAFC72C004A725C /* SystemMoveInAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemMoveInAnimator.swift; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				AE154B051C787DDE0093C05B /* AnimatableNavigationController.swift */,
 				AE0FAD401C1ED41D00B5289B /* AnimatableViewController.swift */,
 				E21E840D1D3A31A900C742E7 /* AnimatablePresentationController.swift */,
+				E2623F891E8A98D6004FDFE2 /* PresentationBackgroundView.swift */,
 				E21E84091D3A30DF00C742E7 /* AnimatableModalViewController.swift */,
 			);
 			name = controller;
@@ -1125,6 +1128,7 @@
 				E2F45B571CDB845F001D2E37 /* FlipAnimator.swift in Sources */,
 				E28E283E1D6CCB550043D56E /* ActivityIndicatorAnimationBallPulseSync.swift in Sources */,
 				AE6B01791C2A444900950BB2 /* ViewControllerDesignable.swift in Sources */,
+				E2623F8A1E8A98D6004FDFE2 /* PresentationBackgroundView.swift in Sources */,
 				E28E28251D6CCA5C0043D56E /* ActivityIndicatorAnimationBallGridBeat.swift in Sources */,
 				AE6B01891C2A445C00950BB2 /* DismissSegue.swift in Sources */,
 				E222CDC81CC400FD00684CA0 /* PresentPortalSegue.swift in Sources */,

--- a/IBAnimatable/AnimatableModalViewController.swift
+++ b/IBAnimatable/AnimatableModalViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 open class AnimatableModalViewController: UIViewController, PresentationDesignable {
 
   // MARK: - AnimatablePresentationController
+  @IBInspectable public var overCurrentContext: Bool = false
+
   @IBInspectable var _presentationAnimationType: String? {
     didSet {
       if let animationType = PresentationAnimationType(string: _presentationAnimationType) {

--- a/IBAnimatable/AnimatableModalViewController.swift
+++ b/IBAnimatable/AnimatableModalViewController.swift
@@ -9,7 +9,11 @@ import UIKit
 open class AnimatableModalViewController: UIViewController, PresentationDesignable {
 
   // MARK: - AnimatablePresentationController
-  @IBInspectable public var overCurrentContext: Bool = false
+  public var contextFrameForPresentation: CGRect? {
+    didSet {
+      presenter?.presentationConfiguration?.contextFrameForPresentation = contextFrameForPresentation
+    }
+  }
 
   @IBInspectable var _presentationAnimationType: String? {
     didSet {

--- a/IBAnimatable/AnimatablePresentationController.swift
+++ b/IBAnimatable/AnimatablePresentationController.swift
@@ -12,6 +12,11 @@ public class AnimatablePresentationController: UIPresentationController {
 
   fileprivate let presentationConfiguration: PresentationConfiguration
   fileprivate var dimmingView = AnimatableView()
+  fileprivate var presentationBackgroundView = PresentationBackgroundView()
+
+  fileprivate var containerFrame: CGRect {
+    return presentationConfiguration.contextFrameForPresentation ?? containerView?.bounds ?? .zero
+  }
 
   // MARK: Init
 
@@ -21,9 +26,9 @@ public class AnimatablePresentationController: UIPresentationController {
     self.presentationConfiguration = presentationConfiguration
     super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
 
-    setupDimmingView()
-    setupPresentedView()
-    setupObservers()
+    configureDimmingView()
+    configurePresentedView()
+    makeObservers()
   }
 
   deinit {
@@ -33,7 +38,7 @@ public class AnimatablePresentationController: UIPresentationController {
 
   // MARK: Actions
 
-  func chromeViewTapped(gesture: UIGestureRecognizer) {
+  func dimmingViewTapped(gesture: UIGestureRecognizer) {
     if gesture.state == .ended && presentationConfiguration.dismissOnTap {
       presentingViewController.dismiss(animated: true, completion: nil)
     }
@@ -45,9 +50,12 @@ public class AnimatablePresentationController: UIPresentationController {
 
 private extension AnimatablePresentationController {
 
-  func setupDimmingView() {
-    let tap = UITapGestureRecognizer(target: self, action: #selector(chromeViewTapped))
+  func configureDimmingView() {
+    var tap = UITapGestureRecognizer(target: self, action: #selector(dimmingViewTapped))
     dimmingView.addGestureRecognizer(tap)
+    tap = UITapGestureRecognizer(target: self, action: #selector(dimmingViewTapped))
+    presentationBackgroundView.addGestureRecognizer(tap)
+
     if let blurEffectStyle = presentationConfiguration.blurEffectStyle {
       dimmingView.blurEffectStyle = blurEffectStyle
       dimmingView.blurOpacity = presentationConfiguration.blurOpacity
@@ -56,7 +64,7 @@ private extension AnimatablePresentationController {
     }
   }
 
-  func setupPresentedView() {
+  func configurePresentedView() {
     if presentationConfiguration.cornerRadius > 0 {
       presentedViewController.view.layer.cornerRadius = presentationConfiguration.cornerRadius
       presentedViewController.view.layer.masksToBounds = true
@@ -79,7 +87,7 @@ private extension AnimatablePresentationController {
 
 extension AnimatablePresentationController {
 
-  fileprivate func setupObservers() {
+  fileprivate func makeObservers() {
     guard presentationConfiguration.keyboardTranslation != .none else {
       return
     }
@@ -116,21 +124,14 @@ extension AnimatablePresentationController {
 private extension AnimatablePresentationController {
 
   func modalSize() -> CGSize {
-    guard let containerSize = containerView?.bounds.size else {
-      return CGSize.zero
-    }
-
+    let containerSize = containerFrame.size
     let width = CGFloat(presentationConfiguration.modalSize.0.width(parentSize: containerSize))
     let height = CGFloat(presentationConfiguration.modalSize.1.height(parentSize: containerSize))
     return CGSize(width: width, height: height)
   }
 
   func modalCenter() -> CGPoint? {
-    guard let containerBounds = containerView?.bounds else {
-      return nil
-    }
-
-    return presentationConfiguration.modalPosition.calculateCenter(containerBounds: containerBounds, modalSize: modalSize())
+    return presentationConfiguration.modalPosition.calculateCenter(containerBounds: containerFrame, modalSize: modalSize())
   }
 
   func modalOrigin() -> CGPoint? {
@@ -152,10 +153,7 @@ public extension AnimatablePresentationController {
   // MARK: Presentation
 
   public override var frameOfPresentedViewInContainerView: CGRect {
-    guard let containerBounds = containerView?.bounds else {
-      return CGRect.zero
-    }
-
+    let containerBounds = containerFrame
     var presentedViewFrame = CGRect.zero
     let sizeForChildContentContainer = size(forChildContentContainer: presentedViewController, withParentContainerSize: containerBounds.size)
     let origin: CGPoint
@@ -175,16 +173,21 @@ public extension AnimatablePresentationController {
   }
 
   override func containerViewWillLayoutSubviews() {
-    dimmingView.frame = containerView?.bounds ?? .zero
+    dimmingView.frame = containerFrame
     presentedView?.frame = frameOfPresentedViewInContainerView
   }
 
   // MARK: Animation
 
   override func presentationTransitionWillBegin() {
-    dimmingView.frame = containerView?.bounds ?? CGRect.zero
+    presentationBackgroundView.frame = containerView?.bounds ?? .zero
+    presentationBackgroundView.passthroughViews = presentingViewController.view.subviews
+    containerView?.insertSubview(presentationBackgroundView, at: 0)
+
+    dimmingView.frame = containerFrame
     dimmingView.alpha = 0.0
-    containerView?.insertSubview(dimmingView, at: 0)
+    containerView?.insertSubview(dimmingView, at: 1)
+
     if let coordinator = presentedViewController.transitionCoordinator {
       coordinator.animate(alongsideTransition: { _ in
         self.dimmingView.alpha = 1.0

--- a/IBAnimatable/AnimatablePresentationController.swift
+++ b/IBAnimatable/AnimatablePresentationController.swift
@@ -123,18 +123,18 @@ extension AnimatablePresentationController {
 
 private extension AnimatablePresentationController {
 
-  func modalSize() -> CGSize {
+  var modalSize: CGSize {
     let containerSize = containerFrame.size
     let width = CGFloat(presentationConfiguration.modalSize.0.width(parentSize: containerSize))
     let height = CGFloat(presentationConfiguration.modalSize.1.height(parentSize: containerSize))
     return CGSize(width: width, height: height)
   }
 
-  func modalCenter() -> CGPoint? {
-    return presentationConfiguration.modalPosition.calculateCenter(containerBounds: containerFrame, modalSize: modalSize())
+  var modalCenter: CGPoint? {
+    return presentationConfiguration.modalPosition.modalCenter(in: containerFrame, modalSize: modalSize)
   }
 
-  func modalOrigin() -> CGPoint? {
+  var modalOrigin: CGPoint? {
     return presentationConfiguration.modalPosition.calculateOrigin()
   }
 
@@ -157,10 +157,10 @@ public extension AnimatablePresentationController {
     var presentedViewFrame = CGRect.zero
     let sizeForChildContentContainer = size(forChildContentContainer: presentedViewController, withParentContainerSize: containerBounds.size)
     let origin: CGPoint
-    if let center = modalCenter() {
+    if let center = modalCenter {
       origin = calculateOrigin(center: center, size: sizeForChildContentContainer)
     } else {
-      origin = modalOrigin() ?? .zero
+      origin = modalOrigin ?? .zero
     }
 
     presentedViewFrame.size = sizeForChildContentContainer
@@ -169,7 +169,7 @@ public extension AnimatablePresentationController {
   }
 
   override func size(forChildContentContainer container: UIContentContainer, withParentContainerSize parentSize: CGSize) -> CGSize {
-    return modalSize()
+    return modalSize
   }
 
   override func containerViewWillLayoutSubviews() {

--- a/IBAnimatable/PresentOverCurrentContextSegue.swift
+++ b/IBAnimatable/PresentOverCurrentContextSegue.swift
@@ -1,0 +1,20 @@
+//
+//  PresentOverContextSegue.swift
+//  IBAnimatable
+//
+//  Created by Tom Baranes on 30/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+open class PresentOverCurrentContextSegue: UIStoryboardSegue {
+  open override func perform() {
+    if let modalVC = destination as? AnimatableModalViewController {
+      let correctedOrigin = source.view.convert(source.view.frame.origin, to: nil)
+      modalVC.contextFrameForPresentation = CGRect(origin: correctedOrigin,
+                                                   size: source.view.bounds.size)
+    }
+    source.present(destination, animated: true, completion: nil)
+  }
+}

--- a/IBAnimatable/PresentationBackgroundView.swift
+++ b/IBAnimatable/PresentationBackgroundView.swift
@@ -1,0 +1,30 @@
+//
+//  PassthroughBackgroundView.swift
+//  IBAnimatable
+//
+//  Created by Tom Baranes on 28/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+final class PresentationBackgroundView: UIView {
+
+  var passthroughViews: [UIView] = []
+
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    var view = super.hitTest(point, with: event)
+    guard view == self else {
+      return view
+    }
+
+    for passthroughView in passthroughViews {
+      view = passthroughView.hitTest(convert(point, to: passthroughView), with: event)
+      if view != nil {
+        break
+      }
+    }
+    return view
+  }
+
+}

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -11,6 +11,9 @@ public protocol PresentationDesignable: class {
 
   var presenter: PresentationPresenter? { get set }
 
+  /// Present over current context, imitates `UIModalPresentation.currentContext`. If true, the presentedVC will have the same frame as the presentingVC 
+  var overCurrentContext: Bool { get set }
+
   /// Presentation animation type, all supported animation type can be found in `PresentationAnimationType`
   var presentationAnimationType: PresentationAnimationType { get set }
 
@@ -74,6 +77,13 @@ public extension PresentationDesignable where Self: UIViewController {
     }
 
     var presentationConfiguration = PresentationConfiguration()
+
+    presentationConfiguration.contextFrameForPresentation = CGRect(origin: .zero, size: CGSize(width: 300, height: 300))
+//    if overCurrentContext {
+//      let correctedOrigin = view.convert(view.frame.origin, to: nil)
+//      presentationConfiguration.contextFrameForPresentation = CGRect(origin: correctedOrigin, size: view.bounds.size)
+//    }
+
     presentationConfiguration.modalPosition = modalPosition
     presentationConfiguration.modalSize = modalSize
     presentationConfiguration.cornerRadius = cornerRadius
@@ -116,4 +126,5 @@ public struct PresentationConfiguration {
   public var modalPosition: PresentationModalPosition = .center
   public var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   public var keyboardTranslation = ModalKeyboardTranslation.none
+  public var contextFrameForPresentation: CGRect?
 }

--- a/IBAnimatable/PresentationDesignable.swift
+++ b/IBAnimatable/PresentationDesignable.swift
@@ -11,8 +11,8 @@ public protocol PresentationDesignable: class {
 
   var presenter: PresentationPresenter? { get set }
 
-  /// Present over current context, imitates `UIModalPresentation.currentContext`. If true, the presentedVC will have the same frame as the presentingVC 
-  var overCurrentContext: Bool { get set }
+  /// Frame of the presentingVC's dimmingView. Used that property if you want to simulate a presentation `overCurrentContext`. If nil, the dimmingView will be in fullscreen.
+  var contextFrameForPresentation: CGRect? { get set }
 
   /// Presentation animation type, all supported animation type can be found in `PresentationAnimationType`
   var presentationAnimationType: PresentationAnimationType { get set }
@@ -77,13 +77,7 @@ public extension PresentationDesignable where Self: UIViewController {
     }
 
     var presentationConfiguration = PresentationConfiguration()
-
-    presentationConfiguration.contextFrameForPresentation = CGRect(origin: .zero, size: CGSize(width: 300, height: 300))
-//    if overCurrentContext {
-//      let correctedOrigin = view.convert(view.frame.origin, to: nil)
-//      presentationConfiguration.contextFrameForPresentation = CGRect(origin: correctedOrigin, size: view.bounds.size)
-//    }
-
+    presentationConfiguration.contextFrameForPresentation = contextFrameForPresentation
     presentationConfiguration.modalPosition = modalPosition
     presentationConfiguration.modalSize = modalSize
     presentationConfiguration.cornerRadius = cornerRadius

--- a/IBAnimatable/PresentationModalPosition.swift
+++ b/IBAnimatable/PresentationModalPosition.swift
@@ -15,18 +15,20 @@ public enum PresentationModalPosition: IBEnum {
   case customCenter(centerPoint: CGPoint)
   case customOrigin(origin: CGPoint)
 
-  func calculateCenter(containerBounds: CGRect, modalSize: CGSize) -> CGPoint? {
+  func modalCenter(in containerFrame: CGRect, modalSize: CGSize) -> CGPoint? {
+    let xCenter = containerFrame.origin.x + (containerFrame.width / 2)
+    let yCenter = containerFrame.origin.y + (containerFrame.height / 2)
     switch self {
     case .center:
-      return CGPoint(x: containerBounds.width / 2, y: containerBounds.height / 2)
+      return CGPoint(x: xCenter, y: yCenter)
     case .topCenter:
-      return CGPoint(x: containerBounds.width / 2, y: modalSize.height / 2)
+      return CGPoint(x: xCenter, y: containerFrame.minY + (modalSize.height / 2))
     case .bottomCenter:
-      return CGPoint(x: containerBounds.width / 2, y: containerBounds.height - modalSize.height / 2)
+      return CGPoint(x: xCenter, y: containerFrame.maxY - (modalSize.height / 2))
     case .leftCenter:
-      return CGPoint(x: modalSize.width / 2, y: containerBounds.height / 2)
+      return CGPoint(x: containerFrame.minX + (modalSize.width / 2), y: yCenter)
     case .rightCenter:
-      return CGPoint(x: containerBounds.width - modalSize.width / 2, y: containerBounds.height / 2)
+      return CGPoint(x: containerFrame.maxX - (modalSize.width / 2), y: yCenter)
     case let .customCenter(point):
       return point
     case .customOrigin(_):
@@ -61,17 +63,17 @@ public extension PresentationModalPosition {
     let point = CGPoint(x: params[safe: 0]?.toDouble() ?? 0, y: params[safe: 1]?.toDouble() ?? 0)
 
     switch name {
-      case "center":
+    case "center":
       self = .center
-      case "topcenter":
+    case "topcenter":
       self = .topCenter
-      case "bottomcenter":
+    case "bottomcenter":
       self = .bottomCenter
-      case "leftcenter":
+    case "leftcenter":
       self = .leftCenter
-      case "rightcenter":
+    case "rightcenter":
       self = .rightCenter
-      case "customcenter" where params.count > 2:
+    case "customcenter" where params.count > 2:
       self = .customCenter(centerPoint: point)
     case "customorigin" where params.count > 2:
       self = .customOrigin(origin: point)
@@ -79,5 +81,5 @@ public extension PresentationModalPosition {
       self = .center
     }
   }
-
+  
 }

--- a/IBAnimatableApp/Presentations.storyboard
+++ b/IBAnimatableApp/Presentations.storyboard
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="obJ-z2-xGJ">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="7ad-nV-MlE">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,19 +22,24 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="MQO-iI-poj">
+                                <rect key="frame" x="32" y="111" width="336" height="178"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Here it is" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lEQ-H8-QWN">
+                                        <rect key="frame" x="0.0" y="0.0" width="336" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="uok-zb-hno">
+                                        <rect key="frame" x="0.0" y="68" width="336" height="110"/>
                                         <subviews>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uCG-fh-RxR">
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uPG-qM-hNx" userLabel="Dismiss button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                <rect key="frame" x="0.0" y="50" width="336" height="60"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="d5t-pE-Vhr"/>
                                                 </constraints>
@@ -74,9 +82,9 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WWi-iw-WFa" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="Y3r-Zl-Guu" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="5637" y="-402"/>
+            <point key="canvasLocation" x="5672" y="-560"/>
         </scene>
-        <!--Custom presentation-->
+        <!--Fullscreen-->
         <scene sceneID="PlL-YA-NUy">
             <objects>
                 <viewController id="obJ-z2-xGJ" customClass="PresentingViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -89,17 +97,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pQP-WM-PMb">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vLX-Al-x4t" userLabel="View - ContentView">
+                                        <rect key="frame" x="20" y="10" width="335" height="9741.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Setup your modal:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JxJ-Hh-Rol">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Configure your modal:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JxJ-Hh-Rol">
+                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="GI5-mZ-MEY" userLabel="Stack View - Basic Modal">
+                                                <rect key="frame" x="0.0" y="40.5" width="335" height="330"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pUB-gC-po6" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="YsC-hW-6Jr"/>
                                                         </constraints>
@@ -125,6 +138,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VtI-H2-dAf" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="70" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="NGk-M0-bK4"/>
                                                         </constraints>
@@ -155,6 +169,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gxt-Gf-235" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="140" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="qqh-99-naF"/>
                                                         </constraints>
@@ -185,6 +200,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0oe-As-5wm" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="210" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="XhJ-0V-Eb6"/>
                                                         </constraints>
@@ -215,6 +231,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T7G-lH-8tJ" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="280" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="PCH-wF-dKq"/>
                                                         </constraints>
@@ -247,26 +264,36 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="0BY-xg-wUS" userLabel="Stack View - DismissOnTap">
+                                                <rect key="frame" x="0.0" y="390.5" width="335" height="31"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dismiss on tap" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrk-qd-NJ2">
+                                                        <rect key="frame" x="0.0" y="6.5" width="286" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qEY-uz-c8O"/>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qEY-uz-c8O">
+                                                        <rect key="frame" x="286" y="0.0" width="51" height="31"/>
+                                                    </switch>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="lW2-QB-a6m" userLabel="Stack View - DimmingView">
+                                                <rect key="frame" x="0.0" y="441.5" width="335" height="3040"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Bv-o7-kgC" userLabel="View - Background color">
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Background color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dN0-SL-d1h">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="slider-colors" translatesAutoresizingMaskIntoConstraints="NO" id="ZbB-zJ-Dfg"/>
+                                                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="slider-colors" translatesAutoresizingMaskIntoConstraints="NO" id="ZbB-zJ-Dfg">
+                                                                <rect key="frame" x="0.0" y="25.5" width="335" height="974.5"/>
+                                                            </imageView>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.5" maxValue="13.5" translatesAutoresizingMaskIntoConstraints="NO" id="znU-mw-gGI">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <color key="minimumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <color key="maximumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <connections>
@@ -296,13 +323,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ahu-fn-J6H" userLabel="View - Opacity">
+                                                        <rect key="frame" x="0.0" y="1020" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Opacity (0.7)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vga-Oj-eVY">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.69999999999999996" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="o2d-za-oGW">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="opacityValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="EJ7-Sw-O0d"/>
                                                                 </connections>
@@ -326,13 +356,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="613-aL-7qy" userLabel="View - CornerRadius">
+                                                        <rect key="frame" x="0.0" y="2040" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Corner radius (10)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GZP-t9-T3f">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="10" minValue="0.0" maxValue="50" translatesAutoresizingMaskIntoConstraints="NO" id="6lR-UP-Rif">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="cornerRadiusValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="n8W-bl-hel"/>
                                                                 </connections>
@@ -358,8 +391,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="UO4-vG-mVJ" userLabel="Stack View - Blur">
+                                                <rect key="frame" x="0.0" y="3501.5" width="335" height="1070"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dw3-L3-qyf" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="e6u-X7-mFk"/>
                                                         </constraints>
@@ -390,13 +425,16 @@
                                                         </connections>
                                                     </button>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uyP-kF-sll" userLabel="View - Blur opacity">
+                                                        <rect key="frame" x="0.0" y="70" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur opacity (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l2N-IS-vZk">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="TkB-Ae-UyR">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="blurOpacityValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="ICd-7e-HCL"/>
                                                                 </connections>
@@ -422,16 +460,22 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="6DO-gh-4jc" userLabel="Stack View - Shadow">
+                                                <rect key="frame" x="0.0" y="4591.5" width="335" height="5080"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bgk-Yr-EBJ" userLabel="View - Shadow color">
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fb0-fm-2dF">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="slider-colors" translatesAutoresizingMaskIntoConstraints="NO" id="0n8-IU-IeJ"/>
+                                                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="slider-colors" translatesAutoresizingMaskIntoConstraints="NO" id="0n8-IU-IeJ">
+                                                                <rect key="frame" x="0.0" y="25.5" width="335" height="974.5"/>
+                                                            </imageView>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.5" maxValue="13.5" translatesAutoresizingMaskIntoConstraints="NO" id="xhS-EN-OHA">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <color key="minimumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <color key="maximumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <connections>
@@ -461,13 +505,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4fx-Bh-YjK" userLabel="View - Shadow opacity">
+                                                        <rect key="frame" x="0.0" y="1020" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow opacity (0,7)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f7l-9Q-bHd" userLabel="Shadow opacity (0,5)">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.69999999999999996" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="fBv-8c-olf">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="shadowOpacityValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="E23-f5-pLM"/>
                                                                 </connections>
@@ -491,13 +538,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nye-wT-PRS" userLabel="View - Shadow radius">
+                                                        <rect key="frame" x="0.0" y="2040" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow radius (6)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gK7-Ly-v1K">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="6" minValue="0.0" maxValue="50" translatesAutoresizingMaskIntoConstraints="NO" id="2cE-mb-5Qg">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="shadowRadiusValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="i0T-7c-3ml"/>
                                                                 </connections>
@@ -521,13 +571,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l8y-VH-a0j" userLabel="View - Shadow offset x">
+                                                        <rect key="frame" x="0.0" y="3060" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow offset X (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DIq-YS-BKW" userLabel="Shadow opacity (0,5)">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="10" translatesAutoresizingMaskIntoConstraints="NO" id="jfR-I3-Sv9">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="shadowOffsetXValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="bDo-oF-OMy"/>
                                                                 </connections>
@@ -551,13 +604,16 @@
                                                         </variation>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oNg-qP-svw" userLabel="View - Shadow offset y">
+                                                        <rect key="frame" x="0.0" y="4080" width="335" height="1000"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shadow offset Y (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ee-Xw-M7t" userLabel="Shadow opacity (0,5)">
+                                                                <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="10" translatesAutoresizingMaskIntoConstraints="NO" id="k69-Or-3S3">
+                                                                <rect key="frame" x="-2" y="25.5" width="339" height="975.5"/>
                                                                 <connections>
                                                                     <action selector="shadowOffsetYValueChanged:" destination="obJ-z2-xGJ" eventType="valueChanged" id="AOg-RL-MHK"/>
                                                                 </connections>
@@ -583,6 +639,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lTp-2g-Lnt" customClass="AnimatableButton" customModule="IBAnimatable">
+                                                <rect key="frame" x="0.0" y="9691.5" width="335" height="50"/>
                                                 <state key="normal" title="Present">
                                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -663,10 +720,13 @@
                                 </constraints>
                             </scrollView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zMo-DB-UiB" userLabel="View - Picker" customClass="AnimatableView" customModule="IBAnimatable">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nKa-KC-J0L" customClass="AnimatableView" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="343" width="375" height="260"/>
                                         <subviews>
                                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FOg-a5-Vlt">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                                 <items>
                                                     <barButtonItem style="done" systemItem="done" id="6Ow-cU-dWs">
                                                         <connections>
@@ -676,6 +736,7 @@
                                                 </items>
                                             </toolbar>
                                             <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PRB-qS-KKW">
+                                                <rect key="frame" x="0.0" y="44" width="375" height="216"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <connections>
                                                     <outlet property="dataSource" destination="obJ-z2-xGJ" id="9m1-1C-hah"/>
@@ -734,7 +795,7 @@
                         </userDefinedRuntimeAttributes>
                     </view>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="Custom presentation" id="tbn-5V-Gy7">
+                    <navigationItem key="navigationItem" title="Fullscreen" id="tbn-5V-Gy7">
                         <barButtonItem key="leftBarButtonItem" image="back" id="cic-Rh-aJC">
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
@@ -790,7 +851,277 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="4926.5" y="-281.5"/>
+            <point key="canvasLocation" x="4868" y="-582"/>
+        </scene>
+        <!--Presentations-->
+        <scene sceneID="1TT-Oe-G8q">
+            <objects>
+                <tableViewController clearsSelectionOnViewWillAppear="NO" id="7ad-nV-MlE" customClass="UserInterfaceTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="gSA-gB-Oug" customClass="AnimatableTableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="separatorColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <sections>
+                            <tableViewSection footerTitle="" id="70R-dO-jbN">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="ckt-yw-BW6" style="IBUITableViewCellStyleDefault" id="0r5-AV-A2W" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0r5-AV-A2W" id="xDY-3C-W5V">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Fullscreen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ckt-yw-BW6">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="obJ-z2-xGJ" kind="show" id="g6l-Rt-cN7"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="NZ6-zp-P1j" style="IBUITableViewCellStyleDefault" id="QBo-u7-pX5" userLabel="Mask" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QBo-u7-pX5" id="i6C-6w-z2c">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Over context" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NZ6-zp-P1j">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="ozi-sp-y4a" kind="show" id="Lqo-jh-5wO"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                        <connections>
+                            <outlet property="dataSource" destination="7ad-nV-MlE" id="0Rj-kf-xzr"/>
+                            <outlet property="delegate" destination="7ad-nV-MlE" id="K5P-YP-1iO"/>
+                        </connections>
+                    </tableView>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Presentations" id="Io4-Fg-1VV">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="JNM-bZ-0Qk">
+                            <color key="tintColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <segue destination="ryG-UD-gcD" kind="unwind" unwindAction="unwindToViewController:" id="uhE-hM-CC8"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="d6c-pQ-fWz" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="ryG-UD-gcD" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4017.5" y="-281.5"/>
+        </scene>
+        <!--Over context-->
+        <scene sceneID="mSX-DZ-woX">
+            <objects>
+                <viewController id="ozi-sp-y4a" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="MQr-ZT-YeY"/>
+                        <viewControllerLayoutGuide type="bottom" id="Bt1-Pk-gN5"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="qTw-Ac-uoZ" customClass="AnimatableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WD8-Nv-m8A">
+                                <rect key="frame" x="0.0" y="64" width="375" height="301.5"/>
+                                <connections>
+                                    <segue destination="1dm-2z-9gI" kind="embed" id="hVt-GK-f23"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YtF-iu-AUb">
+                                <rect key="frame" x="0.0" y="365.5" width="375" height="301.5"/>
+                                <connections>
+                                    <segue destination="d47-jK-71I" kind="embed" id="lBM-98-QaY"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="YtF-iu-AUb" firstAttribute="top" secondItem="WD8-Nv-m8A" secondAttribute="bottom" id="CPN-e1-Mch"/>
+                            <constraint firstAttribute="trailing" secondItem="WD8-Nv-m8A" secondAttribute="trailing" id="FBL-nK-2f1"/>
+                            <constraint firstItem="Bt1-Pk-gN5" firstAttribute="top" secondItem="YtF-iu-AUb" secondAttribute="bottom" id="SUF-jh-Zs7"/>
+                            <constraint firstItem="WD8-Nv-m8A" firstAttribute="top" secondItem="MQr-ZT-YeY" secondAttribute="bottom" id="c58-O1-n3v"/>
+                            <constraint firstItem="YtF-iu-AUb" firstAttribute="leading" secondItem="qTw-Ac-uoZ" secondAttribute="leading" id="gFq-6v-AwA"/>
+                            <constraint firstItem="WD8-Nv-m8A" firstAttribute="height" secondItem="YtF-iu-AUb" secondAttribute="height" id="ntc-fO-bau"/>
+                            <constraint firstAttribute="trailing" secondItem="YtF-iu-AUb" secondAttribute="trailing" id="qiS-6w-QWe"/>
+                            <constraint firstItem="WD8-Nv-m8A" firstAttribute="leading" secondItem="qTw-Ac-uoZ" secondAttribute="leading" id="ye9-AG-fMF"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <navigationItem key="navigationItem" title="Over context" id="SuB-hn-yt9">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="KV0-am-AJR">
+                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <segue destination="EQb-RC-yeg" kind="unwind" unwindAction="unwindToViewController:" id="Lew-G6-mih"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1v7-pt-3sX" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="EQb-RC-yeg" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4868" y="89.505247376311857"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="3Gb-go-mY3">
+            <objects>
+                <viewController id="1dm-2z-9gI" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Den-DD-xOx">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="301.5"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iqv-e8-dHb">
+                                <rect key="frame" x="161" y="136" width="53" height="30"/>
+                                <state key="normal" title="Present"/>
+                                <connections>
+                                    <segue destination="qdi-bw-dbA" kind="presentation" id="VIb-bL-vUS"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="0.64949758255897805" blue="0.73911788694637393" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="iqv-e8-dHb" firstAttribute="centerX" secondItem="Den-DD-xOx" secondAttribute="centerX" id="OoN-9s-dZB"/>
+                            <constraint firstItem="iqv-e8-dHb" firstAttribute="centerY" secondItem="Den-DD-xOx" secondAttribute="centerY" id="xoP-q4-MNn"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="eNL-DI-hWe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5652" y="-66"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="jZz-Gv-ZzW">
+            <objects>
+                <viewController id="d47-jK-71I" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ys6-pQ-cOD">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="301.5"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oFW-Uk-0cN">
+                                <rect key="frame" x="84.5" y="136" width="206" height="30"/>
+                                <state key="normal" title="Still clickable while presenting"/>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="0.99588788878065537" blue="0.84024466060884695" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="oFW-Uk-0cN" firstAttribute="centerX" secondItem="ys6-pQ-cOD" secondAttribute="centerX" id="7ee-7e-Shm"/>
+                            <constraint firstItem="oFW-Uk-0cN" firstAttribute="centerY" secondItem="ys6-pQ-cOD" secondAttribute="centerY" id="ykj-7y-axz"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="TuR-nu-2dh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5652" y="254"/>
+        </scene>
+        <!--Animatable Modal View Controller-->
+        <scene sceneID="79b-As-vFj">
+            <objects>
+                <viewController id="qdi-bw-dbA" customClass="AnimatableModalViewController" customModule="IBAnimatable" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="llR-4a-HSc"/>
+                        <viewControllerLayoutGuide type="bottom" id="X0l-KW-66j"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ElG-i8-3nL">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="9Vi-ji-WpQ">
+                                <rect key="frame" x="20" y="70" width="335" height="161"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Note that all the presentation parameters are also available when presenting over current context." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U72-tv-dXC">
+                                        <rect key="frame" x="8.5" y="0.0" width="318.5" height="61"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uK1-74-RMJ" userLabel="Dismiss button" customClass="AnimatableButton" customModule="IBAnimatable">
+                                        <rect key="frame" x="110.5" y="101" width="114" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="iLh-YD-evM"/>
+                                        </constraints>
+                                        <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
+                                        <state key="normal" title="Dismiss">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="6"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="45K-qE-rLh" kind="unwind" unwindAction="dismissCurrentViewController:" id="TuH-7D-fhi"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="centerX" secondItem="ElG-i8-3nL" secondAttribute="centerX" id="Ex8-eF-ePl"/>
+                            <constraint firstAttribute="trailing" secondItem="9Vi-ji-WpQ" secondAttribute="trailing" constant="20" id="MGU-eK-ZHv"/>
+                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="centerY" secondItem="ElG-i8-3nL" secondAttribute="centerY" id="Rdb-dz-TPn"/>
+                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="leading" secondItem="ElG-i8-3nL" secondAttribute="leading" constant="20" id="TMm-zW-59d"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="375" height="300"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="_modalWidth" value="half"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="_modalHeight" value="half"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="6"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="overCurrentContext" value="YES"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="_presentationAnimationType" value="cover(left)"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="_dismissalAnimationType" value="cover(left)"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dXr-t9-cRz" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="45K-qE-rLh" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="6431" y="-66"/>
         </scene>
     </scenes>
     <resources>

--- a/IBAnimatableApp/Presentations.storyboard
+++ b/IBAnimatableApp/Presentations.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="7ad-nV-MlE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="7ad-nV-MlE">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -699,14 +699,14 @@
                                         </constraints>
                                         <variation key="default">
                                             <mask key="constraints">
-                                                <exclude reference="wJu-F0-n8q"/>
-                                                <exclude reference="398-Kc-LQ7"/>
-                                                <exclude reference="rr4-b8-F5L"/>
-                                                <exclude reference="xvb-UR-kQ5"/>
                                                 <exclude reference="Aon-La-YKB"/>
+                                                <exclude reference="xvb-UR-kQ5"/>
+                                                <exclude reference="wJu-F0-n8q"/>
                                                 <exclude reference="eCr-Jf-Oif"/>
                                                 <exclude reference="nM6-2Q-yff"/>
                                                 <exclude reference="q1V-TU-IF0"/>
+                                                <exclude reference="398-Kc-LQ7"/>
+                                                <exclude reference="rr4-b8-F5L"/>
                                             </mask>
                                         </variation>
                                     </view>
@@ -1005,6 +1005,10 @@
         <scene sceneID="3Gb-go-mY3">
             <objects>
                 <viewController id="1dm-2z-9gI" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="sOB-Lj-43E"/>
+                        <viewControllerLayoutGuide type="bottom" id="nXd-N1-zpG"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Den-DD-xOx">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="301.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1013,7 +1017,7 @@
                                 <rect key="frame" x="161" y="136" width="53" height="30"/>
                                 <state key="normal" title="Present"/>
                                 <connections>
-                                    <segue destination="qdi-bw-dbA" kind="presentation" id="VIb-bL-vUS"/>
+                                    <segue destination="qdi-bw-dbA" kind="presentation" customClass="PresentOverCurrentContextSegue" customModule="IBAnimatable" id="VIb-bL-vUS"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -1032,6 +1036,10 @@
         <scene sceneID="jZz-Gv-ZzW">
             <objects>
                 <viewController id="d47-jK-71I" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="N02-kw-SB1"/>
+                        <viewControllerLayoutGuide type="bottom" id="Bz4-Ck-TUe"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ys6-pQ-cOD">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="301.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1064,45 +1072,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="9Vi-ji-WpQ">
-                                <rect key="frame" x="20" y="70" width="335" height="161"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Note that all the presentation parameters are also available when presenting over current context." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U72-tv-dXC">
-                                        <rect key="frame" x="8.5" y="0.0" width="318.5" height="61"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uK1-74-RMJ" userLabel="Dismiss button" customClass="AnimatableButton" customModule="IBAnimatable">
-                                        <rect key="frame" x="110.5" y="101" width="114" height="60"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="60" id="iLh-YD-evM"/>
-                                        </constraints>
-                                        <inset key="contentEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
-                                        <state key="normal" title="Dismiss">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                                <color key="value" red="0.70980392160000005" green="0.4549019608" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                <real key="value" value="6"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <segue destination="45K-qE-rLh" kind="unwind" unwindAction="dismissCurrentViewController:" id="TuH-7D-fhi"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Did you try to customise the modal?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U72-tv-dXC">
+                                <rect key="frame" x="10" y="139.5" width="355" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="centerX" secondItem="ElG-i8-3nL" secondAttribute="centerX" id="Ex8-eF-ePl"/>
-                            <constraint firstAttribute="trailing" secondItem="9Vi-ji-WpQ" secondAttribute="trailing" constant="20" id="MGU-eK-ZHv"/>
-                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="centerY" secondItem="ElG-i8-3nL" secondAttribute="centerY" id="Rdb-dz-TPn"/>
-                            <constraint firstItem="9Vi-ji-WpQ" firstAttribute="leading" secondItem="ElG-i8-3nL" secondAttribute="leading" constant="20" id="TMm-zW-59d"/>
+                            <constraint firstItem="U72-tv-dXC" firstAttribute="leading" secondItem="ElG-i8-3nL" secondAttribute="leading" constant="10" id="6lQ-bf-2cI"/>
+                            <constraint firstAttribute="trailing" secondItem="U72-tv-dXC" secondAttribute="trailing" constant="10" id="J74-bb-zdl"/>
+                            <constraint firstItem="U72-tv-dXC" firstAttribute="centerY" secondItem="ElG-i8-3nL" secondAttribute="centerY" id="x9L-Z0-ED9"/>
                         </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -1113,13 +1094,11 @@
                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                             <real key="value" value="6"/>
                         </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="overCurrentContext" value="YES"/>
                         <userDefinedRuntimeAttribute type="string" keyPath="_presentationAnimationType" value="cover(left)"/>
                         <userDefinedRuntimeAttribute type="string" keyPath="_dismissalAnimationType" value="cover(left)"/>
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dXr-t9-cRz" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="45K-qE-rLh" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="6431" y="-66"/>
         </scene>


### PR DESCRIPTION
This PR introduces a new way to make custom presentation but also finally close #198 !

What's in?
- A new property in `PresentationDesignable`: `overCurrentContext`.
   - If true, the dimmingView will have the same frame as the controller who started the presentation
   - If false, the dimmingView will take the fullscreen as a `default` presentation

The implementation is a bit tricksy but (almost) working. The internal presentation is still in fullscreen, the main difference is that if we set `overCurrentContext` to true, we will forward all _tap_ which make us able to tap outside.

I have still one issue left that I don't how to fix: in order to do this, I need to know which controllers is our _context_ in order to set its frame to the `dimmingView`. Since we are already in the modal environment, we don't know which controller starts the presentation. There an easy solution when doing presentation programatically, but I have no idea how to get that context while supporting the interface builder. Any suggestions would help!

For example, here the result with a hard coded frame:

![simulator screen shot 28 mar 2017 15 49 10](https://cloud.githubusercontent.com/assets/1402212/24408489/1e9af996-13ce-11e7-92b9-e8697f916432.png)

The first part is the one presenting the controller, but while being presented, the second stay clickable.

**Other things missing:**
- [x] Demo app
- [x] Changelog
- [x] Docs
- [ ] Documentation gif