### PR TITLE
Remove BackgroundDesignable corruption of UIKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Add new mask type `.ellipse`. [#481](https://github.com/IBAnimatable/IBAnimatabl
 
 #### Bugfixes
 - `PlaceholderDesignable` now applies `placeholderColor` to `Placeholder` defined in Interface Builder before checking the `placeholderText` property. [#499](https://github.com/IBAnimatable/IBAnimatable/pull/499) by [@SD10](https://github.com/sd10)
+- Fixes bug where Interface Builder doesn't recognize the delegate outlet for `UITableView` and `UICollectionView`. [#506](https://github.com/IBAnimatable/IBAnimatable/pull/506) by [@SD10](https://github.com/sd10)
 ### [4.1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/4.1.0)
 
 #### API breaking changes

--- a/Sources/Protocols/Designable/BackgroundImageDesignable.swift
+++ b/Sources/Protocols/Designable/BackgroundImageDesignable.swift
@@ -5,16 +5,6 @@
 
 import UIKit
 
-/// Protocol for designing background image
-public protocol BackgroundImageDesignable: class {
-
-  /**
-   * The background image
-   */
-  var backgroundImage: UIImage? { get set }
-
-}
-
 /// Protocol for designing background
 public protocol BackgroundDesignable: class {
 
@@ -25,13 +15,17 @@ public protocol BackgroundDesignable: class {
 
 }
 
-extension UITableViewCell: BackgroundDesignable {}
-extension UITableViewHeaderFooterView: BackgroundDesignable {}
-extension UITableView: BackgroundDesignable {}
-extension UICollectionViewCell: BackgroundDesignable {}
-extension UICollectionView: BackgroundDesignable {}
+/// Protocol for designing background image
+public protocol BackgroundImageDesignable: class, BackgroundDesignable {
 
-public extension BackgroundImageDesignable where Self: BackgroundDesignable {
+  /**
+   * The background image
+   */
+  var backgroundImage: UIImage? { get set }
+
+}
+
+public extension BackgroundImageDesignable {
 
   public func configureBackgroundImage() {
     if let image = backgroundImage {


### PR DESCRIPTION
### Summary of Pull Request:
Removes direct extensions to UIKit classes using `BackgroundDesignable`.
Instead, I made `BackgroundImageDesignable` conform to `BackgroundDesignable`.
This is not the usual approach we take for designable protocols, but to remove this protocol I would have to repeat the same code 3+ times.

Should fix #505. It seems like if you extend a UIKit class it can cause Interface Builder to stop recognizing the IBOutlets for that class.