### PR TITLE
Fix activity indicator broken animation #no-public-changes

### DIFF
--- a/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallGridBeat.swift
@@ -21,6 +21,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
     let durations = [0.96, 0.93, 1.19, 1.13, 1.34, 0.94, 1.2, 0.82, 1.19]
     let beginTime = CACurrentMediaTime()
     let beginTimes = [0.36, 0.4, 0.68, 0.41, 0.71, -0.15, -0.12, 0.01, 0.32]
+    let animation = defaultAnimation
 
     // Draw circles
     for i in 0 ..< 3 {
@@ -45,7 +46,7 @@ public class ActivityIndicatorAnimationBallGridBeat: ActivityIndicatorAnimating 
 
 private extension ActivityIndicatorAnimationBallGridBeat {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "opacity")
     animation.keyTimes = [0, 0.5, 1]
     animation.timingFunctions = [timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulse.swift
@@ -10,35 +10,35 @@ public class ActivityIndicatorAnimationBallPulse: ActivityIndicatorAnimating {
   // MARK: ActivityIndicatorAnimating
 
   public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
+    let circleSpacing: CGFloat = 2
+    let circleSize: CGFloat = (size.width - 2 * circleSpacing) / 3
+    let x: CGFloat = (layer.bounds.size.width - size.width) / 2
+    let y: CGFloat = (layer.bounds.size.height - circleSize) / 2
+    let beginTime = CACurrentMediaTime()
+    let beginTimes: [CFTimeInterval] = [0.12, 0.24, 0.36]
+    let animation = defaultAnimation
 
-        let circleSpacing: CGFloat = 2
-        let circleSize: CGFloat = (size.width - 2 * circleSpacing) / 3
-        let x: CGFloat = (layer.bounds.size.width - size.width) / 2
-        let y: CGFloat = (layer.bounds.size.height - circleSize) / 2
-        let beginTime = CACurrentMediaTime()
-        let beginTimes: [CFTimeInterval] = [0.12, 0.24, 0.36]
+    // Draw circles
+    for i in 0 ..< 3 {
+      let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
+      let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
+                         y: y,
+                         width: circleSize,
+                         height: circleSize)
 
-        // Draw circles
-        for i in 0 ..< 3 {
-            let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
-            let frame = CGRect(x: x + circleSize * CGFloat(i) + circleSpacing * CGFloat(i),
-                y: y,
-                width: circleSize,
-                height: circleSize)
-
-            animation.beginTime = beginTime + beginTimes[i]
-            circle.frame = frame
-            circle.add(animation, forKey: "animation")
-            layer.addSublayer(circle)
-        }
+      animation.beginTime = beginTime + beginTimes[i]
+      circle.frame = frame
+      circle.add(animation, forKey: "animation")
+      layer.addSublayer(circle)
     }
+  }
 }
 
 // MARK: - Setup
 
 private extension ActivityIndicatorAnimationBallPulse {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let duration: CFTimeInterval = 0.75
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.2, 0.68, 0.18, 1.08)
     let animation = CAKeyframeAnimation(keyPath: "transform.scale")

--- a/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallPulseSync.swift
@@ -23,6 +23,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
     let y = (layer.bounds.size.height - circleSize) / 2
     let beginTime = CACurrentMediaTime()
     let beginTimes: [CFTimeInterval] = [0.07, 0.14, 0.21]
