### PR TITLE
Add `AnimatableTableViewController` with designable `UIRefreshControl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Next
 
 #### API breaking changes
-- `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programatically a cornerSide to your view, you will just have to lowercase the A. [#409](https://github.com/IBAnimatable/IBAnimatable/pull/409) by [@tbaranes](https://github.com/tbaranes)
+- `CornerSide`'s swift3 migration leftovers: renaming `.AllSides` to `.allSides`. If you were setting programmatically a cornerSide to your view, you will just have to lowercase the A. [#409](https://github.com/IBAnimatable/IBAnimatable/pull/409) by [@tbaranes](https://github.com/tbaranes)
 - `AnimatableSlider` inherit from `UISlider`
 
 #### Enhancements
@@ -16,13 +16,15 @@ All notable changes to this project will be documented in this file.
 [#403](https://github.com/IBAnimatable/IBAnimatable/pull/403) by [@tbaranes](https://github.com/tbaranes)
 - Make images of `AnimatableSlider` designable.
 [#417](https://github.com/IBAnimatable/IBAnimatable/pull/417) by [@phimage](https://github.com/phimage)
-
+- Add `AnimatableTableViewController` to support `UIRefreshControl` customization.
+[#418](https://github.com/IBAnimatable/IBAnimatable/pull/418) by [@phimage](https://github.com/phimage)
+CHANGELOG
 
 #### Bugfixes
 - Make corner sides case insensitive.
 [#394](https://github.com/IBAnimatable/IBAnimatable/issues/394) by [@mmadjer](https://github.com/mmadjer)
 - Frame is converted to window coordinate space to fix miscalculations in computed values (used with `slideOut`, ...) [#412](https://github.com/IBAnimatable/IBAnimatable/issues/412) by [@redent](https://github.com/redent)
- 
+
 ---
 ### [3.1.3](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.3)
 
@@ -207,13 +209,13 @@ None
 - Add `Turn` to support Turn transition animation. It supports only a direction `Turn(direction)`, if no specified, the default values are `Turn(Left)`. [#155](https://github.com/IBAnimatable/IBAnimatable/issues/155)
 - Add `CardsAnimator` to support Cards transition animation. It supports parameters `Cards(direction)`, if no specified, the default values are `Cards(Forward)`. [#155](https://github.com/IBAnimatable/IBAnimatable/issues/155)
 - Add `FlipAnimator` to support Flip transition animation. It supports parameters `Flip(direction)`, if no specified, the default values are `Flip(Left)`. Currently only support `Flip(Left)` and `Flip(Right)`. [#155](https://github.com/IBAnimatable/IBAnimatable/issues/155)
-- Add `ContainerTransition` to manage transition animations between two UIViewController in a container
+- Add `ContainerTransition` to manage transition animations between two `UIViewController` in a container
 - Add `AnimatableCollectionViewCell` [#167](https://github.com/IBAnimatable/IBAnimatable/pull/167)
 - Add `PinchInteractiveAnimator` to support `Pinch(Close)`, `Pinch(Open)` for `Pinch` gesture transition controller. [#125](https://github.com/IBAnimatable/IBAnimatable/issues/125)
 - Add `SlideAnimator` to support Slide transition animation. It supports parameters `Slide(direction, fade)`, if no specified, the default values are `Flip(Left)`. [#155](https://github.com/IBAnimatable/IBAnimatable/issues/155)
 - Add IBAnimatable Playground to demonstrate transitions and interactions. [#204](https://github.com/IBAnimatable/IBAnimatable/pull/204)
 - Add `Parallelogram` mask. [#207 - Parallelogram Mask support in Maskdesignable](https://github.com/IBAnimatable/IBAnimatable/pull/207)
-- Add `popToRootViewController` segue for poping to root ViewController of the NavigationController. [#212](https://github.com/IBAnimatable/IBAnimatable/pull/212)
+- Add `popToRootViewController` segue for popping to root ViewController of the NavigationController. [#212](https://github.com/IBAnimatable/IBAnimatable/pull/212)
 
 #### Bugfixes
 
@@ -308,7 +310,7 @@ None
 - Add `Navigator` to manage Push and Pop transition animations
 - Add `Presenter` to manage Present and Dismiss transition animations
 - Add `PresentFadeSegue`, `PresentFadeInSegue` and `PresentFadeOutSegue` for Present transition with Fade animations
-- Add `PresentFadeWithDismissInteractionSegue`, `PresentFadeInWithDismissInteractionSegue` and `PresentFadeOutWithDismissInteractionSegue` for Present transition with Fade animations and getsture interactions.
+- Add `PresentFadeWithDismissInteractionSegue`, `PresentFadeInWithDismissInteractionSegue` and `PresentFadeOutWithDismissInteractionSegue` for Present transition with Fade animations and gesture interactions.
 - Add `PanInteractiveAnimator` to handle Pan interaction for Dismiss and Pop
 - Demo App can experiment all transition animations (tap on "Forget Password" button to see)
 
@@ -367,5 +369,3 @@ None
 ### [1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/1.0)
 
 - Initial release
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ All notable changes to this project will be documented in this file.
 [#417](https://github.com/IBAnimatable/IBAnimatable/pull/417) by [@phimage](https://github.com/phimage)
 - Add `AnimatableTableViewController` to support `UIRefreshControl` customization.
 [#418](https://github.com/IBAnimatable/IBAnimatable/pull/418) by [@phimage](https://github.com/phimage)
-CHANGELOG
 
 #### Bugfixes
 - Make corner sides case insensitive.

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -1,4 +1,4 @@
-### Animatable UI elements 
+### Animatable UI elements
 To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with `Animatable` UI element in Identity inspector. Here are the supported `Animatable` UI elements to map UIKit elements.
 
 | UIKit elements | Animatable UI elements | Description |
@@ -18,6 +18,7 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 | UINavigationBar | DesignableNavigationBar | |
 | UIViewController | AnimatableViewController | |
 | UINavigationController | AnimatableNavigationController | |
+| UITableViewController | AnimatableTableViewController| |
 | UISlider | AnimatableSlider | |
 | UIActivityIndicatorView | AnimatableActivityIndicatorView | [List of animations available](./ActivityIndicator.md) |
 
@@ -170,6 +171,26 @@ Easily add color layer on top of the UI element especially `AnimatableImageView`
 | ------------- |:-------------:| ----- |
 | hideNavigationBar | Bool | whether to hide navigation bar. The default value is `false`. |
 
+#### `RefreshControlDesignable`
+Display a `UIRefreshControl` in `AnimatableTableViewController`
+
+| Property name | Data type | Description |
+| ------------- |:-------------:| ----- |
+| hasRefreshControl | Bool | whether to add a `UIRefreshControl`. The default value is `false`. |
+| refreshControlTintColor | Optional&lt;UIColor> | tint color of the `UIRefreshControl` |
+| refreshControlBackgroundColor | Optional&lt;UIColor> | background color of the `UIRefreshControl`  |
+
+#### `SliderImagesDesignable`
+
+| Property name | Data type | Description |
+| ------------- |:-------------:| ----- |
+| thumbImage | Optional&lt;UIImage> | the thumb image when slider state is `normal`. |
+| thumbHighlightedImage | Optional&lt;UIImage> | the thumb image when slider state is `highlighted`. |
+| minimumTrackImage | Optional&lt;UIImage> | the minimum track image when slider state is `normal`. |
+| minimumTrackHighlightedImage | Optional&lt;UIImage> | the minimum track image when slider state is `highlighted`. |
+| maximumTrackImage | Optional&lt;UIImage> | the maximum track image when slider state is `normal`. |
+| maximumTrackHighlightedImage | Optional&lt;UIImage> | the maximum track image when slider state is `highlighted`. |
+
 ### Animatable protocol
 #### Properties
 | Property name | Data type | Description |
@@ -223,5 +244,3 @@ Also see [Transition Animators](Transitions.md#transition-animators) and [Intera
 
 ### Segues
 See [Segues](Transitions.md#segues)
-
-

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -172,8 +172,6 @@ Easily add color layer on top of the UI element especially `AnimatableImageView`
 | hideNavigationBar | Bool | whether to hide navigation bar. The default value is `false`. |
 
 #### `RefreshControlDesignable`
-Display a `UIRefreshControl` in `AnimatableTableViewController`
-
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
 | hasRefreshControl | Bool | whether to add a `UIRefreshControl`. The default value is `false`. |

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		33A8B9ED1C7E790800082529 /* SystemCubeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */; };
-		48D436311E8E221500538E7D /* TimeLineTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D436301E8E221500538E7D /* TimeLineTableViewController.swift */; };
+		48D436311E8E221500538E7D /* RefreshTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D436301E8E221500538E7D /* RefreshTableViewController.swift */; };
 		7305EC0E1E1996E000BF4C9A /* AnimationChainable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */; };
 		731205811D28A3830009BCAC /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731205801D28A3830009BCAC /* Utils.swift */; };
 		732485D71D4902510068FD93 /* ParamType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732485D61D4902510068FD93 /* ParamType.swift */; };
@@ -220,7 +220,7 @@
 
 /* Begin PBXFileReference section */
 		33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCubeAnimator.swift; sourceTree = "<group>"; };
-		48D436301E8E221500538E7D /* TimeLineTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeLineTableViewController.swift; sourceTree = "<group>"; };
+		48D436301E8E221500538E7D /* RefreshTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshTableViewController.swift; sourceTree = "<group>"; };
 		7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationChainable.swift; sourceTree = "<group>"; };
 		731205801D28A3830009BCAC /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		732485D61D4902510068FD93 /* ParamType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParamType.swift; sourceTree = "<group>"; };
@@ -612,6 +612,7 @@
 				733323021D56BCF200B88F6E /* UserInterfaceTableViewController.swift */,
 				73A99B661D5FC8650079C7EC /* BorderViewController.swift */,
 				E2E62B8A1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift */,
+				48D436301E8E221500538E7D /* RefreshTableViewController.swift */,
 				90F04E681DDDC650007614CB /* CornerViewController.swift */,
 			);
 			name = code;
@@ -646,7 +647,6 @@
 				AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */,
 				E2DAD6301D5F141F00333ABF /* Main.storyboard */,
 				AED1A0FF1BFE9820001346FA /* DemoApp.storyboard */,
-				48D436301E8E221500538E7D /* TimeLineTableViewController.swift */,
 				AE28D0551CDFF7D50043273C /* IBAnimatable Playground */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
 			);
@@ -1194,7 +1194,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48D436311E8E221500538E7D /* TimeLineTableViewController.swift in Sources */,
+				48D436311E8E221500538E7D /* RefreshTableViewController.swift in Sources */,
 				733323031D56BCF200B88F6E /* UserInterfaceTableViewController.swift in Sources */,
 				AE1B9A661CE3EB100098D962 /* InteractionTableViewController.swift in Sources */,
 				73A99B671D5FC8650079C7EC /* BorderViewController.swift in Sources */,

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		33A8B9ED1C7E790800082529 /* SystemCubeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */; };
+		48D436311E8E221500538E7D /* TimeLineTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D436301E8E221500538E7D /* TimeLineTableViewController.swift */; };
 		7305EC0E1E1996E000BF4C9A /* AnimationChainable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */; };
 		731205811D28A3830009BCAC /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731205801D28A3830009BCAC /* Utils.swift */; };
 		732485D71D4902510068FD93 /* ParamType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732485D61D4902510068FD93 /* ParamType.swift */; };
@@ -105,6 +106,8 @@
 		AEE552B11C839EB7009CF623 /* TransitionPresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* TransitionPresenterManager.swift */; };
 		AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */; };
 		C47A737C1E86A9BD0044EFF8 /* SliderImagesDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */; };
+		C4B504E01E8832E7001E096A /* RefreshControlerDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B504DF1E8832E7001E096A /* RefreshControlerDesignable.swift */; };
+		C4B504E51E8833C4001E096A /* AnimatableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B504E41E8833C4001E096A /* AnimatableTableViewController.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
 		CAB566CA933963DAA0C7E074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB56A8BA4FB110D501DC1DC /* Constants.swift */; };
 		E20027171D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20027161D467E9700FEB28D /* ViewControllerAnimatedTransitioning.swift */; };
