### PR TITLE
Update PaddingDesignable to set rects for text, edit, and placeholder instead of UIView spacer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - IOS_FRAMEWORK_SCHEME="IBAnimatable"
     - IOS_APP_SCHEME="IBAnimatableApp"
   matrix:
-    - DESTINATION="OS=10.3,name=iPad Pro (12.9-Inch)" SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
+    - DESTINATION="OS=10.3.1,name=iPad Pro (12.9-Inch)" SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
     - DESTINATION="OS=9.3,name=iPhone 6s Plus"        SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
 before_install:
   - bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@ N/A
 Add new mask type `.ellipse`. [#481](https://github.com/IBAnimatable/IBAnimatable/pull/481) by [@phimage](https://github.com/phimage)
 - Add `stickOrMoveUp` keyboard translation option when presenting a viewController. [#489](https://github.com/IBAnimatable/IBAnimatable/pull/489) by [@tbaranes](https://github.com/tbaranes)
 - Add `scale`, `scaleTo` and `scaleFrom` animation types. [#494](https://github.com/IBAnimatable/IBAnimatable/pull/494) by [@phimage](https://github.com/phimage)
+- `PaddingDesignable` now applies padding to the underlying text, edit, and placeholder rects -- opposed to using a `UIView` spacer. [#492](https://github.com/IBAnimatable/IBAnimatable/pull/492) by [@SD10](https://github.com/sd10)
 
 #### Bugfixes
-
-- Padding UIView for `PaddingDesignable` can't expand beyond `UITextField` and now has a default height of 1pt. [#483](https://github.com/IBAnimatable/IBAnimatable/pull/483) by [@SD10](https://github.com/SD10)
 
 ### [4.1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.1.0)
 

--- a/IBAnimatable/IBAnimatable.xcodeproj/xcshareddata/xcschemes/IBAnimatable.xcscheme
+++ b/IBAnimatable/IBAnimatable.xcodeproj/xcshareddata/xcschemes/IBAnimatable.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
@@ -15,9 +15,15 @@ protocol PaddingDesignableTests: class {
 
   var element: Element { get set }
 
-  func testPaddingLeft()
-  func testPaddingRight()
-  func testPaddingSide()
+  func testLeftTextPadding()
+  func testRightTextPadding()
+  func testSideTextPadding()
+  func testLeftEditPadding()
+  func testRightEditPadding()
+  func testSideEditPadding()
+  func testLeftPlaceholderPadding()
+  func testRightPlaceholderPadding()
+  func testSidePlaceholderPadding()
 
 }
 
@@ -25,27 +31,110 @@ protocol PaddingDesignableTests: class {
 
 extension PaddingDesignableTests where Element: UITextField, Element: PaddingDesignable {
 
-  func _testPaddingLeft() {
-    element.paddingLeft = 10.0
-    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10.0, height: 1))
-    XCTAssertEqual(element.leftView?.frame, paddingView.frame)
-    XCTAssertEqual(element.leftViewMode, .always)
+  func _testLeftTextPadding() {
+    testTextPadding(edge: .left(20))
   }
 
-  func _testPaddingRight() {
-    element.paddingRight = 15.0
-    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15.0, height: 1))
-    XCTAssertEqual(element.rightView?.frame, paddingView.frame)
-    XCTAssertEqual(element.rightViewMode, .always)
+  func _testRightTextPadding() {
+    testTextPadding(edge: .right(21))
   }
 
-  func _testPaddingSide() {
-    element.paddingSide = 20.0
-    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 20.0, height: 1))
-    XCTAssertEqual(element.rightView?.frame, paddingView.frame)
-    XCTAssertEqual(element.rightViewMode, .always)
-    XCTAssertEqual(element.leftView?.frame, paddingView.frame)
-    XCTAssertEqual(element.leftViewMode, .always)
+  func _testSideTextPadding() {
+    testTextPadding(edge: .sides(22))
+  }
+
+  func _testLeftEditPadding() {
+    testEditPadding(edge: .left(23))
+  }
+
+  func _testRightEditPadding() {
+    testEditPadding(edge: .right(24))
+  }
+
+  func _testSideEditPadding() {
+    testEditPadding(edge: .sides(25))
+  }
+
+  func _testLeftPlaceholderPadding() {
+    testPlaceholderPadding(edge: .left(26))
+  }
+
+  func _testRightPlaceholderPadding() {
+    testPlaceholderPadding(edge: .right(27))
+  }
+
+  func _testSidePlaceholderPadding() {
+    testPlaceholderPadding(edge: .sides(28))
+  }
+
+  // MARK: - Test Helper Methods
+
+  private func testTextPadding(edge: Edge) {
+
+    let originalRect = element.textRect(forBounds: element.bounds)
+    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
+
+    switch edge {
+    case .left(let padding): element.leftTextPadding = padding
+    case .right(let padding): element.rightTextPadding = padding
+    case .sides(let padding): element.sideTextPadding = padding
+    }
+
+    let newRect = element.textRect(forBounds: element.bounds)
+    XCTAssertEqual(newRect, mockRect)
+
+  }
+
+  private func testEditPadding(edge: Edge) {
+
+    let originalRect = element.editingRect(forBounds: element.bounds)
+    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
+
+    switch edge {
+    case .left(let padding): element.leftEditPadding = padding
+    case .right(let padding): element.rightEditPadding = padding
+    case .sides(let padding): element.sideEditPadding = padding
+    }
+
+    let newRect = element.editingRect(forBounds: element.bounds)
+    XCTAssertEqual(newRect, mockRect)
+    print(mockRect)
+    print(newRect)
+
+  }
+
+  private func testPlaceholderPadding(edge: Edge) {
+
+    element.placeholder = "placeholderRect won't get called if this is nil"
+    let originalRect = element.placeholderRect(forBounds: element.bounds)
+    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
+
+    switch edge {
+    case .left(let padding): element.leftPlaceholderPadding = padding
+    case .right(let padding): element.rightPlaceholderPadding = padding
+    case .sides(let padding): element.sidePlaceholderPadding = padding
+    }
+
+    let newRect = element.placeholderRect(forBounds: element.bounds)
+    XCTAssertEqual(newRect, mockRect)
+
+  }
+
+}
+
+// MARK: - Helper Enum
+
+fileprivate enum Edge {
+  case left(CGFloat)
+  case right(CGFloat)
+  case sides(CGFloat)
+
+  var insets: UIEdgeInsets {
+    switch self {
+    case .left(let value): return UIEdgeInsets(top: 0, left: value, bottom: 0, right: 0)
+    case .right(let value): return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: value)
+    case .sides(let value): return UIEdgeInsets(top: 0, left: value, bottom: 0, right: value)
+    }
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/PaddingDesignableTests.swift
@@ -15,15 +15,9 @@ protocol PaddingDesignableTests: class {
 
   var element: Element { get set }
 
-  func testLeftTextPadding()
-  func testRightTextPadding()
-  func testSideTextPadding()
-  func testLeftEditPadding()
-  func testRightEditPadding()
-  func testSideEditPadding()
-  func testLeftPlaceholderPadding()
-  func testRightPlaceholderPadding()
-  func testSidePlaceholderPadding()
+  func testPaddingLeft()
+  func testPaddingRight()
+  func testPaddingSide()
 
 }
 
@@ -31,93 +25,43 @@ protocol PaddingDesignableTests: class {
 
 extension PaddingDesignableTests where Element: UITextField, Element: PaddingDesignable {
 
-  func _testLeftTextPadding() {
-    testTextPadding(edge: .left(20))
+  func _testPaddingLeft() {
+    testPadding(on: .left(20))
   }
 
-  func _testRightTextPadding() {
-    testTextPadding(edge: .right(21))
+  func _testPaddingRight() {
+    testPadding(on: .right(40))
   }
 
-  func _testSideTextPadding() {
-    testTextPadding(edge: .sides(22))
+  func _testPaddingSide() {
+    testPadding(on: .sides(60))
   }
 
-  func _testLeftEditPadding() {
-    testEditPadding(edge: .left(23))
-  }
+  // MARK: - Helper Methods
 
-  func _testRightEditPadding() {
-    testEditPadding(edge: .right(24))
-  }
-
-  func _testSideEditPadding() {
-    testEditPadding(edge: .sides(25))
-  }
-
-  func _testLeftPlaceholderPadding() {
-    testPlaceholderPadding(edge: .left(26))
-  }
-
-  func _testRightPlaceholderPadding() {
-    testPlaceholderPadding(edge: .right(27))
-  }
-
-  func _testSidePlaceholderPadding() {
-    testPlaceholderPadding(edge: .sides(28))
-  }
-
-  // MARK: - Test Helper Methods
-
-  private func testTextPadding(edge: Edge) {
-
-    let originalRect = element.textRect(forBounds: element.bounds)
-    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
+  private func testPadding(on edge: Edge) {
+    element.placeholder = "placeholderRect will not be called if this is nil"
+    let textRectOriginal = element.textRect(forBounds: element.bounds)
+    let editRectOriginal = element.editingRect(forBounds: element.bounds)
+    let placeholderRectOriginal = element.placeholderRect(forBounds: element.bounds)
 
     switch edge {
-    case .left(let padding): element.leftTextPadding = padding
-    case .right(let padding): element.rightTextPadding = padding
-    case .sides(let padding): element.sideTextPadding = padding
+    case .left(let padding): element.paddingLeft = padding
+    case .right(let padding): element.paddingRight = padding
+    case .sides(let padding): element.paddingSide = padding
     }
 
-    let newRect = element.textRect(forBounds: element.bounds)
-    XCTAssertEqual(newRect, mockRect)
+    let paddedTextRect = element.textRect(forBounds: element.bounds)
+    let paddedEditRect = element.editingRect(forBounds: element.bounds)
+    let paddedPlaceholderRect = element.placeholderRect(forBounds: element.bounds)
 
-  }
+    let mockTextRect = UIEdgeInsetsInsetRect(textRectOriginal, edge.insets)
+    let mockEditRect = UIEdgeInsetsInsetRect(editRectOriginal, edge.insets)
+    let mockPlaceholderRect = UIEdgeInsetsInsetRect(placeholderRectOriginal, edge.insets)
 
-  private func testEditPadding(edge: Edge) {
-
-    let originalRect = element.editingRect(forBounds: element.bounds)
-    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
-
-    switch edge {
-    case .left(let padding): element.leftEditPadding = padding
-    case .right(let padding): element.rightEditPadding = padding
-    case .sides(let padding): element.sideEditPadding = padding
-    }
-
-    let newRect = element.editingRect(forBounds: element.bounds)
-    XCTAssertEqual(newRect, mockRect)
-    print(mockRect)
-    print(newRect)
-
-  }
-
-  private func testPlaceholderPadding(edge: Edge) {
-
-    element.placeholder = "placeholderRect won't get called if this is nil"
-    let originalRect = element.placeholderRect(forBounds: element.bounds)
-    let mockRect = UIEdgeInsetsInsetRect(originalRect, edge.insets)
-
-    switch edge {
-    case .left(let padding): element.leftPlaceholderPadding = padding
-    case .right(let padding): element.rightPlaceholderPadding = padding
-    case .sides(let padding): element.sidePlaceholderPadding = padding
-    }
-
-    let newRect = element.placeholderRect(forBounds: element.bounds)
-    XCTAssertEqual(newRect, mockRect)
-
+    XCTAssertEqual(paddedTextRect, mockTextRect)
+    XCTAssertEqual(paddedEditRect, mockEditRect)
+    XCTAssertEqual(paddedPlaceholderRect, mockPlaceholderRect)
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
@@ -64,16 +64,40 @@ extension AnimatableTextFieldTests: FillDesignableTests {
 
 extension AnimatableTextFieldTests: PaddingDesignableTests {
 
-  func testPaddingLeft() {
-    _testPaddingLeft()
+  func testRightTextPadding() {
+    _testRightTextPadding()
   }
 
-  func testPaddingRight() {
-    _testPaddingRight()
+  func testLeftTextPadding() {
+    _testLeftTextPadding()
   }
 
-  func testPaddingSide() {
-    _testPaddingSide()
+  func testSideTextPadding() {
+    _testSideTextPadding()
+  }
+
+  func testRightPlaceholderPadding() {
+    _testRightPlaceholderPadding()
+  }
+
+  func testLeftPlaceholderPadding() {
+    _testLeftPlaceholderPadding()
+  }
+
+  func testSidePlaceholderPadding() {
+    _testSidePlaceholderPadding()
+  }
+
+  func testRightEditPadding() {
+    _testRightEditPadding()
+  }
+
+  func testLeftEditPadding() {
+    _testLeftEditPadding()
+  }
+
+  func testSideEditPadding() {
+    _testSideEditPadding()
   }
 
 }

--- a/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
+++ b/IBAnimatable/IBAnimatableTests/ViewTests/AnimatableTextFieldTests.swift
@@ -64,40 +64,16 @@ extension AnimatableTextFieldTests: FillDesignableTests {
 
 extension AnimatableTextFieldTests: PaddingDesignableTests {
 
-  func testRightTextPadding() {
-    _testRightTextPadding()
+  func testPaddingLeft() {
+    _testPaddingLeft()
   }
 
-  func testLeftTextPadding() {
-    _testLeftTextPadding()
+  func testPaddingRight() {
+    _testPaddingRight()
   }
 
-  func testSideTextPadding() {
-    _testSideTextPadding()
-  }
-
-  func testRightPlaceholderPadding() {
-    _testRightPlaceholderPadding()
-  }
-
-  func testLeftPlaceholderPadding() {
-    _testLeftPlaceholderPadding()
-  }
-
-  func testSidePlaceholderPadding() {
-    _testSidePlaceholderPadding()
-  }
-
-  func testRightEditPadding() {
-    _testRightEditPadding()
-  }
-
-  func testLeftEditPadding() {
-    _testLeftEditPadding()
-  }
-
-  func testSideEditPadding() {
-    _testSideEditPadding()
+  func testPaddingSide() {
+    _testPaddingSide()
   }
 
 }

--- a/Sources/Protocols/Designable/PaddingDesignable.swift
+++ b/Sources/Protocols/Designable/PaddingDesignable.swift
@@ -6,53 +6,61 @@
 import UIKit
 
 public protocol PaddingDesignable: class {
-  /**
-    `padding-left`
-  */
-  var paddingLeft: CGFloat { get set }
-
-  /**
-    `padding-right`
-  */
-  var paddingRight: CGFloat { get set }
-
-  /**
-   `padding-left` and `padding-right`
-  */
-  var paddingSide: CGFloat { get set }
+  
+  var leftTextPadding: CGFloat { get set }
+  
+  var rightTextPadding: CGFloat { get set }
+  
+  var sideTextPadding: CGFloat { get set }
+  
+  var leftEditPadding: CGFloat { get set }
+  
+  var rightEditPadding: CGFloat { get set }
+  
+  var sideEditPadding: CGFloat { get set }
+  
+  var leftPlaceholderPadding: CGFloat { get set }
+  
+  var rightPlaceholderPadding: CGFloat { get set }
+  
+  var sidePlaceholderPadding: CGFloat { get set }
+  
 }
 
 public extension PaddingDesignable where Self: UITextField {
-  public func configurePaddingLeft() {
-    if paddingLeft.isNaN {
-      return
+  
+  public var textRectInsets: UIEdgeInsets {
+    if sideTextPadding.isNaN {
+      return insets(left: leftTextPadding, right: rightTextPadding)
+    } else {
+      return sideInsets(padding: sideTextPadding)
     }
-
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingLeft, height: 1))
-    leftViewMode = .always
-    leftView = padding
+  }
+  
+  public var editRectInsets: UIEdgeInsets {
+    if sideEditPadding.isNaN {
+      return insets(left: leftEditPadding, right: rightEditPadding)
+    } else {
+      return sideInsets(padding: sideEditPadding)
+    }
+  }
+  
+  public var placeholderRectInsets: UIEdgeInsets {
+    if sidePlaceholderPadding.isNaN {
+      return insets(left: leftPlaceholderPadding, right: rightPlaceholderPadding)
+    } else {
+      return sideInsets(padding: sidePlaceholderPadding)
+    }
+  }
+  
+  private func sideInsets(padding: CGFloat) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding)
+  }
+  
+  private func insets(left: CGFloat, right: CGFloat) -> UIEdgeInsets {
+    let l = left.isNaN ? 0 : left
+    let r = right.isNaN ? 0 : right
+    return UIEdgeInsets(top: 0, left: l, bottom: 0, right: r)
   }
 
-  public func configurePaddingRight() {
-    if paddingRight.isNaN {
-      return
-    }
-
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingRight, height: 1))
-    rightViewMode = .always
-    rightView = padding
-  }
-
-  public func configurePaddingSide() {
-    if paddingSide.isNaN {
-      return
-    }
-
-    let padding = UIView(frame: CGRect(x: 0, y: 0, width: paddingSide, height: 1))
-    leftViewMode = .always
-    leftView = padding
-
-    rightViewMode = .always
-    rightView = padding
-  }
 }

--- a/Sources/Protocols/Designable/PaddingDesignable.swift
+++ b/Sources/Protocols/Designable/PaddingDesignable.swift
@@ -6,57 +6,45 @@
 import UIKit
 
 public protocol PaddingDesignable: class {
-  
-  var leftTextPadding: CGFloat { get set }
-  
-  var rightTextPadding: CGFloat { get set }
-  
-  var sideTextPadding: CGFloat { get set }
-  
-  var leftEditPadding: CGFloat { get set }
-  
-  var rightEditPadding: CGFloat { get set }
-  
-  var sideEditPadding: CGFloat { get set }
-  
-  var leftPlaceholderPadding: CGFloat { get set }
-  
-  var rightPlaceholderPadding: CGFloat { get set }
-  
-  var sidePlaceholderPadding: CGFloat { get set }
-  
+
+  /**
+   `padding-left`
+   */
+  var paddingLeft: CGFloat { get set }
+
+  /**
+   `padding-right`
+   */
+  var paddingRight: CGFloat { get set }
+
+  /**
+   `padding-left` and `padding-right`
+   */
+  var paddingSide: CGFloat { get set }
+
 }
 
 public extension PaddingDesignable where Self: UITextField {
-  
-  public var textRectInsets: UIEdgeInsets {
-    if sideTextPadding.isNaN {
-      return insets(left: leftTextPadding, right: rightTextPadding)
+
+  public func paddedRect(forBounds bounds: CGRect) -> CGRect {
+    if paddingSide.isNaN && paddingLeft.isNaN && paddingRight.isNaN {
+      return bounds
+    }
+    return UIEdgeInsetsInsetRect(bounds, paddingInsets)
+  }
+
+  private var paddingInsets: UIEdgeInsets {
+    if paddingSide.isNaN {
+      return insets(left: paddingLeft, right: paddingRight)
     } else {
-      return sideInsets(padding: sideTextPadding)
+      return sideInsets(padding: paddingSide)
     }
   }
-  
-  public var editRectInsets: UIEdgeInsets {
-    if sideEditPadding.isNaN {
-      return insets(left: leftEditPadding, right: rightEditPadding)
-    } else {
-      return sideInsets(padding: sideEditPadding)
-    }
-  }
-  
-  public var placeholderRectInsets: UIEdgeInsets {
-    if sidePlaceholderPadding.isNaN {
-      return insets(left: leftPlaceholderPadding, right: rightPlaceholderPadding)
-    } else {
-      return sideInsets(padding: sidePlaceholderPadding)
-    }
-  }
-  
+
   private func sideInsets(padding: CGFloat) -> UIEdgeInsets {
     return UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding)
   }
-  
+
   private func insets(left: CGFloat, right: CGFloat) -> UIEdgeInsets {
     let l = left.isNaN ? 0 : left
     let r = right.isNaN ? 0 : right

--- a/Sources/Views/AnimatableTextField.swift
+++ b/Sources/Views/AnimatableTextField.swift
@@ -115,22 +115,38 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - PaddingDesignable
-  @IBInspectable open var paddingLeft: CGFloat = CGFloat.nan {
-    didSet {
-      configurePaddingLeft()
-    }
+  
+  @IBInspectable open var leftTextPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var rightTextPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var sideTextPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var leftEditPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var rightEditPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var sideEditPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var leftPlaceholderPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var rightPlaceholderPadding: CGFloat = CGFloat.nan
+  
+  @IBInspectable open var sidePlaceholderPadding: CGFloat = CGFloat.nan
+  
+  override open func textRect(forBounds bounds: CGRect) -> CGRect {
+    let shouldNotModify = leftTextPadding.isNaN && rightTextPadding.isNaN && sideTextPadding.isNaN
+    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, textRectInsets)
   }
-
-  @IBInspectable open var paddingRight: CGFloat = CGFloat.nan {
-    didSet {
-      configurePaddingRight()
-    }
+  
+  override open func editingRect(forBounds bounds: CGRect) -> CGRect {
+    let shouldNotModify = leftEditPadding.isNaN && rightEditPadding.isNaN && sideEditPadding.isNaN
+    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, editRectInsets)
   }
-
-  @IBInspectable open var paddingSide: CGFloat = CGFloat.nan {
-    didSet {
-      configurePaddingSide()
-    }
+  
+  override open func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+    let shouldNotModify = leftPlaceholderPadding.isNaN && rightPlaceholderPadding.isNaN && sidePlaceholderPadding.isNaN
+    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, placeholderRectInsets)
   }
 
   // MARK: - SideImageDesignable

--- a/Sources/Views/AnimatableTextField.swift
+++ b/Sources/Views/AnimatableTextField.swift
@@ -115,38 +115,23 @@ open class AnimatableTextField: UITextField, CornerDesignable, FillDesignable, B
   }
 
   // MARK: - PaddingDesignable
-  
-  @IBInspectable open var leftTextPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var rightTextPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var sideTextPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var leftEditPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var rightEditPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var sideEditPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var leftPlaceholderPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var rightPlaceholderPadding: CGFloat = CGFloat.nan
-  
-  @IBInspectable open var sidePlaceholderPadding: CGFloat = CGFloat.nan
-  
+
+  @IBInspectable open var paddingLeft: CGFloat = CGFloat.nan
+
+  @IBInspectable open var paddingRight: CGFloat = CGFloat.nan
+
+  @IBInspectable open var paddingSide: CGFloat = CGFloat.nan
+
   override open func textRect(forBounds bounds: CGRect) -> CGRect {
-    let shouldNotModify = leftTextPadding.isNaN && rightTextPadding.isNaN && sideTextPadding.isNaN
-    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, textRectInsets)
+    return paddedRect(forBounds: bounds)
   }
-  
+
   override open func editingRect(forBounds bounds: CGRect) -> CGRect {
-    let shouldNotModify = leftEditPadding.isNaN && rightEditPadding.isNaN && sideEditPadding.isNaN
-    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, editRectInsets)
+    return paddedRect(forBounds: bounds)
   }
-  
+
   override open func placeholderRect(forBounds bounds: CGRect) -> CGRect {
-    let shouldNotModify = leftPlaceholderPadding.isNaN && rightPlaceholderPadding.isNaN && sidePlaceholderPadding.isNaN
-    return shouldNotModify ? bounds : UIEdgeInsetsInsetRect(bounds, placeholderRectInsets)
+    return paddedRect(forBounds: bounds)
   }
 
   // MARK: - SideImageDesignable


### PR DESCRIPTION
### Summary of Pull Request:

This pull request changes the implementation of `PaddingDesignable` to set the padding by insetting the bounds of the text, editing, and placeholder rects -- as opposed to the previous approach that used a UIView as a spacer.

### To Do:
- [x] CHANGELOG