+    let animation = defaultAnimation
 
     // Draw circles
     for i in 0 ..< 3 {
@@ -46,7 +47,7 @@ public class ActivityIndicatorAnimationBallPulseSync: ActivityIndicatorAnimating
 
 private extension ActivityIndicatorAnimationBallPulseSync {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let deltaY = (size.height / 2 - circleSize / 2) / 2
     let timingFunciton = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
     let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")

--- a/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationBallTrianglePath.swift
@@ -20,6 +20,7 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
     let deltaY = size.height / 2 - circleSize / 2
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
+    let animation = defaultAnimation
 
     let topCenterCircle = ActivityIndicatorShape.ring.makeLayer(size: CGSize(width: circleSize, height: circleSize), color: color)
     change(animation: animation, values:["{0,0}", "{hx,fy}", "{-hx,fy}", "{0,0}"], deltaX: deltaX, deltaY: deltaY)
@@ -46,7 +47,7 @@ public class ActivityIndicatorAnimationBallTrianglePath: ActivityIndicatorAnimat
 
 private extension ActivityIndicatorAnimationBallTrianglePath {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform")
     animation.keyTimes = [0, 0.33, 0.66, 1]
     animation.timingFunctions = [timingFunction, timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScale.swift
@@ -20,6 +20,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTime = CACurrentMediaTime()
     let beginTimes = [0.1, 0.2, 0.3, 0.4, 0.5]
+    let animation = defaultAnimation
 
     for i in 0 ..< 5 {
       let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
@@ -38,7 +39,7 @@ public class ActivityIndicatorAnimationLineScale: ActivityIndicatorAnimating {
 
 private extension ActivityIndicatorAnimationLineScale {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")
     animation.keyTimes = [0, 0.5, 1]
     animation.timingFunctions = [timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScaleParty.swift
@@ -20,6 +20,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
     let durations: [CFTimeInterval] = [1.26, 0.43, 1.01, 0.73]
     let beginTime = CACurrentMediaTime()
     let beginTimes: [CFTimeInterval] = [0.77, 0.29, 0.28, 0.74]
+    let animation = defaultAnimation
 
     // Animation
     for i in 0..<4 {
@@ -38,7 +39,7 @@ public class ActivityIndicatorAnimationLineScaleParty: ActivityIndicatorAnimatin
 
 private extension ActivityIndicatorAnimationLineScaleParty {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath:"transform.scale")
     animation.keyTimes = [0, 0.5, 1]
     animation.timingFunctions = [timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOut.swift
@@ -19,6 +19,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTime = CACurrentMediaTime()
     let beginTimes = [0.4, 0.2, 0, 0.2, 0.4]
+    let animation = defaultAnimation
 
     // Draw lines
     for i in 0 ..< 5 {
@@ -42,7 +43,7 @@ public class ActivityIndicatorAnimationLineScalePulseOut: ActivityIndicatorAnima
 
 private extension ActivityIndicatorAnimationLineScalePulseOut {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.85, 0.25, 0.37, 0.85)
     let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")
     animation.keyTimes = [0, 0.5, 1]

--- a/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -20,7 +20,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTimes = [0.5, 0.25, 0, 0.25, 0.5]
-
+    let animation = defaultAnimation
     for i in 0 ..< 5 {
       let line = ActivityIndicatorShape.line.makeLayer(size: CGSize(width: lineSize, height: size.height), color: color)
       let frame = CGRect(x: x + lineSize * 2 * CGFloat(i),
@@ -40,7 +40,7 @@ public class ActivityIndicatorAnimationLineScalePulseOutRapid: ActivityIndicator
 
 private extension ActivityIndicatorAnimationLineScalePulseOutRapid {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.scale.y")
     animation.keyTimes = [0, 0.8, 0.9]
     animation.timingFunctions = [timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -21,6 +21,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTime = CACurrentMediaTime()
     let beginTimes: [CFTimeInterval] = [0.12, 0.24, 0.36, 0.48, 0.6, 0.72, 0.84, 0.96]
+    let animation = defaultAnimation
 
     for i in 0 ..< 8 {
       let line = makeLineLayer(angle: CGFloat.pi / 4 * CGFloat(i),
@@ -40,7 +41,7 @@ public class ActivityIndicatorAnimationLineSpinFadeLoader: ActivityIndicatorAnim
 
 private extension ActivityIndicatorAnimationLineSpinFadeLoader {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "opacity")
     animation.keyTimes = [0, 0.5, 1]
     animation.timingFunctions = [timingFunction, timingFunction]

--- a/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSemiCircleSpin.swift
@@ -23,7 +23,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
       height: size.height
     )
     circle.frame = frame
-    circle.add(animation, forKey: "animation")
+    circle.add(defaultAnimation, forKey: "animation")
     layer.addSublayer(circle)
   }
 }
@@ -32,7 +32,7 @@ public class ActivityIndicatorAnimationSemiCircleSpin: ActivityIndicatorAnimatin
 
 private extension ActivityIndicatorAnimationSemiCircleSpin {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let animation = CAKeyframeAnimation(keyPath: "transform.rotation.z")
     animation.keyTimes = [0, 0.5, 1]
     animation.values = [0, CGFloat.pi, 2 * CGFloat.pi]

--- a/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationSquareSpin.swift
@@ -14,14 +14,13 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
   // MARK: ActivityIndicatorAnimating
 
   public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
-
     let square = ActivityIndicatorShape.rectangle.makeLayer(size: size, color: color)
     let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
                        y: (layer.bounds.size.height - size.height) / 2,
                        width: size.width,
                        height: size.height)
     square.frame = frame
-    square.add(animation, forKey: "animation")
+    square.add(defaultAnimation, forKey: "animation")
     layer.addSublayer(square)
   }
 
@@ -31,7 +30,7 @@ public class ActivityIndicatorAnimationSquareSpin: ActivityIndicatorAnimating {
 
 private extension ActivityIndicatorAnimationSquareSpin {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.09, 0.57, 0.49, 0.9)
     let animation = CAKeyframeAnimation(keyPath: "transform")
     animation.keyTimes = [0, 0.25, 0.5, 0.75, 1]

--- a/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
+++ b/IBAnimatable/ActivityIndicatorAnimationTriangleSkewSpin.swift
@@ -18,7 +18,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
     let y = (layer.bounds.size.height - size.height) / 2
     let triangle = ActivityIndicatorShape.triangle.makeLayer(size: size, color: color)
     triangle.frame = CGRect(x: x, y: y, width: size.width, height: size.height)
-    triangle.add(animation, forKey: "animation")
+    triangle.add(defaultAnimation, forKey: "animation")
     layer.addSublayer(triangle)
   }
 
@@ -28,7 +28,7 @@ public class ActivityIndicatorAnimationTriangleSkewSpin: ActivityIndicatorAnimat
 
 private extension ActivityIndicatorAnimationTriangleSkewSpin {
 
-  var animation: CAKeyframeAnimation {
+  var defaultAnimation: CAKeyframeAnimation {
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.09, 0.57, 0.49, 0.9)
     let animation = CAKeyframeAnimation(keyPath: "transform")
     animation.keyTimes = [0, 0.25, 0.5, 0.75, 1]


### PR DESCRIPTION
Instead of reintroducing the `self.`, I renamed the variable to be sure that it won't compile.
I didn't test them all, just the broken one in my app. I think we should fully retest the playground app to be sure there's no regression.