@@ -217,6 +220,7 @@
 
 /* Begin PBXFileReference section */
 		33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCubeAnimator.swift; sourceTree = "<group>"; };
+		48D436301E8E221500538E7D /* TimeLineTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeLineTableViewController.swift; sourceTree = "<group>"; };
 		7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationChainable.swift; sourceTree = "<group>"; };
 		731205801D28A3830009BCAC /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		732485D61D4902510068FD93 /* ParamType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParamType.swift; sourceTree = "<group>"; };
@@ -312,6 +316,8 @@
 		AEEF86BD1CA8E9E200899AAB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Playground.storyboard; sourceTree = "<group>"; };
 		C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderImagesDesignable.swift; sourceTree = "<group>"; };
+		C4B504DF1E8832E7001E096A /* RefreshControlerDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshControlerDesignable.swift; sourceTree = "<group>"; };
+		C4B504E41E8833C4001E096A /* AnimatableTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableTableViewController.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
 		CAB5692C91C9ECC8018DE83E /* Navigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAB56A8BA4FB110D501DC1DC /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -475,6 +481,7 @@
 				AE0FAD401C1ED41D00B5289B /* AnimatableViewController.swift */,
 				E21E840D1D3A31A900C742E7 /* AnimatablePresentationController.swift */,
 				E21E84091D3A30DF00C742E7 /* AnimatableModalViewController.swift */,
