### PR TITLE
Add RefreshControlDesignable example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ All notable changes to this project will be documented in this file.
 [#403](https://github.com/IBAnimatable/IBAnimatable/pull/403) by [@tbaranes](https://github.com/tbaranes)
 - Make images of `AnimatableSlider` designable.
 [#417](https://github.com/IBAnimatable/IBAnimatable/pull/417) by [@phimage](https://github.com/phimage)
-- Add `AnimatableTableViewController` to support `UIRefreshControl` customization.
-[#418](https://github.com/IBAnimatable/IBAnimatable/pull/418) by [@phimage](https://github.com/phimage)
+- Add `RefreshControlDesignable` to make `UIRefreshControl` customization available in interface builder. Currently supported by `UITableViewController` and `UITableView`
+[#418](https://github.com/IBAnimatable/IBAnimatable/pull/418) by [@phimage](https://github.com/phimage) and [#429](https://github.com/IBAnimatable/IBAnimatable/pull/429) by [@tbaranes](https://github.com/tbaranes)
 
 #### Bugfixes
 - Make corner sides case insensitive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 [#403](https://github.com/IBAnimatable/IBAnimatable/pull/403) by [@tbaranes](https://github.com/tbaranes)
 - Make images of `AnimatableSlider` designable.
 [#417](https://github.com/IBAnimatable/IBAnimatable/pull/417) by [@phimage](https://github.com/phimage)
-- Add `RefreshControlDesignable` to make `UIRefreshControl` customization available in interface builder. Currently supported by `UITableViewController` and `UITableView`
+- Add `RefreshControlDesignable` to make `UIRefreshControl` customization available in Interface Builder. Currently supported by `UITableViewController` and `UITableView`
 [#418](https://github.com/IBAnimatable/IBAnimatable/pull/418) by [@phimage](https://github.com/phimage) and [#429](https://github.com/IBAnimatable/IBAnimatable/pull/429) by [@tbaranes](https://github.com/tbaranes)
 
 #### Bugfixes

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -167,16 +167,33 @@ Easily add color layer on top of the UI element especially `AnimatableImageView`
 | toneOpacity | CGFloat | opacity of tone color. The default value is `CGFloat.NaN`. |
 
 #### `ViewControllerDesignable`
+
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
 | hideNavigationBar | Bool | whether to hide navigation bar. The default value is `false`. |
 
 #### `RefreshControlDesignable`
+
+
 | Property name | Data type | Description |
 | ------------- |:-------------:| ----- |
 | hasRefreshControl | Bool | whether to add a `UIRefreshControl`. The default value is `false`. |
 | refreshControlTintColor | Optional&lt;UIColor> | tint color of the `UIRefreshControl` |
 | refreshControlBackgroundColor | Optional&lt;UIColor> | background color of the `UIRefreshControl`  |
+
+**Note:** `AnimatableTableView` conforms to that protocol, **but** if your deployment target is less than 10, you will have to add your `UIRefreshControl` yourself:
+
+```
+let refreshControl: UIRefreshControl?
+if #available(iOS 10.0, *) {
+  refreshControl = tableView.refreshControl
+} else {
+  refreshControl = UIRefreshControl()
+  tableView.addSubview(refreshControl!)
+  tableView.configureRefreshController()
+}
+refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
+```
 
 #### `SliderImagesDesignable`
 

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		33A8B9ED1C7E790800082529 /* SystemCubeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */; };
-		48D436311E8E221500538E7D /* RefreshTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D436301E8E221500538E7D /* RefreshTableViewController.swift */; };
+		48D436311E8E221500538E7D /* RefreshControlTableViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D436301E8E221500538E7D /* RefreshControlTableViewViewController.swift */; };
 		7305EC0E1E1996E000BF4C9A /* AnimationChainable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */; };
 		731205811D28A3830009BCAC /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731205801D28A3830009BCAC /* Utils.swift */; };
 		732485D71D4902510068FD93 /* ParamType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732485D61D4902510068FD93 /* ParamType.swift */; };
@@ -105,8 +105,8 @@
 		AEE552AE1C82D1E1009CF623 /* PresentFadeSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AC1C82D1E1009CF623 /* PresentFadeSegue.swift */; };
 		AEE552B11C839EB7009CF623 /* TransitionPresenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE552AF1C839EB7009CF623 /* TransitionPresenterManager.swift */; };
 		AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */; };
-		C4B4AD551E8645FD007A79A4 /* BackgroundImageDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */; };
 		C47A737C1E86A9BD0044EFF8 /* SliderImagesDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */; };
