### PR TITLE
Create `.compound` `AnimationType` to make sequential animation (Fix #504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ N/A
 - Fix view's borders when using it with corner radius `allSides` [#530](https://github.com/IBAnimatable/IBAnimatable/pull/530) by [@tbaranes](https://github.com/tbaranes)
 - Fix CACurrentMediaTime usage by calling it on the CALayer object with conversion. [#541](https://github.com/IBAnimatable/IBAnimatable/pull/541) by [@lukas2](https://github.com/lukas2)
 - Animate TabBarItem image view when clicking on it. [#539](https://github.com/IBAnimatable/IBAnimatable/pull/539) by [@phimage](https://github.com/phimage)
+- Add `compound` animation type to do `sequential` or `parallel` animations. [#520](https://github.com/IBAnimatable/IBAnimatable/pull/520) by [@phimage](https://github.com/phimage)
 
 ### [5.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/5.0.0)
 

--- a/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
@@ -15,7 +15,7 @@ private let positiveNumberParam = ParamType.number(min: 0, max: 50, interval: 2,
 private let numberParam = ParamType.number(min: -50, max: 200, interval: 10, ascending: true, unit: "")
 private let repeatCountParam = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit:"")
 private let scaleParam = ParamType.number(min: 0, max: 2, interval: 0.1, ascending: true, unit: "")
-private let animationParam = ParamType.enumeration(values: ["slide", "shake", "pop", "wobble"])
+private let animationParam = ParamType.enumeration(values: ["slide", "shake", "pop", "pop[2]"])
 
 final class AnimationsViewController: UIViewController {
 
@@ -46,7 +46,7 @@ final class AnimationsViewController: UIViewController {
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleFrom"),
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleTo"),
     PickerEntry(params: [scaleParam, scaleParam, scaleParam, scaleParam], name: "scale"),
-    PickerEntry(params: [animationParam, animationParam], name: "compound")
+    PickerEntry(params: [animationParam, animationParam.reversed], name: "compound")
     ]
   var pickerSizeRatio: CGFloat = 0.25 {
     didSet {

--- a/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
@@ -16,6 +16,7 @@ private let numberParam = ParamType.number(min: -50, max: 200, interval: 10, asc
 private let repeatCountParam = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit:"")
 private let scaleParam = ParamType.number(min: 0, max: 2, interval: 0.1, ascending: true, unit: "")
 private let animationParam = ParamType.enumeration(values: ["slide", "shake", "pop", "pop[2]"])
+private let runParam = ParamType(fromEnum: AnimationType.Run.self)
 
 final class AnimationsViewController: UIViewController {
 
@@ -46,7 +47,7 @@ final class AnimationsViewController: UIViewController {
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleFrom"),
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleTo"),
     PickerEntry(params: [scaleParam, scaleParam, scaleParam, scaleParam], name: "scale"),
-    PickerEntry(params: [animationParam, animationParam.reversed], name: "compound")
+    PickerEntry(params: [animationParam, animationParam.reversed, runParam], name: "compound")
     ]
   var pickerSizeRatio: CGFloat = 0.25 {
     didSet {
@@ -96,7 +97,7 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
   func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
     switch component {
     case 0:
-      return view.frame.size.width * 0.5
+      return view.frame.size.width * 0.35
     case 1...4:
       return view.frame.size.width * pickerSizeRatio
     default:
@@ -133,6 +134,8 @@ extension AnimationsViewController : UIPickerViewDelegate, UIPickerViewDataSourc
     if case .scale = animationType {
       resetTimeInterval = 1
       pickerSizeRatio = 0.120
+    } else if case .compound = animationType {
+      pickerSizeRatio = 0.20
     } else {
       pickerSizeRatio = 0.25
     }

--- a/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/Animations/AnimationsViewController.swift
@@ -15,6 +15,7 @@ private let positiveNumberParam = ParamType.number(min: 0, max: 50, interval: 2,
 private let numberParam = ParamType.number(min: -50, max: 200, interval: 10, ascending: true, unit: "")
 private let repeatCountParam = ParamType.number(min: 1, max: 10, interval: 1, ascending: true, unit:"")
 private let scaleParam = ParamType.number(min: 0, max: 2, interval: 0.1, ascending: true, unit: "")
+private let animationParam = ParamType.enumeration(values: ["slide", "shake", "pop", "wobble"])
 
 final class AnimationsViewController: UIViewController {
 
@@ -44,7 +45,8 @@ final class AnimationsViewController: UIViewController {
     PickerEntry(params: [numberParam, numberParam], name: "moveto"),
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleFrom"),
     PickerEntry(params: [scaleParam, scaleParam], name: "scaleTo"),
-    PickerEntry(params: [scaleParam, scaleParam, scaleParam, scaleParam], name: "scale")
+    PickerEntry(params: [scaleParam, scaleParam, scaleParam, scaleParam], name: "scale"),
+    PickerEntry(params: [animationParam, animationParam], name: "compound")
     ]
   var pickerSizeRatio: CGFloat = 0.25 {
     didSet {

--- a/IBAnimatableApp/IBAnimatableApp/Playground/Utils/ParamType.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/Utils/ParamType.swift
@@ -64,6 +64,15 @@ enum ParamType {
       return   ("\(value(at: index)) \(unit)").trimmingCharacters(in: CharacterSet.whitespaces)
     }
   }
+
+  var reversed: ParamType {
+    switch self {
+    case .number(let min, let max, let interval, let ascending, let unit):
+      return .number(min: min, max: max, interval: interval, ascending: !ascending, unit: unit)
+    case .enumeration(let values):
+      return .enumeration(values: values.reversed())
+    }
+  }
 }
 
 struct PickerEntry {

--- a/Sources/Enums/AnimationType.swift
+++ b/Sources/Enums/AnimationType.swift
@@ -29,7 +29,7 @@ public indirect enum AnimationType {
   case moveTo(x: Double, y: Double)
   case moveBy(x: Double, y: Double)
   case scale(fromX: Double, fromY: Double, toX: Double, toY: Double)
-  case compound(x: AnimationType, y: AnimationType)
+  case compound(animations: [AnimationType])
   case none
 
   public enum FadeWay: String {
@@ -132,7 +132,7 @@ extension AnimationType: IBEnum {
     case "scaleto":
       self = .scaleTo(x: params[safe: 0]?.toDouble() ?? 0, y: params[safe: 1]?.toDouble() ?? 0)
     case "compound":
-      self = .compound(x: params[safe: 0]?.toAnimationType() ?? .none, y: params[safe: 1]?.toAnimationType() ?? .none)
+      self = .compound(animations: params.map { $0.toAnimationType() ?? .none } )
     default:
       self = .none
     }
@@ -140,7 +140,9 @@ extension AnimationType: IBEnum {
 }
 private extension String {
   func toAnimationType() -> AnimationType? {
-    return AnimationType(string: self)
+    let type = self.replacingOccurrences(of: "[", with: "(")
+      .replacingOccurrences(of: "]", with: ")")
+    return AnimationType(string: type)
   }
 }
 private func retrieveRepeatCount(string: String?) -> Int {

--- a/Sources/Enums/AnimationType.swift
+++ b/Sources/Enums/AnimationType.swift
@@ -9,7 +9,7 @@ import UIKit
  Predefined Animation Type
  */
 
-public enum AnimationType {
+public indirect enum AnimationType {
   case slide(way: Way, direction: Direction)
   case squeeze(way: Way, direction: Direction)
   case slideFade(way: Way, direction: Direction)
@@ -29,6 +29,7 @@ public enum AnimationType {
   case moveTo(x: Double, y: Double)
   case moveBy(x: Double, y: Double)
   case scale(fromX: Double, fromY: Double, toX: Double, toY: Double)
+  case compound(x: AnimationType, y: AnimationType)
   case none
 
   public enum FadeWay: String {
@@ -130,12 +131,18 @@ extension AnimationType: IBEnum {
       self = .scaleFrom(x: params[safe: 0]?.toDouble() ?? 0, y: params[safe: 1]?.toDouble() ?? 0)
     case "scaleto":
       self = .scaleTo(x: params[safe: 0]?.toDouble() ?? 0, y: params[safe: 1]?.toDouble() ?? 0)
+    case "compound":
+      self = .compound(x: params[safe: 0]?.toAnimationType() ?? .none, y: params[safe: 1]?.toAnimationType() ?? .none)
     default:
       self = .none
     }
   }
 }
-
+private extension String {
+  func toAnimationType() -> AnimationType? {
+    return AnimationType(string: self)
+  }
+}
 private func retrieveRepeatCount(string: String?) -> Int {
   // Default value for repeat count is `1`
   guard let string = string, let repeatCount = Int(string) else {

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -92,11 +92,24 @@ public extension Animatable where Self: UIView {
     let completion = {
       promise.animationCompleted()
     }
-    doAnimation(animation, configuration: configuration, completion: completion)
+    doAnimation(animation ?? self.animationType, configuration: configuration, completion: completion)
   }
 
-  internal func doAnimation(_ animation: AnimationType? = nil, configuration: AnimationConfiguration, completion: @escaping () -> Void) {
-    switch animation ?? animationType {
+  /**
+   `autoRunAnimation` method, should be called in layoutSubviews() method
+   */
+  func autoRunAnimation() {
+    if autoRun {
+      autoRun = false
+      animate(animationType)
+    }
+  }
+}
+
+fileprivate extension UIView {
+
+  func doAnimation(_ animation: AnimationType, configuration: AnimationConfiguration, completion: @escaping () -> Void) {
+    switch animation {
     case let .slide(way, direction):
       slide(way, direction: direction, configuration: configuration, completion: completion)
     case let .squeeze(way, direction):

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -135,10 +135,10 @@ public extension Animatable where Self: UIView {
       moveTo(x: x, y: y, configuration: configuration, completion: completion)
     case let .scale(fromX, fromY, toX, toY):
       scale(fromX: fromX, fromY: fromY, toX: toX, toY: toY, configuration: configuration, completion: completion)
-    case let .compound(x, y):
-      doAnimation(x, configuration: configuration) {
-        self.doAnimation(y, configuration: configuration, completion: completion)
-      }
+    case let .compound(animations):
+      animations.reversed().reduce(completion) { result, animation in
+        return { self.doAnimation(animation, configuration: configuration, completion: result) }
+        }()
     case .none:
       break
     }

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -92,6 +92,10 @@ public extension Animatable where Self: UIView {
     let completion = {
       promise.animationCompleted()
     }
+    doAnimation(animation, configuration: configuration , completion: completion)
+  }
+  internal func doAnimation(_ animation: AnimationType? = nil, configuration: AnimationConfiguration, completion: @escaping () -> Void) {
+    
     switch animation ?? animationType {
     case let .slide(way, direction):
       slide(way, direction: direction, configuration: configuration, completion: completion)
@@ -131,6 +135,10 @@ public extension Animatable where Self: UIView {
       moveTo(x: x, y: y, configuration: configuration, completion: completion)
     case let .scale(fromX, fromY, toX, toY):
       scale(fromX: fromX, fromY: fromY, toX: toX, toY: toY, configuration: configuration, completion: completion)
+    case let .compound(x, y):
+      doAnimation(x, configuration: configuration) {
+        self.doAnimation(y, configuration: configuration, completion: completion)
+      }
     case .none:
       break
     }
@@ -725,6 +733,8 @@ public extension AnimationType {
       return false
     case .fade(way: .inOut), .fade(way: .outIn):
       return false
+    case .compound:
+      return true
     case .none:
       return false
     }
@@ -743,6 +753,8 @@ public extension AnimationType {
       return false
     case .fade(way: .in), .fade(way: .out):
       return false
+    case .compound:
+      return true
     case .none:
       return false
     }


### PR DESCRIPTION
Just a try for #504

Add `indirect` on `AnimationType` to be able to reference itself

The `compound` animation type here could take only two animations, but we could image an array

I have tested on demo with only some animations, and no parameters for them.