+				C4B504E41E8833C4001E096A /* AnimatableTableViewController.swift */,
 			);
 			name = controller;
 			sourceTree = "<group>";
@@ -639,6 +646,7 @@
 				AED1A0FD1BFE9820001346FA /* LaunchScreen.storyboard */,
 				E2DAD6301D5F141F00333ABF /* Main.storyboard */,
 				AED1A0FF1BFE9820001346FA /* DemoApp.storyboard */,
+				48D436301E8E221500538E7D /* TimeLineTableViewController.swift */,
 				AE28D0551CDFF7D50043273C /* IBAnimatable Playground */,
 				AED1A1011BFE9820001346FA /* Info.plist */,
 			);
@@ -748,6 +756,7 @@
 				AE0FAD421C1ED52800B5289B /* ViewControllerDesignable.swift */,
 				E21E840F1D3A36C600C742E7 /* PresentationDesignable.swift */,
 				C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */,
+				C4B504DF1E8832E7001E096A /* RefreshControlerDesignable.swift */,
 			);
 			name = Designable;
 			sourceTree = "<group>";
@@ -1027,6 +1036,7 @@
 				E28E28361D6CCA5C0043D56E /* ActivityIndicatorAnimationLineScalePulseOutRapid.swift in Sources */,
 				E2E62B861D69B6B400294A73 /* ActivityIndicatorShape.swift in Sources */,
 				E20078A11CB8FB94002B2C16 /* FoldAnimator.swift in Sources */,
