### PR TITLE
Fix M_PI_2 migration which was breaking transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 [#394](https://github.com/IBAnimatable/IBAnimatable/issues/394) by [@mmadjer](https://github.com/mmadjer)
 - Frame is converted to window coordinate space to fix miscalculations in computed values (used with `slideOut`, ...) [#412](https://github.com/IBAnimatable/IBAnimatable/issues/412) by [@redent](https://github.com/redent)
 - Reset destination view's `transform` property to `CGAffineTransform.identity` after a slide transition completes. [#432](https://github.com/IBAnimatable/IBAnimatable/pull/432) by [@broadwaylamb](https://github.com/broadwaylamb)
+- Fixed `{Flip,Turn,Fold}Animator` which was resulting in broken transitions. Thanks to[@phimage](https://github.com/phimage) for the fix. [#441](https://github.com/IBAnimatable/IBAnimatable/pull/437) by [@tbaranes](https://github.com/tbaranes)
 
 ---
 ### [3.1.3](https://github.com/IBAnimatable/IBAnimatable/releases/tag/3.1.3)

--- a/IBAnimatable/FlipAnimator.swift
+++ b/IBAnimatable/FlipAnimator.swift
@@ -91,7 +91,7 @@ private extension FlipAnimator {
     axesValues = valuesForAxe(initialValue: reverse ? 1.0 : 0.0, reverseValue: 0.5)
     updateAnchorPointAndOffset(anchorPoint: CGPoint(x: axesValues.0, y: axesValues.1), view: flippedSectionOfToView)
 
-    flippedSectionOfToView.layer.transform = rotate(angle: reverse ? .pi * 2 : -.pi * 2)
+    flippedSectionOfToView.layer.transform = rotate(angle: (reverse ? .pi : -.pi) / 2)
     return ((flippedSectionOfFromView, flippedSectionOfFromViewShadow), (flippedSectionOfToView, flippedSectionOfToViewShadow))
   }
 
@@ -173,7 +173,7 @@ private extension FlipAnimator {
                              completion: @escaping AnimatableCompletion) {
     UIView.animateKeyframes(withDuration: transitionDuration, delay: 0, options: .layoutSubviews, animations: {
       UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 0.5, animations: {
-        flippedSectionOfFromView.0.layer.transform = self.rotate(angle: self.reverse ? -.pi * 2 : .pi * 2)
+        flippedSectionOfFromView.0.layer.transform = self.rotate(angle: (self.reverse ? -.pi : .pi) / 2)
         flippedSectionOfFromView.1.alpha = 1.0
       })
 

--- a/IBAnimatable/FoldAnimator.swift
+++ b/IBAnimatable/FoldAnimator.swift
@@ -108,14 +108,14 @@ private extension FoldAnimator {
       axesValues = valuesForAxe(initialValue: self.reverse ? width : 0.0, reverseValue: height / 2)
       leftToViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       axesValues = valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
-      leftToViewFold.layer.transform = CATransform3DMakeRotation(.pi * 2, axesValues.0, axesValues.1, 0.0)
+      leftToViewFold.layer.transform = CATransform3DMakeRotation(.pi / 2, axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(leftToViewFold)
 
       let rightToViewFold = makeSnapshot(from: toView, afterUpdates: true, offset: offset + foldSize, left: false)
       axesValues = valuesForAxe(initialValue: self.reverse ? width : 0.0, reverseValue: height / 2)
       rightToViewFold.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
       axesValues = valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
-      rightToViewFold.layer.transform = CATransform3DMakeRotation(-.pi * 2, axesValues.0, axesValues.1, 0.0)
+      rightToViewFold.layer.transform = CATransform3DMakeRotation(-.pi / 2, axesValues.0, axesValues.1, 0.0)
       toViewFolds.append(rightToViewFold)
     }
     return [toViewFolds, fromViewFolds]
@@ -185,14 +185,14 @@ private extension FoldAnimator {
         var axesValues = self.valuesForAxe(initialValue: self.reverse ? 0.0 : self.width, reverseValue: self.height / 2)
         leftFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         axesValues = self.valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
-        leftFromView.layer.transform = CATransform3DRotate(self.transform, .pi * 2, axesValues.0, axesValues.1, 0)
+        leftFromView.layer.transform = CATransform3DRotate(self.transform, .pi / 2, axesValues.0, axesValues.1, 0)
         leftFromView.subviews[1].alpha = 1.0
 
         let rightFromView = fromViewFolds[i * 2 + 1]
         axesValues = self.valuesForAxe(initialValue: self.reverse ? 0.0 : self.width, reverseValue: self.height / 2)
         rightFromView.layer.position = CGPoint(x: axesValues.0, y: axesValues.1)
         axesValues = self.valuesForAxe(initialValue: 0.0, reverseValue: 1.0)
-        rightFromView.layer.transform = CATransform3DRotate(self.transform, -.pi * 2, axesValues.0, axesValues.1, 0)
+        rightFromView.layer.transform = CATransform3DRotate(self.transform, -.pi / 2, axesValues.0, axesValues.1, 0)
         rightFromView.subviews[1].alpha = 1.0
 
         let leftToView = toViewFolds[i * 2]

--- a/IBAnimatable/TurnAnimator.swift
+++ b/IBAnimatable/TurnAnimator.swift
@@ -56,10 +56,10 @@ extension TurnAnimator: UIViewControllerAnimatedTransitioning {
 
   private func animateTurnTransition(fromView: UIView, toView: UIView, completion: @escaping AnimatableCompletion) {
     let factor = reverse ? 1.0 : -1.0
-    toView.layer.transform = rotate(angle: factor * -.pi * 2)
+    toView.layer.transform = rotate(angle: factor * -.pi / 2)
     UIView.animateKeyframes(withDuration: transitionDuration, delay: 0.0, options: .layoutSubviews, animations: {
       UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 0.5) {
-            fromView.layer.transform = self.rotate(angle: factor * .pi * 2)
+            fromView.layer.transform = self.rotate(angle: factor * .pi / 2)
       }
 
       UIView.addKeyframe(withRelativeStartTime: 0.5, relativeDuration: 0.5) {


### PR DESCRIPTION
Close #440 
Fix a few animators, introduced in https://github.com/IBAnimatable/IBAnimatable/pull/237/commits/10104cd0a15cfc29d0c38112d5b4b6ad04aa0a3c:

- Flip
- Turn
- Fold

Thanks to @phimage for the fix! 
@SD10 This fix the broken transition you reported a few days ago 

May also close #305 ? Need more testing to confirm