### PR TITLE
When device orientation change reset the modal dialog context frame Fix #515

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ N/A
 
 #### Bugfixes
 
-N/A
+- Fix presented modal view (over context) frame when device orientation changed. [#516](https://github.com/IBAnimatable/IBAnimatable/pull/516) by [@phimage](https://github.com/phimage)
 
 ### [5.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/5.0.0)
 
@@ -24,7 +24,7 @@ N/A
 N/A
 
 ### Enhancements
-- Support for Swift 4.0 
+- Support for Swift 4.0
 - Add more screen size ratio to present  modal view controller. [#512](https://github.com/IBAnimatable/IBAnimatable/pull/512) by [@phimage](https://github.com/phimage)
 
 ### Bugfixes
@@ -441,5 +441,3 @@ None
 ### [1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/1.0)
 
 - Initial release
-
-

--- a/Sources/Controllers/AnimatableModalViewController.swift
+++ b/Sources/Controllers/AnimatableModalViewController.swift
@@ -9,9 +9,9 @@ import UIKit
 open class AnimatableModalViewController: UIViewController, PresentationDesignable {
 
   // MARK: - AnimatablePresentationController
-  public var contextFrameForPresentation: CGRect? {
+  public var contextFrameForPresentation: (() -> CGRect)? {
     didSet {
-      presenter?.presentationConfiguration?.contextFrameForPresentation = contextFrameForPresentation
+      configurePresenterFrameForPresentation()
     }
   }
 
@@ -179,4 +179,10 @@ open class AnimatableModalViewController: UIViewController, PresentationDesignab
     super.viewDidAppear(animated)
     configureDismissalTransition()
   }
+
+  open override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    configurePresenterFrameForPresentation()
+  }
+
 }

--- a/Sources/Protocols/Designable/PresentationDesignable.swift
+++ b/Sources/Protocols/Designable/PresentationDesignable.swift
@@ -12,7 +12,7 @@ public protocol PresentationDesignable: class {
   var presenter: PresentationPresenter? { get set }
 
   /// Frame of the presentingVC's dimmingView. Used that property if you want to simulate a presentation `overCurrentContext`. If nil, the dimmingView will be in fullscreen.
-  var contextFrameForPresentation: CGRect? { get set }
+  var contextFrameForPresentation: (() -> CGRect)? { get set }
 
   /// Presentation animation type, all supported animation type can be found in `PresentationAnimationType`
   var presentationAnimationType: PresentationAnimationType { get set }
@@ -79,7 +79,7 @@ public extension PresentationDesignable where Self: UIViewController {
     }
 
     var presentationConfiguration = PresentationConfiguration()
-    presentationConfiguration.contextFrameForPresentation = contextFrameForPresentation
+    presentationConfiguration.contextFrameForPresentation = contextFrameForPresentation?()
     presentationConfiguration.modalPosition = modalPosition
     presentationConfiguration.modalSize = modalSize
     presentationConfiguration.cornerRadius = cornerRadius
@@ -102,13 +102,18 @@ public extension PresentationDesignable where Self: UIViewController {
       modalTransitionStyle = dismissalSystemTransition
     }
   }
+  
+  public func configurePresenterFrameForPresentation() {
+       presenter?.presentationConfiguration?.contextFrameForPresentation = contextFrameForPresentation?()
+    print("presenter \( presenter?.presentationConfiguration?.contextFrameForPresentation)")
+  }
 
 }
 
 // MARK: - PresentationConfiguration
 
-/// `PresentationConfiguration` a struct is used for specifying the dimming view and modal view for `AnimatablePresentationController`
-public struct PresentationConfiguration {
+/// `PresentationConfiguration` a class is used for specifying the dimming view and modal view for `AnimatablePresentationController`
+public class PresentationConfiguration {
   public var cornerRadius: CGFloat = .nan
   public var dismissOnTap: Bool = true
   public var backgroundColor: UIColor = .black
@@ -122,5 +127,5 @@ public struct PresentationConfiguration {
   public var modalPosition: PresentationModalPosition = .center
   public var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   public var keyboardTranslation = ModalKeyboardTranslation.none
-  public var contextFrameForPresentation: CGRect?
+  public var contextFrameForPresentation: CGRect? = nil
 }

--- a/Sources/Protocols/Designable/PresentationDesignable.swift
+++ b/Sources/Protocols/Designable/PresentationDesignable.swift
@@ -102,7 +102,7 @@ public extension PresentationDesignable where Self: UIViewController {
       modalTransitionStyle = dismissalSystemTransition
     }
   }
-  
+
   public func configurePresenterFrameForPresentation() {
        presenter?.presentationConfiguration?.contextFrameForPresentation = contextFrameForPresentation?()
     print("presenter \( presenter?.presentationConfiguration?.contextFrameForPresentation)")
@@ -127,5 +127,5 @@ public class PresentationConfiguration {
   public var modalPosition: PresentationModalPosition = .center
   public var modalSize: (PresentationModalSize, PresentationModalSize) = (.half, .half)
   public var keyboardTranslation = ModalKeyboardTranslation.none
-  public var contextFrameForPresentation: CGRect? = nil
+  public var contextFrameForPresentation: CGRect?
 }

--- a/Sources/Protocols/Designable/PresentationDesignable.swift
+++ b/Sources/Protocols/Designable/PresentationDesignable.swift
@@ -105,7 +105,6 @@ public extension PresentationDesignable where Self: UIViewController {
 
   public func configurePresenterFrameForPresentation() {
        presenter?.presentationConfiguration?.contextFrameForPresentation = contextFrameForPresentation?()
-    print("presenter \( presenter?.presentationConfiguration?.contextFrameForPresentation)")
   }
 
 }

--- a/Sources/Segues/PresentOverCurrentContextSegue.swift
+++ b/Sources/Segues/PresentOverCurrentContextSegue.swift
@@ -11,9 +11,11 @@ import UIKit
 open class PresentOverCurrentContextSegue: UIStoryboardSegue {
   open override func perform() {
     if let modalVC = destination as? AnimatableModalViewController {
-      let correctedOrigin = source.view.convert(source.view.frame.origin, to: nil)
-      modalVC.contextFrameForPresentation = CGRect(origin: correctedOrigin,
-                                                   size: source.view.bounds.size)
+      let source = self.source
+      modalVC.contextFrameForPresentation = {
+        let correctedOrigin = source.view.convert(source.view.frame.origin, to: nil)
+        return CGRect(origin: correctedOrigin, size: source.view.bounds.size)
+      }
     }
     source.present(destination, animated: true, completion: nil)
   }


### PR DESCRIPTION
I am not sure that this is the best solution but I try to fix it.

To detect device orientation change I override `AnimatableModalViewController. viewDidLayoutSubviews`

When device orientation change I call the same code launched when updating `AnimatableModalViewController.contextFrameForPresentation`
(I make a method for that `configurePresenterFrameForPresentation`)

But how to update the frame without knowing the source, the segue, the parent view, ...?
I replace `contextFrameForPresentation` type from `CGRect` to closure to execute exactly the same code in `PresentOverCurrentContextSegue`
Maybe we can do better, find element in view hierarchy, make constraint, ...?

Then I see an issue, updating the `contextFrameForPresentation` in the `presenter`(`configurePresenterFrameForPresentation`) do nothing.
And I understand why. The `PresentationConfiguration` passed to the presentation controller is a `struct`, so a copy and no update in presentation controller.
By changing type to `class`, the object is shared.