+				C4B504E51E8833C4001E096A /* AnimatableTableViewController.swift in Sources */,
 				7305EC0E1E1996E000BF4C9A /* AnimationChainable.swift in Sources */,
 				90F04E671DDDC1D9007614CB /* CornerSide.swift in Sources */,
 				AEDE6E6B1CCECE8A000DECF0 /* PinchInteractiveAnimator.swift in Sources */,
@@ -1100,6 +1110,7 @@
 				AE154B2D1C7BB5760093C05B /* CALayerExtension.swift in Sources */,
 				AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */,
 				E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */,
+				C4B504E01E8832E7001E096A /* RefreshControlerDesignable.swift in Sources */,
 				E2E28E6F1C6A6D22003F3852 /* UIColorExtension.swift in Sources */,
 				E2A062B51CB1A60E00C54B40 /* PresentExplodeSegue.swift in Sources */,
 				E28E28391D6CCA5C0043D56E /* ActivityIndicatorAnimationPacman.swift in Sources */,
@@ -1183,6 +1194,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48D436311E8E221500538E7D /* TimeLineTableViewController.swift in Sources */,
 				733323031D56BCF200B88F6E /* UserInterfaceTableViewController.swift in Sources */,
 				AE1B9A661CE3EB100098D962 /* InteractionTableViewController.swift in Sources */,
 				73A99B671D5FC8650079C7EC /* BorderViewController.swift in Sources */,

