### PR TITLE
Add tests for PaddingDesignable & fix height bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ N/A
 
 #### Bugfixes
 
-N/A
+- Padding UIView for `PaddingDesignable` can't expand beyond `UITextField` and now has a default height of 1pt. [#483](https://github.com/IBAnimatable/IBAnimatable/pull/483) by [@SD10](https://github.com/SD10)
 
 ### [4.1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.1.0)
 

--- a/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		B0B332411ECA7FF400928CB4 /* AnimatableSliderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B332401ECA7FF400928CB4 /* AnimatableSliderTests.swift */; };
 		B0B332431ECA81A800928CB4 /* SliderImagesDesignableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B332421ECA81A800928CB4 /* SliderImagesDesignableTests.swift */; };
 		B0B332451ECA880A00928CB4 /* RotationDesignableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B332441ECA880A00928CB4 /* RotationDesignableTests.swift */; };
+		B0B67C661ECAA09E008820A7 /* PaddingDesignableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B67C651ECAA09E008820A7 /* PaddingDesignableTests.swift */; };
 		B0FF353E1EC6916A005C5F62 /* CornerDesignableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF353D1EC6916A005C5F62 /* CornerDesignableTests.swift */; };
 		B0FF35431EC6968F005C5F62 /* AnimatableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF35421EC6968F005C5F62 /* AnimatableViewTests.swift */; };
 		B0FF35451EC6A5F5005C5F62 /* AnimatableScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF35441EC6A5F5005C5F62 /* AnimatableScrollViewTests.swift */; };
@@ -348,6 +349,7 @@
 		B0B332401ECA7FF400928CB4 /* AnimatableSliderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableSliderTests.swift; sourceTree = "<group>"; };
 		B0B332421ECA81A800928CB4 /* SliderImagesDesignableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SliderImagesDesignableTests.swift; sourceTree = "<group>"; };
 		B0B332441ECA880A00928CB4 /* RotationDesignableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RotationDesignableTests.swift; sourceTree = "<group>"; };
+		B0B67C651ECAA09E008820A7 /* PaddingDesignableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddingDesignableTests.swift; sourceTree = "<group>"; };
 		B0FF353D1EC6916A005C5F62 /* CornerDesignableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CornerDesignableTests.swift; sourceTree = "<group>"; };
 		B0FF35421EC6968F005C5F62 /* AnimatableViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableViewTests.swift; sourceTree = "<group>"; };
 		B0FF35441EC6A5F5005C5F62 /* AnimatableScrollViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableScrollViewTests.swift; sourceTree = "<group>"; };
@@ -841,6 +843,7 @@
 				B0FF35491EC6A8D3005C5F62 /* FillDesignableTests.swift */,
 				B0B332421ECA81A800928CB4 /* SliderImagesDesignableTests.swift */,
 				B0B332441ECA880A00928CB4 /* RotationDesignableTests.swift */,
+				B0B67C651ECAA09E008820A7 /* PaddingDesignableTests.swift */,
 			);
 			name = TestProtocols;
 			sourceTree = "<group>";
@@ -1377,6 +1380,7 @@
 				B0B332451ECA880A00928CB4 /* RotationDesignableTests.swift in Sources */,
 				B0FF353E1EC6916A005C5F62 /* CornerDesignableTests.swift in Sources */,
 				B0FF355F1EC6B57D005C5F62 /* AnimatableCollectionViewCellTests.swift in Sources */,
+				B0B67C661ECAA09E008820A7 /* PaddingDesignableTests.swift in Sources */,
 				B0FF35611EC6B65D005C5F62 /* AnimatableTextFieldTests.swift in Sources */,
 				B0B332411ECA7FF400928CB4 /* AnimatableSliderTests.swift in Sources */,
 				B0FF35551EC6B0C8005C5F62 /* AnimatableImageViewTests.swift in Sources */,

--- a/IBAnimatable/PaddingDesignable.swift
+++ b/IBAnimatable/PaddingDesignable.swift
@@ -28,7 +28,7 @@ public extension PaddingDesignable where Self: UITextField {
       return
     }
 
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingLeft, height: 0))
+    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingLeft, height: 1))
     leftViewMode = .always
     leftView = padding
   }
