### PR TITLE
Move test method constraints to extension level #no-public-changes

### DIFF
--- a/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
@@ -13,6 +13,10 @@ import XCTest
 
 protocol CornerDesignableTests: class {
 
+  associatedtype Element
+
+  var element: Element { get set }
+
   func testCornerRadius()
   func test_cornerSides()
 
@@ -20,9 +24,9 @@ protocol CornerDesignableTests: class {
 
 // MARK: - Universal Tests
 
-extension CornerDesignableTests {
+extension CornerDesignableTests where Element: StringCornerDesignable {
 
-  func _test_cornerSides(_ element: StringCornerDesignable) {
+  func _test_cornerSides() {
     element._cornerSides = "topLeft"
     XCTAssertEqual(element.cornerSides, .topLeft)
     element._cornerSides = "topRight"
@@ -41,9 +45,9 @@ extension CornerDesignableTests {
 
 // MARK: - UIView Tests
 
-extension CornerDesignableTests {
+extension CornerDesignableTests where Element: UIView, Element: CornerDesignable {
 
-  func _testCornerRadius<E: UIView>(_ element: E) where E: CornerDesignable {
+  func _testCornerRadius() {
     element.cornerRadius = 3.0
     element.cornerSides = .allSides
     XCTAssertEqual(element.cornerRadius, element.layer.cornerRadius)
@@ -61,9 +65,9 @@ extension CornerDesignableTests {
 
 // MARK: - UICollectionViewCell Tests
 
-extension CornerDesignableTests {
+extension CornerDesignableTests where Element: UICollectionViewCell, Element: CornerDesignable {
 
-  func _testCornerRadius<E: UICollectionViewCell>(_ element: E) where E: CornerDesignable {
+  func _testCornerRadius() {
     element.cornerRadius = -1
     XCTAssertFalse(element.contentView.layer.masksToBounds)
     element.cornerRadius = 3.0

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/FillDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/FillDesignableTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 @testable import IBAnimatable
 
-protocol FillDesignableTests {
+protocol FillDesignableTests: class {
+
+  associatedtype Element
+
+  var element: Element { get set }
 
   func testFillColor()
   func testOpacity()
@@ -20,9 +24,9 @@ protocol FillDesignableTests {
 
 // MARK: - Universal Tests
 
-extension FillDesignableTests {
+extension FillDesignableTests where Element: StringFillDesignable {
 
-  func _test_predefinedColor(_ element: StringFillDesignable) {
+  func _test_predefinedColor() {
     element._predefinedColor = "flatEmerland"
     XCTAssertEqual(element.predefinedColor, .flatEmerland)
     element._predefinedColor = "flatPomegranate"
@@ -69,14 +73,14 @@ extension FillDesignableTests {
 
 // MARK: - UIView Tests
 
-extension FillDesignableTests {
+extension FillDesignableTests where Element: UIView, Element: FillDesignable {
 
-  func _testFillColor<E: UIView>(_ element: E) where E: FillDesignable {
+  func _testFillColor() {
     element.fillColor = .red
     XCTAssertEqual(element.backgroundColor, .red)
   }
 
-  func _testOpacity<E: UIView>(_ element: E) where E: FillDesignable {
+  func _testOpacity() {
     element.opacity = 0.5
     XCTAssertEqual(element.opacity, element.alpha)
     XCTAssertFalse(element.isOpaque)
@@ -85,7 +89,7 @@ extension FillDesignableTests {
     XCTAssertTrue(element.isOpaque)
   }
 
-  func _testPredefinedColor<E: UIView>(_ element: E) where E: FillDesignable {
+  func _testPredefinedColor() {
     element.predefinedColor = .flatGreenSea
     XCTAssertEqual(element.backgroundColor, ColorType.flatGreenSea.color)
   }
@@ -94,15 +98,15 @@ extension FillDesignableTests {
 
 // MARK: - UICollectionViewCell Tests
 
-extension FillDesignableTests {
+extension FillDesignableTests where Element: UICollectionViewCell, Element: FillDesignable {
 
-  func _testFillColor<E: UICollectionViewCell>(_ element: E) where E: FillDesignable {
+  func _testFillColor() {
     element.fillColor = .red
     XCTAssertEqual(element.backgroundColor, .red)
     XCTAssertEqual(element.contentView.backgroundColor, .red)
   }
 
-  func _testOpacity<E: UICollectionViewCell>(_ element: E) where E: FillDesignable {
+  func _testOpacity() {
     element.opacity = 0.5
     XCTAssertEqual(element.opacity, element.alpha)
     XCTAssertFalse(element.isOpaque)
@@ -111,7 +115,7 @@ extension FillDesignableTests {
     XCTAssertTrue(element.isOpaque)
   }
 
-  func _testPredefinedColor<E: UICollectionViewCell>(_ element: E) where E: FillDesignable {
+  func _testPredefinedColor() {
     element.predefinedColor = .flatClouds
     XCTAssertEqual(element.backgroundColor, ColorType.flatClouds.color)
     XCTAssertEqual(element.contentView.backgroundColor, ColorType.flatClouds.color)

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 @testable import IBAnimatable
 
-protocol PaddingDesignableTests {
+protocol PaddingDesignableTests: class {
+
+  associatedtype Element
+
+  var element: Element { get set }
 
   func testPaddingLeft()
   func testPaddingRight()
@@ -19,23 +23,23 @@ protocol PaddingDesignableTests {
 
 // MARK: - UITextField Tests
 
-extension PaddingDesignableTests {
+extension PaddingDesignableTests where Element: UITextField, Element: PaddingDesignable {
 
-  func _testPaddingLeft<E: UITextField>(_ element: E) where E: PaddingDesignable {
+  func _testPaddingLeft() {
     element.paddingLeft = 10.0
     let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10.0, height: 1))
     XCTAssertEqual(element.leftView?.frame, paddingView.frame)
     XCTAssertEqual(element.leftViewMode, .always)
   }
 
-  func _testPaddingRight<E: UITextField>(_ element: E) where E: PaddingDesignable {
+  func _testPaddingRight() {
     element.paddingRight = 15.0
     let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15.0, height: 1))
     XCTAssertEqual(element.rightView?.frame, paddingView.frame)
     XCTAssertEqual(element.rightViewMode, .always)
   }
 
-  func _testPaddingSide<E: UITextField>(_ element: E) where E: PaddingDesignable {
+  func _testPaddingSide() {
     element.paddingSide = 20.0
     let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 20.0, height: 1))
     XCTAssertEqual(element.rightView?.frame, paddingView.frame)

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/RotationDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/RotationDesignableTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 @testable import IBAnimatable
 
-protocol RotationDesignableTests {
+protocol RotationDesignableTests: class {
+
+  associatedtype Element
+
+  var element: Element { get set }
 
   func testRotate()
 
@@ -17,9 +21,9 @@ protocol RotationDesignableTests {
 
 // MARK: - UIView Tests
 
-extension RotationDesignableTests {
+extension RotationDesignableTests where Element: UIView, Element: RotationDesignable {
 
-  func _testRotate<E: UIView>(_ element: E) where E: RotationDesignable {
+  func _testRotate() {
     element.rotate = -360
     XCTAssertEqual(element.transform, .identity)
     element.rotate = 360

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/SliderImagesDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/SliderImagesDesignableTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 @testable import IBAnimatable
 
-protocol SliderImagesDesignableTests {
+protocol SliderImagesDesignableTests: class {
+
+  associatedtype Element
+
+  var element: Element { get set }
 
   func testThumbImage()
   func testThumbHighlightedImage()
@@ -20,15 +24,17 @@ protocol SliderImagesDesignableTests {
 
 }
 
-extension SliderImagesDesignableTests {
+// MARK: - UISlider Tests
 
-  func _testThumbImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+extension SliderImagesDesignableTests where Element: UISlider, Element: SliderImagesDesignable {
+
+  func _testThumbImage() {
     let normalImage = UIImage()
     element.thumbImage = normalImage
     XCTAssertEqual(element.thumbImage(for: .normal), normalImage)
   }
 
-  func _testThumbHighlightedImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+  func _testThumbHighlightedImage() {
     let normalImage = UIImage()
     let highlightedImage = UIImage()
     element.thumbImage = normalImage
@@ -39,13 +45,13 @@ extension SliderImagesDesignableTests {
     XCTAssertEqual(element.thumbImage(for: .highlighted), highlightedImage)
   }
 
-  func _testMaximumTrackImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+  func _testMaximumTrackImage() {
     let normalImage = UIImage()
     element.maximumTrackImage = normalImage
     XCTAssertEqual(element.maximumTrackImage(for: .normal), normalImage)
   }
 
-  func _testMaximumTrackHighlightedImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+  func _testMaximumTrackHighlightedImage() {
     let normalImage = UIImage()
     let highlightedImage = UIImage()
     element.maximumTrackImage = normalImage
@@ -56,13 +62,13 @@ extension SliderImagesDesignableTests {
     XCTAssertEqual(element.maximumTrackImage(for: .highlighted), highlightedImage)
   }
 
-  func _testMinimumTrackImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+  func _testMinimumTrackImage() {
     let normalImage = UIImage()
     element.minimumTrackImage = normalImage
     XCTAssertEqual(element.minimumTrackImage(for: .normal), normalImage)
   }
 
-  func _testMinimumTrackHighlightedImage<E: UISlider>(_ element: E) where E: SliderImagesDesignable {
+  func _testMinimumTrackHighlightedImage() {
     let normalImage = UIImage()
     let highlightedImage = UIImage()
     element.minimumTrackImage = normalImage

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableButtonTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableButtonTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableButtonTests: XCTestCase {
 
-  var animatableButton: AnimatableButton!
+  var element = AnimatableButton()
 
   override func setUp() {
     super.setUp()
-    animatableButton = AnimatableButton()
+    element = AnimatableButton()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableButtonTests: XCTestCase {
 extension AnimatableButtonTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableButton)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableButton)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableButtonTests: CornerDesignableTests {
 extension AnimatableButtonTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableButton)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableButton)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableButton)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableButton)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableCheckBoxTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableCheckBoxTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableCheckBoxTests: XCTestCase {
 
-  var animatableCheckBox: AnimatableCheckBox!
+  var element = AnimatableCheckBox()
 
   override func setUp() {
     super.setUp()
-    animatableCheckBox = AnimatableCheckBox()
+    element = AnimatableCheckBox()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableCheckBoxTests: XCTestCase {
 extension AnimatableCheckBoxTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableCheckBox)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableCheckBox)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableCheckBoxTests: CornerDesignableTests {
 extension AnimatableCheckBoxTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableCheckBox)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableCheckBox)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableCheckBox)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableCheckBox)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableCollectionViewCellTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableCollectionViewCellTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableCollectionViewCellTests: XCTestCase {
 
-  var animatableCollectionViewCell: AnimatableCollectionViewCell!
+  var element = AnimatableCollectionViewCell()
 
   override func setUp() {
     super.setUp()
-    animatableCollectionViewCell = AnimatableCollectionViewCell()
+    element = AnimatableCollectionViewCell()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableCollectionViewCellTests: XCTestCase {
 extension AnimatableCollectionViewCellTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableCollectionViewCell)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableCollectionViewCell)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableCollectionViewCellTests: CornerDesignableTests {
 extension AnimatableCollectionViewCellTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableCollectionViewCell)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableCollectionViewCell)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableCollectionViewCell)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableCollectionViewCell)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableImageViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableImageViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableImageViewTests: XCTestCase {
 
-  var animatableImageView: AnimatableImageView!
+  var element = AnimatableImageView()
 
   override func setUp() {
     super.setUp()
-    animatableImageView = AnimatableImageView()
+    element = AnimatableImageView()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableImageViewTests: XCTestCase {
 extension AnimatableImageViewTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableImageView)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableImageView)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableImageViewTests: CornerDesignableTests {
 extension AnimatableImageViewTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableImageView)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableImageView)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableImageView)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableImageView)
+    _test_predefinedColor()
   }
 
 }
@@ -65,7 +65,7 @@ extension AnimatableImageViewTests: FillDesignableTests {
 extension AnimatableImageViewTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableImageView)
+    _testRotate()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableLabelTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableLabelTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableLabelTests: XCTestCase {
 
-  var animatableLabel: AnimatableLabel!
+  var element = AnimatableLabel()
 
   override func setUp() {
     super.setUp()
-    animatableLabel = AnimatableLabel()
+    element = AnimatableLabel()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableLabelTests: XCTestCase {
 extension AnimatableLabelTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableLabel)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableLabel)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableLabelTests: CornerDesignableTests {
 extension AnimatableLabelTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableLabel)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableLabel)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableLabel)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableLabel)
+    _test_predefinedColor()
   }
 
 }
@@ -65,7 +65,7 @@ extension AnimatableLabelTests: FillDesignableTests {
 extension AnimatableLabelTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableLabel)
+    _testRotate()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableScrollViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableScrollViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableScrollViewTests: XCTestCase {
 
-  var animatableScrollView: AnimatableScrollView!
+  var element = AnimatableScrollView()
 
   override func setUp() {
     super.setUp()
-    animatableScrollView = AnimatableScrollView()
+    element = AnimatableScrollView()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableScrollViewTests: XCTestCase {
 extension AnimatableScrollViewTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableScrollView)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableScrollView)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableScrollViewTests: CornerDesignableTests {
 extension AnimatableScrollViewTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableScrollView)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableScrollView)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableScrollView)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableScrollView)
+    _test_predefinedColor()
   }
 
 }
@@ -65,7 +65,7 @@ extension AnimatableScrollViewTests: FillDesignableTests {
 extension AnimatableScrollViewTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableScrollView)
+    _testRotate()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableSliderTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableSliderTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableSliderTests: XCTestCase {
 
-  var animatableSlider: AnimatableSlider!
+  var element = AnimatableSlider()
 
   override func setUp() {
     super.setUp()
-    animatableSlider = AnimatableSlider()
+    element = AnimatableSlider()
   }
 
   override func tearDown() {
@@ -29,27 +29,27 @@ final class AnimatableSliderTests: XCTestCase {
 extension AnimatableSliderTests: SliderImagesDesignableTests {
 
   func testThumbImage() {
-    _testThumbImage(animatableSlider)
+    _testThumbImage()
   }
 
   func testThumbHighlightedImage() {
-    _testThumbHighlightedImage(animatableSlider)
+    _testThumbHighlightedImage()
   }
 
   func testMaximumTrackImage() {
-    _testMaximumTrackImage(animatableSlider)
+    _testMaximumTrackImage()
   }
 
   func testMaximumTrackHighlightedImage() {
-    _testMaximumTrackHighlightedImage(animatableSlider)
+    _testMaximumTrackHighlightedImage()
   }
 
   func testMinimumTrackImage() {
-    _testMinimumTrackImage(animatableSlider)
+    _testMinimumTrackImage()
   }
 
   func testMinimumTrackHighlightedImage() {
-    _testMinimumTrackHighlightedImage(animatableSlider)
+    _testMinimumTrackHighlightedImage()
   }
 
 }
@@ -59,7 +59,7 @@ extension AnimatableSliderTests: SliderImagesDesignableTests {
 extension AnimatableSliderTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableSlider)
+    _testRotate()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableStackViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableStackViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableStackViewTests: XCTestCase {
 
-  var animatableStackView: AnimatableStackView!
+  var element = AnimatableStackView()
 
   override func setUp() {
     super.setUp()
-    animatableStackView = AnimatableStackView()
+    element = AnimatableStackView()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableStackViewTests: XCTestCase {
 extension AnimatableStackViewTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableStackView)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableStackView)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableStackViewTests: CornerDesignableTests {
 extension AnimatableStackViewTests: FillDesignableTests {
 
   func testFillColor() {
-    //_testFillColor(animatableStackView) // broken see issue #461
+    //_testFillColor() // broken see issue #461
   }
 
   func testOpacity() {
-    //_testOpacity(animatableStackView) // broken see issue #461
+    //_testOpacity() // broken see issue #461
   }
 
   func testPredefinedColor() {
-    //_testPredefinedColor(animatableStackView) // broken see issue #461
+    //_testPredefinedColor() // broken see issue #461
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableStackView)
+    _test_predefinedColor()
   }
 
 }
@@ -65,7 +65,7 @@ extension AnimatableStackViewTests: FillDesignableTests {
 extension AnimatableStackViewTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableStackView)
+    _testRotate()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTableViewCellTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTableViewCellTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableTableViewCellTests: XCTestCase {
 
-  var animatableTableViewCell: AnimatableTableViewCell!
+  var element = AnimatableTableViewCell()
 
   override func setUp() {
     super.setUp()
-    animatableTableViewCell = AnimatableTableViewCell()
+    element = AnimatableTableViewCell()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ final class AnimatableTableViewCellTests: XCTestCase {
 extension AnimatableTableViewCellTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableTableViewCell)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableTableViewCell)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableTableViewCellTests: CornerDesignableTests {
 extension AnimatableTableViewCellTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableTableViewCell)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableTableViewCell)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableTableViewCell)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableTableViewCell)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTableViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTableViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableTableViewTests: XCTestCase {
 
-  var animatableTableView: AnimatableTableView!
+  var element = AnimatableTableView()
 
   override func setUp() {
     super.setUp()
-    animatableTableView = AnimatableTableView()
+    element = AnimatableTableView()
   }
 
   override func tearDown() {
@@ -29,19 +29,19 @@ final class AnimatableTableViewTests: XCTestCase {
 extension AnimatableTableViewTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableTableView)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableTableView)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableTableView)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableTableView)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 class AnimatableTextFieldTests: XCTestCase {
 
-  var animatableTextField: AnimatableTextField!
+  var element = AnimatableTextField()
 
   override func setUp() {
     super.setUp()
-    animatableTextField = AnimatableTextField()
+    element = AnimatableTextField()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ class AnimatableTextFieldTests: XCTestCase {
 extension AnimatableTextFieldTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableTextField)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableTextField)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableTextFieldTests: CornerDesignableTests {
 extension AnimatableTextFieldTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableTextField)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableTextField)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableTextField)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableTextField)
+    _test_predefinedColor()
   }
 
 }
@@ -65,15 +65,15 @@ extension AnimatableTextFieldTests: FillDesignableTests {
 extension AnimatableTextFieldTests: PaddingDesignableTests {
 
   func testPaddingLeft() {
-    _testPaddingLeft(animatableTextField)
+    _testPaddingLeft()
   }
 
   func testPaddingRight() {
-    _testPaddingRight(animatableTextField)
+    _testPaddingRight()
   }
 
   func testPaddingSide() {
-    _testPaddingSide(animatableTextField)
+    _testPaddingSide()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 class AnimatableTextViewTests: XCTestCase {
 
-  var animatableTextView: AnimatableTextView!
+  var element = AnimatableTextView()
 
   override func setUp() {
     super.setUp()
-    animatableTextView = AnimatableTextView()
+    element = AnimatableTextView()
   }
 
   override func tearDown() {
@@ -29,11 +29,11 @@ class AnimatableTextViewTests: XCTestCase {
 extension AnimatableTextViewTests: CornerDesignableTests {
 
   func testCornerRadius() {
-    _testCornerRadius(animatableTextView)
+    _testCornerRadius()
   }
 
   func test_cornerSides() {
-    _test_cornerSides(animatableTextView)
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableTextViewTests: CornerDesignableTests {
 extension AnimatableTextViewTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableTextView)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableTextView)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableTextView)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableTextView)
+    _test_predefinedColor()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableViewTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 final class AnimatableViewTests: XCTestCase {
 
-  var animatableView: AnimatableView!
+  var element = AnimatableView()
 
   override func setUp() {
     super.setUp()
-    animatableView = AnimatableView()
+    element = AnimatableView()
   }
 
   override func tearDown() {
@@ -28,12 +28,12 @@ final class AnimatableViewTests: XCTestCase {
 
 extension AnimatableViewTests: CornerDesignableTests {
 
-  func test_cornerSides() {
-    _test_cornerSides(animatableView)
+  func testCornerRadius() {
+    _testCornerRadius()
   }
 
-  func testCornerRadius() {
-    _testCornerRadius(animatableView)
+  func test_cornerSides() {
+    _test_cornerSides()
   }
 
 }
@@ -43,19 +43,19 @@ extension AnimatableViewTests: CornerDesignableTests {
 extension AnimatableViewTests: FillDesignableTests {
 
   func testFillColor() {
-    _testFillColor(animatableView)
+    _testFillColor()
   }
 
   func testOpacity() {
-    _testOpacity(animatableView)
+    _testOpacity()
   }
 
   func testPredefinedColor() {
-    _testPredefinedColor(animatableView)
+    _testPredefinedColor()
   }
 
   func test_predefinedColor() {
-    _test_predefinedColor(animatableView)
+    _test_predefinedColor()
   }
 
 }
@@ -65,7 +65,7 @@ extension AnimatableViewTests: FillDesignableTests {
 extension AnimatableViewTests: RotationDesignableTests {
 
   func testRotate() {
-    _testRotate(animatableView)
+    _testRotate()
   }
 
 }


### PR DESCRIPTION
### Summary of Pull Request:
This Pull Request adds an `associatedtype` to the test protocols so that we can constrain the IBAnimatable element being tested at the extension level as opposed to in the function signature.

~~It's not linted so it's only ready for review not merging.~~ I'll have to rebase after #487 anyways.