+		C4B4AD551E8645FD007A79A4 /* BackgroundImageDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */; };
 		C4B504E01E8832E7001E096A /* RefreshControlerDesignable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B504DF1E8832E7001E096A /* RefreshControlerDesignable.swift */; };
 		C4B504E51E8833C4001E096A /* AnimatableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B504E41E8833C4001E096A /* AnimatableTableViewController.swift */; };
 		CAB5610BC7B5D20C927AAB87 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5692C91C9ECC8018DE83E /* Navigator.swift */; };
@@ -142,6 +142,8 @@
 		E27691EB1CAFC91A004A725C /* SystemPushAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */; };
 		E27691EF1CAFCA29004A725C /* SystemRevealAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */; };
 		E27691F31CAFCD67004A725C /* SystemRotateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */; };
+		E27F1D5C1E90EAC900BAB013 /* RefreshControl.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E27F1D5B1E90EAC900BAB013 /* RefreshControl.storyboard */; };
+		E27F1D601E90F16200BAB013 /* RefreshControlTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27F1D5F1E90F16200BAB013 /* RefreshControlTableViewController.swift */; };
 		E28E28211D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28051D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift */; };
 		E28E28221D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28061D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift */; };
 		E28E28231D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E28071D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift */; };
@@ -221,7 +223,7 @@
 
 /* Begin PBXFileReference section */
 		33A8B9EB1C7E790800082529 /* SystemCubeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCubeAnimator.swift; sourceTree = "<group>"; };
-		48D436301E8E221500538E7D /* RefreshTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshTableViewController.swift; sourceTree = "<group>"; };
+		48D436301E8E221500538E7D /* RefreshControlTableViewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshControlTableViewViewController.swift; sourceTree = "<group>"; };
 		7305EC0D1E1996E000BF4C9A /* AnimationChainable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationChainable.swift; sourceTree = "<group>"; };
 		731205801D28A3830009BCAC /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		732485D61D4902510068FD93 /* ParamType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParamType.swift; sourceTree = "<group>"; };
@@ -316,8 +318,8 @@
 		AEEE200C1C18D10C00AD033B /* DesignableNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DesignableNavigationBar.swift; sourceTree = "<group>"; };
 		AEEF86BD1CA8E9E200899AAB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AEF4938C1CE0161C00B76FD6 /* Playground.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Playground.storyboard; sourceTree = "<group>"; };
-		C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundImageDesignable.swift; sourceTree = "<group>"; };
 		C47A737B1E86A9BD0044EFF8 /* SliderImagesDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderImagesDesignable.swift; sourceTree = "<group>"; };
+		C4B4AD541E8645FD007A79A4 /* BackgroundImageDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundImageDesignable.swift; sourceTree = "<group>"; };
 		C4B504DF1E8832E7001E096A /* RefreshControlerDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshControlerDesignable.swift; sourceTree = "<group>"; };
 		C4B504E41E8833C4001E096A /* AnimatableTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableTableViewController.swift; sourceTree = "<group>"; };
 		CAB562E75DABEED7FCE0F309 /* FillDesignable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FillDesignable.swift; sourceTree = "<group>"; };
@@ -360,6 +362,8 @@
 		E27691EA1CAFC91A004A725C /* SystemPushAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPushAnimator.swift; sourceTree = "<group>"; };
 		E27691EE1CAFCA29004A725C /* SystemRevealAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRevealAnimator.swift; sourceTree = "<group>"; };
 		E27691F21CAFCD67004A725C /* SystemRotateAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemRotateAnimator.swift; sourceTree = "<group>"; };
+		E27F1D5B1E90EAC900BAB013 /* RefreshControl.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RefreshControl.storyboard; sourceTree = "<group>"; };
+		E27F1D5F1E90F16200BAB013 /* RefreshControlTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshControlTableViewController.swift; sourceTree = "<group>"; };
 		E28E28051D6CCA5C0043D56E /* ActivityIndicatorAnimationAudioEqualizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationAudioEqualizer.swift; sourceTree = "<group>"; };
 		E28E28061D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallClipRotate.swift; sourceTree = "<group>"; };
 		E28E28071D6CCA5C0043D56E /* ActivityIndicatorAnimationBallClipRotateMultiple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationBallClipRotateMultiple.swift; sourceTree = "<group>"; };
@@ -614,8 +618,9 @@
 				733323021D56BCF200B88F6E /* UserInterfaceTableViewController.swift */,
 				73A99B661D5FC8650079C7EC /* BorderViewController.swift */,
 				E2E62B8A1D69BE3800294A73 /* UserInterfaceActivityIndicatorViewController.swift */,
-				48D436301E8E221500538E7D /* RefreshTableViewController.swift */,
 				90F04E681DDDC650007614CB /* CornerViewController.swift */,
