### PR TITLE
Call `configureImages` when properties are set programatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ N/A
 
 - `AnimatableTextField` won't override anymore the default border if no custom one set. [#457](https://github.com/IBAnimatable/IBAnimatable/pull/457) by [tbaranes](https://github.com/tbaranes)
 - Make `placeholderColor` working with `placeholderText` AND `placehodler`. It will keep the current priorirty: `placeholderText` > `placehodler`. [#459](https://github.com/IBAnimatable/IBAnimatable/pull/459) by [@tbaranes](https://github.com/tbaranes)
+- Fixed `AnimatableTextField` interface update when using it programatically [#458](https://github.com/IBAnimatable/IBAnimatable/pull/458) by [@tbaranes](https://github.com/tbaranes)
 
 ---
 ### [4.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.0.0)

--- a/IBAnimatable/AnimatableTextField.swift
+++ b/IBAnimatable/AnimatableTextField.swift
@@ -134,15 +134,53 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - SideImageDesignable
-  @IBInspectable open var leftImage: UIImage?
-  @IBInspectable open var leftImageLeftPadding: CGFloat = CGFloat.nan
-  @IBInspectable open var leftImageRightPadding: CGFloat = CGFloat.nan
-  @IBInspectable open var leftImageTopPadding: CGFloat = CGFloat.nan
+  @IBInspectable open var leftImage: UIImage? {
+    didSet {
+      configureImages()
+    }
+  }
 
-  @IBInspectable open var rightImage: UIImage?
-  @IBInspectable open var rightImageLeftPadding: CGFloat = CGFloat.nan
-  @IBInspectable open var rightImageRightPadding: CGFloat = CGFloat.nan
-  @IBInspectable open var rightImageTopPadding: CGFloat = CGFloat.nan
+  @IBInspectable open var leftImageLeftPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var leftImageRightPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var leftImageTopPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var rightImage: UIImage? {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var rightImageLeftPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var rightImageRightPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
+
+  @IBInspectable open var rightImageTopPadding: CGFloat = CGFloat.nan {
+    didSet {
+      configureImages()
+    }
+  }
 
   // MARK: - CSSPlaceholderable
   @IBInspectable open var placeholderColor: UIColor? {


### PR DESCRIPTION
Partially fixed #451 (still an issue with the placeholder), but that fixed the images update when using `AnimatableTextField` programmatically.