--- a/IBAnimatable/AnimatableTableViewController.swift
+++ b/IBAnimatable/AnimatableTableViewController.swift
@@ -19,7 +19,7 @@ open class AnimatableTableViewController: UITableViewController, ViewControllerD
   @IBInspectable open var rootWindowBackgroundColor: UIColor?
 
   // MARK: - TransitionAnimatable
-  @IBInspectable open var _transitionAnimationType: String? {
+  @IBInspectable var _transitionAnimationType: String? {
     didSet {
       if let _transitionAnimationType = _transitionAnimationType {
         transitionAnimationType = TransitionAnimationType(string: _transitionAnimationType)
@@ -31,7 +31,7 @@ open class AnimatableTableViewController: UITableViewController, ViewControllerD
   @IBInspectable open var transitionDuration: Double = .nan
 
   open var interactiveGestureType: InteractiveGestureType = .none
-  @IBInspectable open var _interactiveGestureType: String? {
+  @IBInspectable var _interactiveGestureType: String? {
     didSet {
       if let _interactiveGestureType = _interactiveGestureType {
         interactiveGestureType = InteractiveGestureType(string: _interactiveGestureType)

--- a/IBAnimatable/AnimatableTableViewController.swift
+++ b/IBAnimatable/AnimatableTableViewController.swift
@@ -6,7 +6,8 @@
 import UIKit
 
 @IBDesignable
-open class AnimatableTableViewController: UITableViewController, ViewControllerDesignable, StatusBarDesignable, RootWindowDesignable, TransitionAnimatable, RefreshControlDesignable {
+open class AnimatableTableViewController: UITableViewController, ViewControllerDesignable, StatusBarDesignable,
+                                             RootWindowDesignable, TransitionAnimatable, RefreshControlDesignable {
 
   // MARK: - ViewControllerDesignable
   @IBInspectable open var hideNavigationBar: Bool = false

--- a/IBAnimatable/AnimatableTableViewController.swift
+++ b/IBAnimatable/AnimatableTableViewController.swift
@@ -1,0 +1,111 @@
+//
+//  AnimatableTableViewController.swift
+//  IBAnimatable
+//
+//  Created by phimage on 26/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+open class AnimatableTableViewController: UITableViewController, ViewControllerDesignable, StatusBarDesignable, RootWindowDesignable, TransitionAnimatable, RefreshControlDesignable {
+
+  // MARK: - ViewControllerDesignable
+  @IBInspectable open var hideNavigationBar: Bool = false
+
+  // MARK: - StatusBarDesignable
+  @IBInspectable open var lightStatusBar: Bool = false
+
+  // MARK: - RootWindowDesignable
+  @IBInspectable open var rootWindowBackgroundColor: UIColor?
+
+  // MARK: - TransitionAnimatable
+  @IBInspectable open var _transitionAnimationType: String? {
+    didSet {
+      if let _transitionAnimationType = _transitionAnimationType {
+        transitionAnimationType = TransitionAnimationType(string: _transitionAnimationType)
+      }
+    }
+  }
+  open var transitionAnimationType: TransitionAnimationType = .none
+
+  @IBInspectable open var transitionDuration: Double = .nan
+
+  open var interactiveGestureType: InteractiveGestureType = .none
+  @IBInspectable open var _interactiveGestureType: String? {
+    didSet {
+      if let _interactiveGestureType = _interactiveGestureType {
+        interactiveGestureType = InteractiveGestureType(string: _interactiveGestureType)
+      }
+    }
+  }
+
+  // MARK: - RefreshControlDesignable
+
+  @IBInspectable open var hasRefreshControl: Bool = false {
+    didSet {
+      configureRefreshController()
+    }
+  }
+  @IBInspectable open var refreshControlTintColor: UIColor? {
+    didSet {
+      configureRefreshController()
+    }
+  }
+  @IBInspectable open var refreshControlBackgroundColor: UIColor? {
+    didSet {
+      configureRefreshController()
+    }
+  }
+
+  // MARK: - Lifecylce
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+    configureRefreshController()
+  }
+
+  open override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    configureHideNavigationBar()
+    configureRootWindowBackgroundColor()
+  }
+
+  open override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    resetHideNavigationBar()
+  }
+
+  open override var preferredStatusBarStyle: UIStatusBarStyle {
+    if lightStatusBar {
+      return .lightContent
+    }
+    return .default
+  }
+
+  open override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+    super.prepare(for: segue, sender: sender)
+
+    // Configure custom transition animation
+    guard (segue.destination is PresentationDesignable) == false else {
+      return
+    }
+
+    if case .none = transitionAnimationType {
+      return
+    }
+
+    let toViewController = segue.destination
+    // If interactiveGestureType hasn't been set
+    let transitionManager = TransitionPresenterManager.shared
+    if case .none = interactiveGestureType {
+      toViewController.transitioningDelegate = transitionManager.retrievePresenter(transitionAnimationType: transitionAnimationType,
+                                                                                   transitionDuration: transitionDuration)
+    } else {
+      toViewController.transitioningDelegate = transitionManager.retrievePresenter(transitionAnimationType: transitionAnimationType,
+                                                                                   transitionDuration: transitionDuration,
+                                                                                   interactiveGestureType: interactiveGestureType)
+    }
+  }
+
+}

--- a/IBAnimatable/AnimatableTableViewController.swift
+++ b/IBAnimatable/AnimatableTableViewController.swift
@@ -1,7 +1,4 @@
 //
-//  AnimatableTableViewController.swift
-//  IBAnimatable
-//
 //  Created by phimage on 26/03/2017.
 //  Copyright © 2017 IBAnimatable. All rights reserved.
 //

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -1,0 +1,41 @@
+//
+//  Created by phimage on 26/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+public protocol RefreshControlDesignable {
+
+  /**
+   Component need to display a refresh control
+   */
+  var hasRefreshControl: Bool { get set }
+  /**
+   The tint color of the refresh control
+   */
+  var refreshControlTintColor: UIColor? { get set }
+  /**
+   The background color of the refresh control
+   */
+  var refreshControlBackgroundColor: UIColor? { get set }
+
+}
+
+public extension RefreshControlDesignable where Self: UITableViewController {
+
+  func configureRefreshController() {
+    if isViewLoaded {
+      if hasRefreshControl {
+        if refreshControl == nil {
+          refreshControl = UIRefreshControl()
+        }
+        refreshControl?.tintColor = refreshControlTintColor
+        refreshControl?.backgroundColor = refreshControlBackgroundColor
+      } else {
+        refreshControl = nil
+      }
+    }
+  }
+
+}

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -25,16 +25,17 @@ public protocol RefreshControlDesignable {
 public extension RefreshControlDesignable where Self: UITableViewController {
 
   func configureRefreshController() {
-    if isViewLoaded {
-      if hasRefreshControl {
-        if refreshControl == nil {
-          refreshControl = UIRefreshControl()
-        }
-        refreshControl?.tintColor = refreshControlTintColor
-        refreshControl?.backgroundColor = refreshControlBackgroundColor
-      } else {
-        refreshControl = nil
+    guard !isViewLoaded else {
+      return
+    }
+    if hasRefreshControl {
+      if refreshControl == nil {
+        refreshControl = UIRefreshControl()
       }
+      refreshControl?.tintColor = refreshControlTintColor
+      refreshControl?.backgroundColor = refreshControlBackgroundColor
+    } else {
+      refreshControl = nil
     }
   }
 

--- a/IBAnimatableApp/Base.lproj/DemoApp.storyboard
+++ b/IBAnimatableApp/Base.lproj/DemoApp.storyboard
@@ -3401,10 +3401,10 @@
             </objects>
             <point key="canvasLocation" x="8145" y="482"/>
         </scene>
-        <!--Time Line Table View Controller-->
+        <!--Table View Controller-->
         <scene sceneID="3oo-QP-Iqp">
             <objects>
-                <tableViewController id="DWs-Hm-hGO" customClass="TimeLineTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="DWs-Hm-hGO" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="none" rowHeight="117" sectionHeaderHeight="28" sectionFooterHeight="28" id="ho8-uA-Rom" customClass="AnimatableTableView" customModule="IBAnimatable">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3848,15 +3848,6 @@
                             <outlet property="delegate" destination="DWs-Hm-hGO" id="sbK-sG-FUs"/>
                         </connections>
                     </tableView>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
-                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
-                            <color key="value" red="0.72886490821838379" green="0.46856951713562012" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
-                            <color key="value" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ho-XZ-9UL" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/IBAnimatableApp/Base.lproj/DemoApp.storyboard
+++ b/IBAnimatableApp/Base.lproj/DemoApp.storyboard
@@ -2419,7 +2419,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="179"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dPq-Qw-4O3" id="Q7q-ck-Vtm">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="179"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="178.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" image="work-bg" translatesAutoresizingMaskIntoConstraints="NO" id="cnu-II-h1B">
@@ -2468,7 +2468,7 @@
                                         <rect key="frame" x="0.0" y="179" width="375" height="179"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ybq-pW-18L" id="SF6-21-gh6">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="179"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="178.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" image="food-bg" translatesAutoresizingMaskIntoConstraints="NO" id="Ais-XN-CDv">
@@ -2517,7 +2517,7 @@
                                         <rect key="frame" x="0.0" y="358" width="375" height="179"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="iOC-nU-P2z" id="gdv-TZ-N01">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="179"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="178.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" image="auto-bg" translatesAutoresizingMaskIntoConstraints="NO" id="8sP-hs-JHd">
@@ -2566,7 +2566,7 @@
                                         <rect key="frame" x="0.0" y="537" width="375" height="179"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2ww-Ma-YOf" id="d3U-xh-uUe">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="179"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="178.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" image="work-bg" translatesAutoresizingMaskIntoConstraints="NO" id="Add-xy-b3S">
@@ -3401,10 +3401,10 @@
             </objects>
             <point key="canvasLocation" x="8145" y="482"/>
         </scene>
-        <!--Table View Controller-->
+        <!--Time Line Table View Controller-->
         <scene sceneID="3oo-QP-Iqp">
             <objects>
-                <tableViewController id="DWs-Hm-hGO" sceneMemberID="viewController">
+                <tableViewController id="DWs-Hm-hGO" customClass="TimeLineTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="none" rowHeight="117" sectionHeaderHeight="28" sectionFooterHeight="28" id="ho8-uA-Rom" customClass="AnimatableTableView" customModule="IBAnimatable">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3414,22 +3414,22 @@
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" image="timeline-bg" translatesAutoresizingMaskIntoConstraints="NO" id="nix-9Y-ybX" userLabel="Background image view">
-                                    <rect key="frame" x="0.0" y="0.0" width="1000" height="200"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="9" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1bT-kq-qgM">
-                                    <rect key="frame" x="479.5" y="26" width="41.5" height="84"/>
+                                    <rect key="frame" x="167" y="26" width="41.5" height="84"/>
                                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="70"/>
                                     <color key="textColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tuesday" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="unS-ao-PKN">
-                                    <rect key="frame" x="444" y="109" width="112.5" height="36"/>
+                                    <rect key="frame" x="131.5" y="109" width="112.5" height="36"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                     <color key="textColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FEBRUARY 2015" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ci4-bP-T7P">
-                                    <rect key="frame" x="457" y="151" width="86.5" height="13.5"/>
+                                    <rect key="frame" x="144.5" y="151" width="86.5" height="13.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                     <color key="textColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -3848,6 +3848,15 @@
                             <outlet property="delegate" destination="DWs-Hm-hGO" id="sbK-sG-FUs"/>
                         </connections>
                     </tableView>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
+                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
+                            <color key="value" red="0.72886490821838379" green="0.46856951713562012" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
+                            <color key="value" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ho-XZ-9UL" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/IBAnimatableApp/RefreshTableViewController.swift
+++ b/IBAnimatableApp/RefreshTableViewController.swift
@@ -12,7 +12,7 @@ public class RefreshTableViewController: AnimatableTableViewController {
     super.viewDidLoad()
 
     // Install action on refresh
-    self.refreshControl?.addTarget(self, action: #selector(TimeLineTableViewController.refresh(_:)), for: .valueChanged)
+    self.refreshControl?.addTarget(self, action: #selector(RefreshTableViewController.refresh(_:)), for: .valueChanged)
   }
 
   public func refresh(_ refreshControl: UIRefreshControl) {

--- a/IBAnimatableApp/RefreshTableViewController.swift
+++ b/IBAnimatableApp/RefreshTableViewController.swift
@@ -1,7 +1,4 @@
 //
-//  TimeLineTableViewController.swift
-//  IBAnimatable
-//
 //  Created by Eric Marchand on 31/03/2017.
 //  Copyright © 2017 IBAnimatable. All rights reserved.
 //
@@ -9,7 +6,7 @@
 import UIKit
 import IBAnimatable
 
-public class TimeLineTableViewController: AnimatableTableViewController {
+public class RefreshTableViewController: AnimatableTableViewController {
 
   override public func viewDidLoad() {
     super.viewDidLoad()
@@ -36,7 +33,7 @@ public class TimeLineTableViewController: AnimatableTableViewController {
 
   // Function to update message recursively
   func updateMessage(refreshControl: UIRefreshControl, time: TimeInterval) {
-    if time < 0 {
+    guard time >= 0 else {
       return
     }
     var attributes: [String : Any] = [:]

--- a/IBAnimatableApp/TimeLineTableViewController.swift
+++ b/IBAnimatableApp/TimeLineTableViewController.swift
@@ -1,0 +1,63 @@
+//
+//  TimeLineTableViewController.swift
+//  IBAnimatable
+//
+//  Created by Eric Marchand on 31/03/2017.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+import IBAnimatable
+
+public class TimeLineTableViewController: AnimatableTableViewController {
+
+  override public func viewDidLoad() {
+    super.viewDidLoad()
+
+    // Install action on refresh
+    self.refreshControl?.addTarget(self, action: #selector(TimeLineTableViewController.refresh(_:)), for: .valueChanged)
+  }
+
+  public func refresh(_ refreshControl: UIRefreshControl) {
+    // could update attributedTitle of refreshControl here
+
+    // Simulate an asynchrone refresh, could be a network request...
+    let time: TimeInterval = 5
+    self.updateMessage(refreshControl: refreshControl, time: time)
+    DispatchQueue.background.after(time) {
+       // could update attributedTitle at each step
+
+      // end refreshing, maybe reload table data if you do not implement table delegate to update each insert, update and delete events
+      DispatchQueue.main.async {
+        refreshControl.endRefreshing()
+      }
+    }
+  }
+
+  // Function to update message recursively
+  func updateMessage(refreshControl: UIRefreshControl, time: TimeInterval) {
+    if time < 0 {
+      return
+    }
+    var attributes: [String : Any] = [:]
+    if let color = self.refreshControlTintColor {
+      attributes[NSForegroundColorAttributeName] = color
+    }
+    refreshControl.attributedTitle = NSAttributedString(string: "\(Int(time))", attributes: attributes )
+
+    DispatchQueue.main.after(1) { [unowned self] in
+      self.updateMessage(refreshControl: refreshControl, time: time - 1)
+    }
+  }
+
+}
+
+// MARK: DispatchQueue utility extension
+fileprivate extension DispatchQueue {
+  static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
+
+  func after(_ delay: TimeInterval, execute closure: @escaping () -> Void) {
+    asyncAfter(deadline: .now() + delay, execute: closure)
+  }
+
+}


### PR DESCRIPTION
and other features same as `AnimatableViewController`

`RefreshControlDesignable` allow to custom the internal `UIRefreshControl`

`UIRefreshControl` must not be set in subview but using refreshControl attribute of `UITableViewController`


ReStart of PR #418 due to many conflict
Modification since review by @tbaranes and @JakeLin 
- remove some space and add missing open on IBoutlet variable copied from AnimatableViewController
- add `TimeLineTableViewController` in demo app , to show how refresh control could be customised (simulate the refresh using `DispatchQueue`)
- fix a bug : if view not already loaded. If view not loaded, refreshControl could not be set