### PR TITLE
Fix UITextField borderStyle when no borders set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ N/A
 
 #### Bugfixes
 
-N/A
+- `AnimatableTextField` won't override anymore the default border if no custom one set. [#457](https://github.com/IBAnimatable/IBAnimatable/pull/457) by [tbaranes](https://github.com/tbaranes)
 
 ---
 ### [4.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.0.0)

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -30,8 +30,9 @@ public protocol BorderDesignable {
 
 public extension BorderDesignable where Self: UITextField {
   public func configureBorder() {
-    // set the borderSytle to `.None` to support single side of border
-    borderStyle = .none
+    if borderWidth > 0 {
+      borderStyle = .none
+    }
     commonConfigBorder()
   }
 }


### PR DESCRIPTION
That's a bit tricky: in the current configuration, if using `AnimatableTextField` without setting a custom border, the `borderStyle` will simply set to `.none` even if we want to keep it. I didn't find a way to fix it using `borderSides`, so I used `borderWidth` instead. Due to that situation, placeholders won't be displayed anymore too.

<strike>I need more testing to confirm but may be related to #451, the issue there is different since borders are used</strike>