### PR TITLE
Refactoring travis #no-public-changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,31 @@
-osx_image: xcode8
 language: objective-c
-before_install: 
+osx_image: xcode8.3
+env:
+  global:
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
+    - XCODEPROJ="IBAnimatable.xcodeproj"
+    - IOS_FRAMEWORK_SCHEME="IBAnimatable"
+    - IOS_APP_SCHEME="IBAnimatableApp"
+  matrix:
+    - DESTINATION="OS=10.3,name=iPad Pro (12.9-Inch)" SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
+    - DESTINATION="OS=9.3,name=iPhone 6s Plus"        SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
+before_install:
   - bundle install
+  - brew update
   - brew outdated swiftlint || brew upgrade swiftlint
-script: 
-  - xcodebuild build -project IBAnimatable.xcodeproj -scheme IBAnimatableApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'
+script:
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -showsdks
+
+  # Build Framework in Release
+  - xcodebuild clean build -project "$XCODEPROJ" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release | xcpretty;
+
+  # Build App in Release
+  - xcodebuild clean build -project "$XCODEPROJ" -scheme "$APP_SCHEME" -destination "$DESTINATION" -configuration Release | xcpretty;
+
   - bundle exec danger
+
+after_success:
+   - sleep 10 # Workaround for https://github.com/travis-ci/travis-ci/issues/4725


### PR DESCRIPTION
I wanted to add iOS9 compilation to travis to avoid merge of PR that doesn't compile on that version (cf #442), but in the current state of travis, I think it was too complicated to add a simple platform. So I went ahead, and refactor it. Now travis may looks more complicated, but in fact it is much simpler!

- Grouped the `matrix` which means every updates of the build platform. That also works when we want to add a new platform
- Avoid duplicating schemes. Our schemes are the same whatever the build is 
- Simplify the process to add a new build in the `script` phase. Starting now, variables are available which means, adding a new build phase will simply ask an update for the xcodebuild's properties, but the `IBAnimatible` related part won't change (thinking of #434 )
- Build the framework and the app separately for each platforms
- ...

Anyway, I think that's a good move, let's see what travis says!