@@ -38,7 +38,7 @@ public extension PaddingDesignable where Self: UITextField {
       return
     }
 
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingRight, height: 0))
+    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingRight, height: 1))
     rightViewMode = .always
     rightView = padding
   }
@@ -48,7 +48,7 @@ public extension PaddingDesignable where Self: UITextField {
       return
     }
 
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingSide, height: paddingSide))
+    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingSide, height: 1))
     leftViewMode = .always
     leftView = padding
 

--- a/IBAnimatableTests/AnimatableTextFieldTests.swift
+++ b/IBAnimatableTests/AnimatableTextFieldTests.swift
@@ -59,3 +59,21 @@ extension AnimatableTextFieldTests: FillDesignableTests {
   }
 
 }
+
+// MARK: - PaddingDesignable Tests
+
+extension AnimatableTextFieldTests: PaddingDesignableTests {
+
+  func testPaddingLeft() {
+    _testPaddingLeft(animatableTextField)
+  }
+  
+  func testPaddingRight() {
+    _testPaddingRight(animatableTextField)
+  }
+  
+  func testPaddingSide() {
+    _testPaddingSide(animatableTextField)
+  }
+  
+}

--- a/IBAnimatableTests/AnimatableTextFieldTests.swift
+++ b/IBAnimatableTests/AnimatableTextFieldTests.swift
@@ -67,13 +67,13 @@ extension AnimatableTextFieldTests: PaddingDesignableTests {
   func testPaddingLeft() {
     _testPaddingLeft(animatableTextField)
   }
-  
+
   func testPaddingRight() {
     _testPaddingRight(animatableTextField)
   }
-  
+
   func testPaddingSide() {
     _testPaddingSide(animatableTextField)
   }
-  
+
 }

--- a/IBAnimatableTests/PaddingDesignableTests.swift
+++ b/IBAnimatableTests/PaddingDesignableTests.swift
@@ -1,0 +1,47 @@
+//
+//  PaddingDesignableTests.swift
+//  IBAnimatable
+//
+//  Created by Steven on 5/15/17.
+//  Copyright © 2017 IBAnimatable. All rights reserved.
+//
+
+import XCTest
+@testable import IBAnimatable
+
+protocol PaddingDesignableTests {
+
+  func testPaddingLeft()
+  func testPaddingRight()
+  func testPaddingSide()
+
+}
+
+// MARK: - UITextField Tests
+
+extension PaddingDesignableTests {
+
+  func _testPaddingLeft<E: UITextField>(_ element: E) where E: PaddingDesignable {
+    element.paddingLeft = 10.0
+    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10.0, height: 1))
+    XCTAssertEqual(element.leftView?.frame, paddingView.frame)
+    XCTAssertEqual(element.leftViewMode, .always)
+  }
+
+  func _testPaddingRight<E: UITextField>(_ element: E) where E: PaddingDesignable {
+    element.paddingRight = 15.0
+    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15.0, height: 1))
+    XCTAssertEqual(element.rightView?.frame, paddingView.frame)
+    XCTAssertEqual(element.rightViewMode, .always)
+  }
+
+  func _testPaddingSide<E: UITextField>(_ element: E) where E: PaddingDesignable {
+    element.paddingSide = 20.0
+    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 20.0, height: 1))
+    XCTAssertEqual(element.rightView?.frame, paddingView.frame)
+    XCTAssertEqual(element.rightViewMode, .always)
+    XCTAssertEqual(element.leftView?.frame, paddingView.frame)
+    XCTAssertEqual(element.leftViewMode, .always)
+  }
+
+}


### PR DESCRIPTION
### Summary of Pull Request:
- This Pull Request adds tests for the `PaddingDesignable` protocol.
- The height for the padding view has been changed to a default value of 1 pt.

Reasoning:
- The height previously was 0 for the left and right padding.
- The height for the `sides` configuration was set to the amount of width padding.

Therefore, if you provided a width that was greater than the height of the text field, the padding view could possibly extend outside the bounds of the text field.