+				E27F1D5F1E90F16200BAB013 /* RefreshControlTableViewController.swift */,
+				48D436301E8E221500538E7D /* RefreshControlTableViewViewController.swift */,
 			);
 			name = code;
 			sourceTree = "<group>";
@@ -826,6 +831,7 @@
 				AE0D30991CE149150093B578 /* UserInterface.storyboard */,
 				AE87646B1D232F1D0044E0AB /* UserInterfaceMask.storyboard */,
 				E2E62B881D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard */,
+				E27F1D5B1E90EAC900BAB013 /* RefreshControl.storyboard */,
 			);
 			name = UserInterface;
 			sourceTree = "<group>";
@@ -989,6 +995,7 @@
 				AE0D309C1CE14A170093B578 /* Animations.storyboard in Resources */,
 				AE154B101C788A560093C05B /* Transitions.storyboard in Resources */,
 				AEF4938D1CE0161C00B76FD6 /* Playground.storyboard in Resources */,
+				E27F1D5C1E90EAC900BAB013 /* RefreshControl.storyboard in Resources */,
 				E2E62B891D69BDEF00294A73 /* UserInterfaceActivityIndicator.storyboard in Resources */,
 				AE0D309A1CE149150093B578 /* UserInterface.storyboard in Resources */,
 				AE87646C1D232F1D0044E0AB /* UserInterfaceMask.storyboard in Resources */,
@@ -1198,7 +1205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48D436311E8E221500538E7D /* RefreshTableViewController.swift in Sources */,
+				48D436311E8E221500538E7D /* RefreshControlTableViewViewController.swift in Sources */,
 				733323031D56BCF200B88F6E /* UserInterfaceTableViewController.swift in Sources */,
 				AE1B9A661CE3EB100098D962 /* InteractionTableViewController.swift in Sources */,
 				73A99B671D5FC8650079C7EC /* BorderViewController.swift in Sources */,
@@ -1220,6 +1227,7 @@
 				90F04E691DDDC650007614CB /* CornerViewController.swift in Sources */,
 				AED1A1031BFE9820001346FA /* AppDelegate.swift in Sources */,
 				732485D71D4902510068FD93 /* ParamType.swift in Sources */,
