### PR TITLE
Add class only requirement to Designable protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### API breaking changes
 
-N/A
+- Designable protocols have been changed to `class` only protocols. [#463](https://github.com/IBAnimatable/IBAnimatable/pull/463) by [@SD10](https://github.com/SD10)
 
 #### Enhancements
 

--- a/IBAnimatable/ActivityIndicatorAnimating.swift
+++ b/IBAnimatable/ActivityIndicatorAnimating.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// Protocol for all activity indicator classes.
-public protocol ActivityIndicatorAnimating {
+public protocol ActivityIndicatorAnimating: class {
   /**
    Define the animation for the activity indicator.
 

--- a/IBAnimatable/BackgroundImageDesignable.swift
+++ b/IBAnimatable/BackgroundImageDesignable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// Protocol for designing background image
-public protocol BackgroundImageDesignable {
+public protocol BackgroundImageDesignable: class {
 
   /**
    * The background image

--- a/IBAnimatable/BarButtonItemDesignable.swift
+++ b/IBAnimatable/BarButtonItemDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol BarButtonItemDesignable {
+public protocol BarButtonItemDesignable: class {
   var roundedImage: UIImage? { get set }
 }
 

--- a/IBAnimatable/BlurDesignable.swift
+++ b/IBAnimatable/BlurDesignable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// A protocol provides blur designable feature.
-public protocol BlurDesignable {
+public protocol BlurDesignable: class {
   /**
    Blur effect style: `extraLight`, `light`, `dark`, `regular` (iOS 10+) or `prominent` (iOS 10+).
    */

--- a/IBAnimatable/BorderDesignable.swift
+++ b/IBAnimatable/BorderDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol BorderDesignable {
+public protocol BorderDesignable: class {
   /**
    `bordertype: solid, dash, if not specified, solid will be used
    */

--- a/IBAnimatable/CheckBoxDesignable.swift
+++ b/IBAnimatable/CheckBoxDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol CheckBoxDesignable {
+public protocol CheckBoxDesignable: class {
   var checked: Bool { get set }
   var checkedImage: UIImage? { get set }
   var uncheckedImage: UIImage? { get set }

--- a/IBAnimatable/CornerDesignable.swift
+++ b/IBAnimatable/CornerDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol CornerDesignable {
+public protocol CornerDesignable: class {
   /**
    `border-radius`
    */

--- a/IBAnimatable/FillDesignable.swift
+++ b/IBAnimatable/FillDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol FillDesignable {
+public protocol FillDesignable: class {
   var fillColor: UIColor? { get set }
   var predefinedColor: ColorType? { get set }
   var opacity: CGFloat { get set }

--- a/IBAnimatable/GradientDesignable.swift
+++ b/IBAnimatable/GradientDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol GradientDesignable {
+public protocol GradientDesignable: class {
   var startColor: UIColor? { get set }
   var endColor: UIColor? { get set }
   var predefinedGradient: GradientType? { get set }

--- a/IBAnimatable/MaskDesignable.swift
+++ b/IBAnimatable/MaskDesignable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// A protocol provides mask designable feature.
-public protocol MaskDesignable {
+public protocol MaskDesignable: class {
   /**
    The type of the mask used for masking an IBAnimatable UI element.
 

--- a/IBAnimatable/NavigationBarDesginable.swift
+++ b/IBAnimatable/NavigationBarDesginable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol NavigationBarDesignable {
+public protocol NavigationBarDesignable: class {
   /**
    Specify whether is solid color only, if `true` will remove hairline from navigation bar
    */

--- a/IBAnimatable/PaddingDesignable.swift
+++ b/IBAnimatable/PaddingDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol PaddingDesignable {
+public protocol PaddingDesignable: class {
   /**
     `padding-left`
   */

--- a/IBAnimatable/PlaceholderDesignable.swift
+++ b/IBAnimatable/PlaceholderDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol PlaceholderDesignable {
+public protocol PlaceholderDesignable: class {
   /**
    `color` within `::-webkit-input-placeholder`, `::-moz-placeholder` or `:-ms-input-placeholder`
    */

--- a/IBAnimatable/RefreshControlerDesignable.swift
+++ b/IBAnimatable/RefreshControlerDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol RefreshControlDesignable {
+public protocol RefreshControlDesignable: class {
 
   /**
    Component need to display a refresh control

--- a/IBAnimatable/RootWindowDesignable.swift
+++ b/IBAnimatable/RootWindowDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol RootWindowDesignable {
+public protocol RootWindowDesignable: class {
   /**
    Root window background color
    */

--- a/IBAnimatable/RotationDesignable.swift
+++ b/IBAnimatable/RotationDesignable.swift
@@ -9,7 +9,7 @@ import Darwin
 /**
   It is not able to preview the rotation in IB.
 */
-public protocol RotationDesignable {
+public protocol RotationDesignable: class {
   var rotate: CGFloat { get set }
 }
 

--- a/IBAnimatable/ShadowDesignable.swift
+++ b/IBAnimatable/ShadowDesignable.swift
@@ -10,7 +10,7 @@ import UIKit
 
   To use them, `UIView`'s `clipsToBounds` and `CALayer`'s `masksToBounds` (`Clip Subviews` in IB) must be `false`,
 */
-public protocol ShadowDesignable {
+public protocol ShadowDesignable: class {
   /**
    `color` when using with `box-shadow`
   */

--- a/IBAnimatable/SideImageDesignable.swift
+++ b/IBAnimatable/SideImageDesignable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// Protocol for designing side image
-public protocol SideImageDesignable {
+public protocol SideImageDesignable: class {
   /**
    * The left image
    */

--- a/IBAnimatable/SliderImagesDesignable.swift
+++ b/IBAnimatable/SliderImagesDesignable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// Protocol for designing slider image
-public protocol SliderImagesDesignable {
+public protocol SliderImagesDesignable: class {
 
   /**
    * The thumb image when slider state is `normal`

--- a/IBAnimatable/StatusBarDesignable.swift
+++ b/IBAnimatable/StatusBarDesignable.swift
@@ -5,6 +5,6 @@
 
 import UIKit
 
-public protocol StatusBarDesignable {
+public protocol StatusBarDesignable: class {
   var lightStatusBar: Bool { get set }
 }

--- a/IBAnimatable/TableViewCellDesignable.swift
+++ b/IBAnimatable/TableViewCellDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol TableViewCellDesignable {
+public protocol TableViewCellDesignable: class {
   var removeSeparatorMargins: Bool { get set }
 }
 

--- a/IBAnimatable/TintDesignable.swift
+++ b/IBAnimatable/TintDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol TintDesignable {
+public protocol TintDesignable: class {
   /**
    Opacity in tint Color (White): from 0 to 1
    */

--- a/IBAnimatable/ViewControllerDesignable.swift
+++ b/IBAnimatable/ViewControllerDesignable.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public protocol ViewControllerDesignable {
+public protocol ViewControllerDesignable: class {
   var hideNavigationBar: Bool { get set }
 }
 

--- a/IBAnimatableApp/GradientViewController.swift
+++ b/IBAnimatableApp/GradientViewController.swift
@@ -27,14 +27,14 @@ class GradientViewController: UIViewController {
       gView.startColor = ColorType(rawValue: self.colorValues.value(at: 0))?.color
       gView.endColor = ColorType(rawValue: self.colorValues.value(at: 0))?.color
     }
-    var navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
+    let navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
     navigationBar?.copyGradient(from: gView)
     navigationBar?.configureGradient()
   }
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    var navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
+    let navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
     navigationBar?.resetGradient()
     navigationBar?.setBackgroundImage(nil, for: .default)
   }
@@ -72,7 +72,7 @@ extension GradientViewController : UIPickerViewDelegate, UIPickerViewDataSource 
     }
     gView.configureGradient()
 
-    var navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
+    let navigationBar = self.navigationController?.navigationBar as? DesignableNavigationBar
     navigationBar?.copyGradient(from: gView)
     navigationBar?.configureGradient()
   }
@@ -80,14 +80,14 @@ extension GradientViewController : UIPickerViewDelegate, UIPickerViewDataSource 
 
 fileprivate extension GradientDesignable {
 
-  mutating func copyGradient(from designable: GradientDesignable) {
+  func copyGradient(from designable: GradientDesignable) {
     predefinedGradient = designable.predefinedGradient
     startColor = designable.startColor
     endColor = designable.endColor
     startPoint = designable.startPoint
   }
 
-  mutating func resetGradient(defaultStartPoint: GradientStartPoint = .top) {
+  func resetGradient(defaultStartPoint: GradientStartPoint = .top) {
     predefinedGradient = nil
     startColor = nil
     endColor = nil


### PR DESCRIPTION
### Summary of Pull Requests:
Changes the `Designable` protocols to be `class` only protocols

How should we handle the CHANGELOG entry? 

Technically this is an API Breaking change if someone was using these protocols on a `struct` for some reason.