### PR TITLE
Replace CGFloat.pi with CGFloat(Double.pi) for ActivityIndicatorShape #no-public-changes

### DIFF
--- a/IBAnimatable/ActivityIndicatorShape.swift
+++ b/IBAnimatable/ActivityIndicatorShape.swift
@@ -54,7 +54,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
                           startAngle: 0,
-                          endAngle: 2 * CGFloat.pi,
+                          endAngle: 2 * CGFloat(Double.pi),
                           clockwise: false)
     layer.fillColor = color.cgColor
     layer.apply(path: path, size: size)
@@ -66,8 +66,8 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
-                          startAngle: -CGFloat.pi / 6,
-                          endAngle: -5 * CGFloat.pi / 6,
+                          startAngle: -CGFloat(Double.pi) / 6,
+                          endAngle: -5 * CGFloat(Double.pi) / 6,
                           clockwise: false)
     path.close()
     layer.fillColor = color.cgColor
@@ -87,7 +87,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
                           startAngle: 0,
-                          endAngle: 2 * CGFloat.pi,
+                          endAngle: 2 * CGFloat(Double.pi),
                           clockwise: false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -101,17 +101,17 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:-3 * CGFloat.pi / 4,
-                          endAngle:-CGFloat.pi / 4,
+                          startAngle:-3 * CGFloat(Double.pi) / 4,
+                          endAngle:-CGFloat(Double.pi) / 4,
                           clockwise:true)
     path.move(
-      to: CGPoint(x: size.width / 2 - size.width / 2 * cos(CGFloat.pi / 4),
-        y: size.height / 2 + size.height / 2 * sin(CGFloat.pi / 4))
+      to: CGPoint(x: size.width / 2 - size.width / 2 * cos(CGFloat(Double.pi) / 4),
+        y: size.height / 2 + size.height / 2 * sin(CGFloat(Double.pi) / 4))
     )
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:-5 * CGFloat.pi / 4,
-                          endAngle:-7 * CGFloat.pi / 4,
+                          startAngle:-5 * CGFloat(Double.pi) / 4,
+                          endAngle:-7 * CGFloat(Double.pi) / 4,
                           clockwise:false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -125,17 +125,17 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:3 * CGFloat.pi / 4,
-                          endAngle:5 * CGFloat.pi / 4,
+                          startAngle:3 * CGFloat(Double.pi) / 4,
+                          endAngle:5 * CGFloat(Double.pi) / 4,
                           clockwise:true)
     path.move(
-      to: CGPoint(x: size.width / 2 + size.width / 2 * cos(CGFloat.pi / 4),
-        y: size.height / 2 - size.height / 2 * sin(CGFloat.pi / 4))
+      to: CGPoint(x: size.width / 2 + size.width / 2 * cos(CGFloat(Double.pi) / 4),
+        y: size.height / 2 - size.height / 2 * sin(CGFloat(Double.pi) / 4))
     )
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius:size.width / 2,
-                          startAngle:-CGFloat.pi / 4,
-                          endAngle:CGFloat.pi / 4,
+                          startAngle:-CGFloat(Double.pi) / 4,
+                          endAngle:CGFloat(Double.pi) / 4,
                           clockwise:true)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -149,8 +149,8 @@ private extension ActivityIndicatorShape {
     let path = UIBezierPath()
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 2,
-                          startAngle: -3 * CGFloat.pi / 4,
-                          endAngle: -CGFloat.pi / 4,
+                          startAngle: -3 * CGFloat(Double.pi) / 4,
+                          endAngle: -CGFloat(Double.pi) / 4,
                           clockwise: false)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor
@@ -206,7 +206,7 @@ private extension ActivityIndicatorShape {
     path.addArc(withCenter: CGPoint(x: size.width / 2, y: size.height / 2),
                           radius: size.width / 4,
                           startAngle: 0,
-                          endAngle: 2 * CGFloat.pi,
+                          endAngle: 2 * CGFloat(Double.pi),
                           clockwise: true)
     layer.fillColor = nil
     layer.strokeColor = color.cgColor


### PR DESCRIPTION
I have experienced an issue that had been described here ninjaprox/NVActivityIndicatorView#138.

Since activity indicator animations in IBAnimatable have been ported from the `NVActivityIndicatorView` project, I thought that the solution had to be the same, and it worked.

This patch fixes missing activity indicator animations on iPhone 5.

P. S. Can we make a patch release if this PR is merged?