+				E27F1D601E90F16200BAB013 /* RefreshControlTableViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -125,23 +125,17 @@ open var startPoint: GradientStartPoint = .top
   // MARK: - RefreshControlDesignable
   @IBInspectable open var hasRefreshControl: Bool = false {
     didSet {
-      if #available(iOSApplicationExtension 10.0, *) {
-        configureRefreshController()
-      }
+      configureRefreshController()
     }
   }
   @IBInspectable open var refreshControlTintColor: UIColor? {
     didSet {
-      if #available(iOSApplicationExtension 10.0, *) {
-        configureRefreshController()
-      }
+      configureRefreshController()
     }
   }
   @IBInspectable open var refreshControlBackgroundColor: UIColor? {
     didSet {
-      if #available(iOSApplicationExtension 10.0, *) {
-        configureRefreshController()
-      }
+      configureRefreshController()
     }
   }
 

--- a/IBAnimatable/AnimatableTableView.swift
+++ b/IBAnimatable/AnimatableTableView.swift
@@ -7,7 +7,8 @@ import UIKit
 
 @IBDesignable
 open class AnimatableTableView: UITableView, FillDesignable, BorderDesignable, GradientDesignable,
-                                             BackgroundImageDesignable, BlurDesignable, Animatable {
+                                             BackgroundImageDesignable, BlurDesignable, RefreshControlDesignable,
+                                             Animatable {
 
   // MARK: - FillDesignable
   @IBInspectable open var fillColor: UIColor? {
@@ -118,6 +119,29 @@ open var startPoint: GradientStartPoint = .top
   @IBInspectable open var blurOpacity: CGFloat = CGFloat.nan {
     didSet {
       configureBackgroundBlurEffectStyle()
+    }
+  }
+
+  // MARK: - RefreshControlDesignable
+  @IBInspectable open var hasRefreshControl: Bool = false {
+    didSet {
+      if #available(iOSApplicationExtension 10.0, *) {
+        configureRefreshController()
+      }
+    }
+  }
+  @IBInspectable open var refreshControlTintColor: UIColor? {
+    didSet {
+      if #available(iOSApplicationExtension 10.0, *) {
+        configureRefreshController()
+      }
+    }
+  }
+  @IBInspectable open var refreshControlBackgroundColor: UIColor? {
+    didSet {
+      if #available(iOSApplicationExtension 10.0, *) {
+        configureRefreshController()
+      }
     }
   }
 

--- a/IBAnimatable/AnimatableTableViewController.swift
+++ b/IBAnimatable/AnimatableTableViewController.swift
@@ -40,7 +40,6 @@ open class AnimatableTableViewController: UITableViewController, ViewControllerD
   }
 
   // MARK: - RefreshControlDesignable
-
   @IBInspectable open var hasRefreshControl: Bool = false {
     didSet {
       configureRefreshController()

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -25,6 +25,10 @@ public protocol RefreshControlDesignable {
 public extension RefreshControlDesignable where Self: UITableViewController {
 
   func configureRefreshController() {
+    guard isViewLoaded else {
+      return
+    }
+
     configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
   }
 

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -25,18 +25,32 @@ public protocol RefreshControlDesignable {
 public extension RefreshControlDesignable where Self: UITableViewController {
 
   func configureRefreshController() {
-    guard !isViewLoaded else {
-      return
-    }
-    if hasRefreshControl {
-      if refreshControl == nil {
-        refreshControl = UIRefreshControl()
-      }
-      refreshControl?.tintColor = refreshControlTintColor
-      refreshControl?.backgroundColor = refreshControlBackgroundColor
-    } else {
-      refreshControl = nil
-    }
+    configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
   }
 
+}
+
+@available(iOSApplicationExtension 10.0, *)
+public extension RefreshControlDesignable where Self: UITableView {
+
+  func configureRefreshController() {
+    configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
+  }
+
+}
+
+fileprivate extension RefreshControlDesignable {
+
+  func configureRefreshController(hasRefreshControl: Bool, refreshControl: inout UIRefreshControl?) {
+    guard hasRefreshControl else {
+      refreshControl = nil
+      return
+    }
+
+    if refreshControl == nil {
+      refreshControl = UIRefreshControl()
+    }
+    refreshControl?.tintColor = refreshControlTintColor
+    refreshControl?.backgroundColor = refreshControlBackgroundColor
+  }
 }

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -34,11 +34,15 @@ public extension RefreshControlDesignable where Self: UITableViewController {
 
 }
 
-@available(iOSApplicationExtension 10.0, *)
 public extension RefreshControlDesignable where Self: UITableView {
 
   func configureRefreshController() {
-    configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
+    if #available(iOSApplicationExtension 10.0, *) {
+      configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
+    } else {
+      var refreshControl = self.subviews.first { $0 is UIRefreshControl } as? UIRefreshControl
+      configureRefreshController(hasRefreshControl: hasRefreshControl, refreshControl: &refreshControl)
+    }
   }
 
 }

--- a/IBAnimatableApp/Playground.storyboard
+++ b/IBAnimatableApp/Playground.storyboard
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="FqL-96-clY">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="FqL-96-clY">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,6 +23,7 @@
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" image="playground" translatesAutoresizingMaskIntoConstraints="NO" id="5cS-gd-cgd">
+                                    <rect key="frame" x="127.5" y="17" width="120" height="102"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="120" id="ASv-5t-aez"/>
                                         <constraint firstAttribute="height" constant="102" id="Sms-eq-qEd"/>
@@ -45,11 +49,11 @@
                                         <rect key="frame" x="0.0" y="136" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Wiv-ZC-JbZ" id="GLu-M1-cmK">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="User Interface" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FNs-V6-60T">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -71,11 +75,11 @@
                                         <rect key="frame" x="0.0" y="180" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Wek-o7-Wnd" id="Go3-uY-hfG">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Animations" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zjp-hI-fR0">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -97,11 +101,11 @@
                                         <rect key="frame" x="0.0" y="224" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jeF-es-O5e" id="RYQ-lO-BIo">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Activity Indicator" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Fm-ye-H8s">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -119,15 +123,41 @@
                                             <segue destination="jdq-a3-17E" kind="show" id="04Y-ni-wbb"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="uDf-bP-Roh" style="IBUITableViewCellStyleDefault" id="x9C-HM-AGl" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="YbL-1u-GQ4" style="IBUITableViewCellStyleDefault" id="H6R-P8-8xM" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="268" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="H6R-P8-8xM" id="cii-uW-9nY">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Refresh control" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YbL-1u-GQ4">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="JmH-It-Lpx" kind="show" id="8uV-c2-Rf9"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="uDf-bP-Roh" style="IBUITableViewCellStyleDefault" id="x9C-HM-AGl" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="312" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="x9C-HM-AGl" id="T30-6U-gWZ">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Transitions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uDf-bP-Roh">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -146,14 +176,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="DHY-gE-QzJ" style="IBUITableViewCellStyleDefault" id="leW-Pc-8Nt" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="312" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="356" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="leW-Pc-8Nt" id="6Es-tX-lSH">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Presentations" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DHY-gE-QzJ">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -172,14 +202,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="1k4-58-akZ" style="IBUITableViewCellStyleDefault" id="Mvc-tD-5em" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="356" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="400" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Mvc-tD-5em" id="M6i-U2-ARG">
-                                            <frame key="frameInset" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Interactions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1k4-58-akZ">
-                                                    <frame key="frameInset" minX="15" width="345" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -231,7 +261,7 @@
                 <viewControllerPlaceholder storyboardName="UserInterface" id="VGT-SK-HRG" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dpn-Wz-hk3" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6328" y="-372"/>
+            <point key="canvasLocation" x="6326" y="-394"/>
         </scene>
         <!--Animations-->
         <scene sceneID="IlU-Wj-CPN">
@@ -239,7 +269,7 @@
                 <viewControllerPlaceholder storyboardName="Animations" id="YMk-Jn-KUW" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eLW-Ww-QM4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6316" y="-327"/>
+            <point key="canvasLocation" x="6314" y="-349"/>
         </scene>
         <!--Transitions-->
         <scene sceneID="rFV-yH-sSh">
@@ -247,7 +277,7 @@
                 <viewControllerPlaceholder storyboardName="Transitions" id="Yrg-NP-dYZ" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PSX-rh-CnY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6315" y="-282"/>
+            <point key="canvasLocation" x="6312" y="-304"/>
         </scene>
         <!--Interactions-->
         <scene sceneID="LKK-ky-A7J">
@@ -255,7 +285,7 @@
                 <viewControllerPlaceholder storyboardName="Interactions" id="rei-S7-RFR" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RB5-Hg-lBY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6319" y="-192"/>
+            <point key="canvasLocation" x="6316" y="-214"/>
         </scene>
         <!--UserInterfaceActivityIndicator-->
         <scene sceneID="kqp-wX-GlM">
@@ -263,7 +293,15 @@
                 <viewControllerPlaceholder storyboardName="UserInterfaceActivityIndicator" id="jdq-a3-17E" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dbD-CE-CNS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6408" y="-146"/>
+            <point key="canvasLocation" x="6406" y="-168"/>
+        </scene>
+        <!--RefreshControl-->
+        <scene sceneID="rSn-zt-8m8">
+            <objects>
+                <viewControllerPlaceholder storyboardName="RefreshControl" id="JmH-It-Lpx" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Mfs-lf-9YJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="6331" y="-124"/>
         </scene>
         <!--Presentations-->
         <scene sceneID="JYL-TY-QR4">
@@ -271,7 +309,7 @@
                 <viewControllerPlaceholder storyboardName="Presentations" id="tXh-nS-4b7" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Sb-x6-cQw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6329" y="-237"/>
+            <point key="canvasLocation" x="6327" y="-259"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="VjR-mb-m73">

--- a/IBAnimatableApp/RefreshControl.storyboard
+++ b/IBAnimatableApp/RefreshControl.storyboard
@@ -66,6 +66,9 @@
                                                 <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Hb6-9C-WK3" kind="show" id="Fkx-wr-C05"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -96,6 +99,74 @@
                 <exit id="3EZ-cU-Feo" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="4180" y="-309"/>
+        </scene>
+        <!--Refresh Control Table View View Controller-->
+        <scene sceneID="qph-rI-mCg">
+            <objects>
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="Hb6-9C-WK3" customClass="RefreshControlTableViewViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="uSN-YV-Bvw"/>
+                        <viewControllerLayoutGuide type="bottom" id="Qc7-MT-YHH"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="d3Q-U8-gDq">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLc-UP-L4H" customClass="AnimatableTableView" customModule="IBAnimatable">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="refreshControllCell" textLabel="H57-mo-Hkq" style="IBUITableViewCellStyleDefault" id="rZf-ej-Ffy">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rZf-ej-Ffy" id="NU9-oq-Qhs">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="H57-mo-Hkq">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                    </tableViewCell>
+                                </prototypes>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                        <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
+                                        <color key="value" red="1" green="0.64949758260000001" blue="0.73911788690000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
+                                        <color key="value" red="1" green="0.99588788880000001" blue="0.84024466060000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="dataSource" destination="Hb6-9C-WK3" id="MBu-SN-A7l"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="KLc-UP-L4H" secondAttribute="trailing" id="7vD-mq-JTF"/>
+                            <constraint firstItem="Qc7-MT-YHH" firstAttribute="top" secondItem="KLc-UP-L4H" secondAttribute="bottom" id="R9V-yy-mtb"/>
+                            <constraint firstItem="KLc-UP-L4H" firstAttribute="leading" secondItem="d3Q-U8-gDq" secondAttribute="leading" id="cx9-gx-JSM"/>
+                            <constraint firstItem="KLc-UP-L4H" firstAttribute="top" secondItem="uSN-YV-Bvw" secondAttribute="bottom" id="h1c-3c-kg3"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="KLc-UP-L4H" id="uN5-hm-gIZ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uYv-YL-so7" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4500" y="448"/>
         </scene>
         <!--UITableViewController-->
         <scene sceneID="JpO-ch-v2V">
@@ -204,13 +275,6 @@
                             <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
                                 <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
-                                <color key="value" red="1" green="0.16535832149999999" blue="0.14962058049999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
-                                <color key="value" red="1" green="0.64949758260000001" blue="0.73911788690000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="o1A-WF-mTk" id="GIc-rr-8LK"/>
@@ -241,7 +305,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZOg-Tc-mKd" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="Ggz-NY-fp6" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4921" y="-310"/>
+            <point key="canvasLocation" x="3666" y="449"/>
         </scene>
     </scenes>
     <resources>

--- a/IBAnimatableApp/RefreshControl.storyboard
+++ b/IBAnimatableApp/RefreshControl.storyboard
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CPK-NY-g6P">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Refresh Control-->
+        <scene sceneID="Eos-ME-Hw8">
+            <objects>
+                <tableViewController clearsSelectionOnViewWillAppear="NO" id="CPK-NY-g6P" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="7pC-PR-dIK" customClass="AnimatableTableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="separatorColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <sections>
+                            <tableViewSection footerTitle="" id="j1o-9k-c15">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mzc-bX-U00" style="IBUITableViewCellStyleDefault" id="3uz-Zg-vUb" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3uz-Zg-vUb" id="7hU-zI-5e4">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="UITableViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mzc-bX-U00">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="o1A-WF-mTk" kind="show" id="BDX-Cj-N9s"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="zwL-L7-NaG" style="IBUITableViewCellStyleDefault" id="MZH-Pu-nAn" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MZH-Pu-nAn" id="YcH-Jx-xVe">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="UITableView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zwL-L7-NaG">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                        <connections>
+                            <outlet property="dataSource" destination="CPK-NY-g6P" id="6IM-EI-ov3"/>
+                            <outlet property="delegate" destination="CPK-NY-g6P" id="WLx-8A-ki5"/>
+                        </connections>
+                    </tableView>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Refresh Control" id="aQ7-wN-oJ3">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="v1v-6H-JF0">
+                            <color key="tintColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <segue destination="3EZ-cU-Feo" kind="unwind" unwindAction="unwindToViewController:" id="jBJ-k0-uhP"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sA7-vK-PNc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="3EZ-cU-Feo" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4180" y="-309"/>
+        </scene>
+        <!--UITableViewController-->
+        <scene sceneID="JpO-ch-v2V">
+            <objects>
+                <tableViewController clearsSelectionOnViewWillAppear="NO" id="o1A-WF-mTk" customClass="RefreshControlTableViewController" customModule="IBAnimatableApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="nf9-Xg-Tk0" customClass="AnimatableTableView" customModule="IBAnimatable">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="separatorColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <sections>
+                            <tableViewSection footerTitle="" id="bPL-yI-l5E">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="BEM-GS-fIN" style="IBUITableViewCellStyleDefault" id="wxR-K7-6j2" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wxR-K7-6j2" id="goD-d8-XIK">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Did you try to pull?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BEM-GS-fIN">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="sKx-9v-UUH" style="IBUITableViewCellStyleDefault" id="cy0-4L-hIW" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cy0-4L-hIW" id="LbI-x6-B5L">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Nice control isn't it?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sKx-9v-UUH">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="20R-UK-LoM" style="IBUITableViewCellStyleDefault" id="5zV-uY-Qbh" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5zV-uY-Qbh" id="yQ5-qn-L3m">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Fully customisable from interface builder!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="20R-UK-LoM">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="aFw-yi-rv6" style="IBUITableViewCellStyleDefault" id="ixm-MT-x5a" userLabel="Placeholder" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ixm-MT-x5a" id="sKD-uP-KgG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Amazing!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="aFw-yi-rv6">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
+                                <color key="value" red="1" green="0.16535832149999999" blue="0.14962058049999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
+                                <color key="value" red="1" green="0.64949758260000001" blue="0.73911788690000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
+                        </userDefinedRuntimeAttributes>
+                        <connections>
+                            <outlet property="dataSource" destination="o1A-WF-mTk" id="GIc-rr-8LK"/>
+                            <outlet property="delegate" destination="o1A-WF-mTk" id="hQK-3L-xs9"/>
+                        </connections>
+                    </tableView>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="UITableViewController" id="j5M-Yl-7HR">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="0vd-rg-Giw">
+                            <color key="tintColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <segue destination="Ggz-NY-fp6" kind="unwind" unwindAction="unwindToViewController:" id="LNz-47-F3u"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="hasRefreshControl" value="YES"/>
+                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlTintColor">
+                            <color key="value" red="1" green="0.99588788880000001" blue="0.84024466060000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="refreshControlBackgroundColor">
+                            <color key="value" red="1" green="0.64949758260000001" blue="0.73911788690000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZOg-Tc-mKd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="Ggz-NY-fp6" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="4921" y="-310"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="back" width="21" height="21"/>
+    </resources>
+</document>

--- a/IBAnimatableApp/RefreshControlTableViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewController.swift
@@ -12,7 +12,7 @@ public class RefreshControlTableViewController: AnimatableTableViewController {
     super.viewDidLoad()
 
     // Install action on refresh
-    self.refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
+    refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
   }
 
   public func refresh(_ refreshControl: UIRefreshControl) {
@@ -42,8 +42,8 @@ public class RefreshControlTableViewController: AnimatableTableViewController {
     }
     refreshControl.attributedTitle = NSAttributedString(string: "\(Int(time))", attributes: attributes )
 
-    DispatchQueue.main.after(1) { [weak self] in
-      self?.updateMessage(refreshControl: refreshControl, time: time - 1)
+    DispatchQueue.main.after(1) {
+      self.updateMessage(refreshControl: refreshControl, time: time - 1)
     }
   }
 

--- a/IBAnimatableApp/RefreshControlTableViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewController.swift
@@ -6,24 +6,23 @@
 import UIKit
 import IBAnimatable
 
-public class RefreshTableViewController: AnimatableTableViewController {
+public class RefreshControlTableViewController: AnimatableTableViewController {
 
   override public func viewDidLoad() {
     super.viewDidLoad()
 
     // Install action on refresh
-    self.refreshControl?.addTarget(self, action: #selector(RefreshTableViewController.refresh(_:)), for: .valueChanged)
+    self.refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
   }
 
   public func refresh(_ refreshControl: UIRefreshControl) {
     // could update attributedTitle of refreshControl here
-
     // Simulate an asynchrone refresh, could be a network request...
     let time: TimeInterval = 5
-    self.updateMessage(refreshControl: refreshControl, time: time)
-    DispatchQueue.background.after(time) {
-       // could update attributedTitle at each step
+    updateMessage(refreshControl: refreshControl, time: time)
 
+    DispatchQueue.background.after(time) {
+      // could update attributedTitle at each step
       // end refreshing, maybe reload table data if you do not implement table delegate to update each insert, update and delete events
       DispatchQueue.main.async {
         refreshControl.endRefreshing()
@@ -36,8 +35,9 @@ public class RefreshTableViewController: AnimatableTableViewController {
     guard time >= 0 else {
       return
     }
-    var attributes: [String : Any] = [:]
-    if let color = self.refreshControlTintColor {
+
+    var attributes = [String: Any]()
+    if let color = refreshControlTintColor {
       attributes[NSForegroundColorAttributeName] = color
     }
     refreshControl.attributedTitle = NSAttributedString(string: "\(Int(time))", attributes: attributes )
@@ -50,7 +50,9 @@ public class RefreshTableViewController: AnimatableTableViewController {
 }
 
 // MARK: DispatchQueue utility extension
+
 fileprivate extension DispatchQueue {
+
   static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
 
   func after(_ delay: TimeInterval, execute closure: @escaping () -> Void) {

--- a/IBAnimatableApp/RefreshControlTableViewViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewViewController.swift
@@ -6,13 +6,18 @@
 import UIKit
 import IBAnimatable
 
-public class RefreshControlTableViewController: AnimatableTableViewController {
+public class RefreshControlTableViewViewController: AnimatableViewController {
+
+  @IBOutlet fileprivate weak var tableView: AnimatableTableView!
+  fileprivate let rows = ["Did you try to pull?", "Nice control, isn't it?", "Fully customisable in interface builder", "Amazing!", "iOS10 only... wanna make a PR to change this?"]
 
   override public func viewDidLoad() {
     super.viewDidLoad()
 
     // Install action on refresh
-    self.refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
+    if #available(iOS 10.0, *) {
+      tableView.refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
+    }
   }
 
   public func refresh(_ refreshControl: UIRefreshControl) {
@@ -37,7 +42,7 @@ public class RefreshControlTableViewController: AnimatableTableViewController {
     }
 
     var attributes = [String: Any]()
-    if let color = refreshControlTintColor {
+    if let color = tableView.refreshControlTintColor {
       attributes[NSForegroundColorAttributeName] = color
     }
     refreshControl.attributedTitle = NSAttributedString(string: "\(Int(time))", attributes: attributes )
@@ -45,6 +50,23 @@ public class RefreshControlTableViewController: AnimatableTableViewController {
     DispatchQueue.main.after(1) { [weak self] in
       self?.updateMessage(refreshControl: refreshControl, time: time - 1)
     }
+  }
+
+}
+
+
+// MARK: DispatchQueue utility extension
+
+extension RefreshControlTableViewViewController: UITableViewDataSource {
+
+  public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return rows.count
+  }
+
+  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "refreshControllCell", for: indexPath) as UITableViewCell
+    cell.textLabel?.text = rows[indexPath.row]
+    return cell
   }
 
 }

--- a/IBAnimatableApp/RefreshControlTableViewViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewViewController.swift
@@ -12,16 +12,21 @@ public class RefreshControlTableViewViewController: AnimatableViewController {
   fileprivate let rows = ["Did you try to pull?",
                           "Nice control, isn't it?",
                           "Fully customisable in interface builder",
-                          "Amazing!",
-                          "iOS10 only... wanna make a PR to change this?"]
+                          "Amazing!"]
 
   override public func viewDidLoad() {
     super.viewDidLoad()
 
     // Install action on refresh
+    let refreshControl: UIRefreshControl?
     if #available(iOS 10.0, *) {
-      tableView.refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
+      refreshControl = tableView.refreshControl
+    } else {
+      refreshControl = UIRefreshControl()
+      tableView.addSubview(refreshControl!)
+      tableView.configureRefreshController()
     }
+    refreshControl?.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
   }
 
   public func refresh(_ refreshControl: UIRefreshControl) {

--- a/IBAnimatableApp/RefreshControlTableViewViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewViewController.swift
@@ -9,7 +9,11 @@ import IBAnimatable
 public class RefreshControlTableViewViewController: AnimatableViewController {
 
   @IBOutlet fileprivate weak var tableView: AnimatableTableView!
-  fileprivate let rows = ["Did you try to pull?", "Nice control, isn't it?", "Fully customisable in interface builder", "Amazing!", "iOS10 only... wanna make a PR to change this?"]
+  fileprivate let rows = ["Did you try to pull?",
+                          "Nice control, isn't it?",
+                          "Fully customisable in interface builder",
+                          "Amazing!",
+                          "iOS10 only... wanna make a PR to change this?"]
 
   override public func viewDidLoad() {
     super.viewDidLoad()
@@ -53,7 +57,6 @@ public class RefreshControlTableViewViewController: AnimatableViewController {
   }
 
 }
-
 
 // MARK: DispatchQueue utility extension
 

--- a/IBAnimatableApp/RefreshControlTableViewViewController.swift
+++ b/IBAnimatableApp/RefreshControlTableViewViewController.swift
@@ -56,8 +56,8 @@ public class RefreshControlTableViewViewController: AnimatableViewController {
     }
     refreshControl.attributedTitle = NSAttributedString(string: "\(Int(time))", attributes: attributes )
 
-    DispatchQueue.main.after(1) { [weak self] in
-      self?.updateMessage(refreshControl: refreshControl, time: time - 1)
+    DispatchQueue.main.after(1) {
+      self.updateMessage(refreshControl: refreshControl, time: time - 1)
     }
   }
 


### PR DESCRIPTION
Related to #238 and #425 

A few things in this PR:

- Make `AnimatableTableView` conforms to `RefreshControlDesignable`<s>, iOS10 only, I think we can add a support for lower version, by adding manually the refreshControl. Is it worth it?</s>
- Add `RefreshControlDesignable` examples in playground:
   - For `UITableViewController`.
  - For `UITableView`

Seems big, but its mainly storyboards!

<s>Just one thing: I'm getting these warnings in the console for the `UITableViewController` example, but don't know why 🤔 

```
Failed to set (hasRefreshControl) user defined inspected property on (IBAnimatableApp.RefreshControlTableViewController): Could not load NIB in bundle: 'NSBundle <../IBAnimatableApp.app> (loaded)' with name '' 
Failed to set (refreshControlTintColor) user defined inspected property on (IBAnimatableApp.RefreshControlTableViewController): Could not load NIB in bundle: 'NSBundle <../IBAnimatableApp.app> (loaded)' with name '' 
Failed to set (refreshControlBackgroundColor) user defined inspected property on (IBAnimatableApp.RefreshControlTableViewController): Could not load NIB in bundle: 'NSBundle <../IBAnimatableApp.app> (loaded)' with name '' 
```
</s>