### PR TITLE
[SlideAnimator] Reset toView.transform to CGAffineTransform.identity #no-public-changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Make corner sides case insensitive.
 [#394](https://github.com/IBAnimatable/IBAnimatable/issues/394) by [@mmadjer](https://github.com/mmadjer)
 - Frame is converted to window coordinate space to fix miscalculations in computed values (used with `slideOut`, ...) [#412](https://github.com/IBAnimatable/IBAnimatable/issues/412) by [@redent](https://github.com/redent)
+- Reset destination view's `transform` property to `CGAffineTransform.identity` after a slide transition completes. [#432](https://github.com/IBAnimatable/IBAnimatable/pull/432) by [@broadwaylamb](https://github.com/broadwaylamb)
 
 ---
 ### [3.1.3](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.3)

--- a/IBAnimatable/SlideAnimator.swift
+++ b/IBAnimatable/SlideAnimator.swift
@@ -71,6 +71,7 @@ extension SlideAnimator: UIViewControllerAnimatedTransitioning {
     }
     toView.transform = travel.inverted()
     animateSlideTransition(toView: toView, fromView: fromView, travel: travel) {
+      toView.transform = CGAffineTransform.identity
       fromView.transform = CGAffineTransform.identity
       transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
     }


### PR DESCRIPTION
After a slide transition is ended, we need to reset the destination view's `transform` to `CGAffineTransform.identity `, otherwise it causes weird behaviour, like this overlapping:

![simulator screen shot 3 apr 2017 19 29 24](https://cloud.githubusercontent.com/assets/16309982/24619928/6f7f42ba-18a4-11e7-8f9a-f19f583b029e.png)

Here I tried to pop the view controller with sciences. The settings view controller were exepected to slide from the left, but instead it overlapped the sciences view controller. It is hard to reproduce because I use `UISplitViewController` in my app, and when I test it on iPhone 6/6s/7 Plus, there is this collapsing/separation behaviour triggered by device rotation. It is quite complex, in addition to that `UISplitViewController` doensn't do very well with custom transitions (because it uses some `UINavigationController` magic under the hood). However, I've managed to find some workaround (not very elegant though) and the only thing that remained broken was _this_.

Adding this line of code fixes it completely.

```diff
    animateSlideTransition(toView: toView, fromView: fromView, travel: travel) {
+      toView.transform = CGAffineTransform.identity
      fromView.transform = CGAffineTransform.identity
      transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
    }
```