### PR TITLE
Fix placeholderColor when using basic placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ N/A
 #### Bugfixes
 
 - `AnimatableTextField` won't override anymore the default border if no custom one set. [#457](https://github.com/IBAnimatable/IBAnimatable/pull/457) by [tbaranes](https://github.com/tbaranes)
+- Make `placeholderColor` working with `placeholderText` AND `placehodler`. It will keep the current priorirty: `placeholderText` > `placehodler`. [#459](https://github.com/IBAnimatable/IBAnimatable/pull/459) by [@tbaranes](https://github.com/tbaranes)
 
 ---
 ### [4.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.0.0)

--- a/IBAnimatable/PlaceholderDesignable.swift
+++ b/IBAnimatable/PlaceholderDesignable.swift
@@ -18,7 +18,8 @@ public extension PlaceholderDesignable where Self: UITextField {
   var placeholderText: String? { get { return "" } set {} }
 
   public func configurePlaceholderColor() {
-    if let placeholderColor = placeholderColor, let placeholder = placeholder {
+    let text = placeholderText ?? placeholder
+    if let placeholderColor = placeholderColor, let placeholder = text {
       attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSForegroundColorAttributeName: placeholderColor])
     }
   }


### PR DESCRIPTION
While trying to fix #451, I encountered a new issue: `placeholderColor` wasn't working 😨 
In the end, the issue was simply that I wasn't using `placeholderText` but `placeholder`. I don't know if that's the right fix, but I'm even wondering if `placeholderText` should exist in the first place. That PR will make `placeholderColor` available for `placeholderText` AND `placeholder`, but it will keep the current priority level: `placeholderText` > `placeholder`.

That also makes me wondering if it's really useful to have `placeholderText` since the property already exists natively and worked in interface builder. I have also the same question for `fillColor`. I have the impression that just bring confusion. If anyone is interested to discuss this, let's open a new issue about this.