### PR TITLE
Fix view's borders when using it with corner radius `allSides` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ N/A
 
 - Fix presented modal view (over context) frame when device orientation changed. [#516](https://github.com/IBAnimatable/IBAnimatable/pull/516) by [@phimage](https://github.com/phimage)
 - Fix dismissal animation type of AnimatableModalViewController when the type is set in Interface Builder. [#526](https://github.com/IBAnimatable/IBAnimatable/pull/526) by [@kazyk](https://github.com/kazyk)
+- Fix view's borders when using it with corner radius `allSides` [#530](https://github.com/IBAnimatable/IBAnimatable/pull/530) by [@tbaranes](https://github.com/tbaranes)
 
 ### [5.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/5.0.0)
 

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
@@ -48,15 +48,19 @@ extension CornerDesignableTests where Element: StringCornerDesignable {
 extension CornerDesignableTests where Element: UIView, Element: CornerDesignable {
 
   func _testCornerRadius() {
-    element.cornerRadius = 3.0
+    element.cornerRadius = 3
     element.cornerSides = .allSides
-    XCTAssertEqual(element.cornerRadius, element.layer.cornerRadius)
+    testRadiusPath(for: [.topLeft, .topRight, .bottomLeft, .bottomRight])
     element.cornerSides = [.bottomLeft, .bottomRight, .topLeft]
+    testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft])
+  }
+
+  private func testRadiusPath(for sides: UIRectCorner) {
     let mask = element.layer.mask as? CAShapeLayer
     XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.bounds.size))
     XCTAssertEqual(mask?.name, "cornerSideLayer")
     let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
-    let corners: UIRectCorner = [.bottomLeft, .bottomRight, .topLeft]
+    let corners: UIRectCorner = sides
     let mockPath = UIBezierPath(roundedRect: element.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
     XCTAssertEqual(mask?.path, mockPath)
   }
@@ -73,18 +77,21 @@ extension CornerDesignableTests where Element: UICollectionViewCell, Element: Co
     element.cornerRadius = 3.0
     XCTAssertNil(element.layer.mask)
     XCTAssertEqual(element.layer.cornerRadius, 0.0)
+
     element.cornerSides = .allSides
-    XCTAssertEqual(element.contentView.layer.cornerRadius, element.cornerRadius)
+    testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft, .topRight])
     element.cornerSides = [.bottomLeft, .bottomRight, .topLeft]
-    XCTAssertEqual(element.contentView.layer.cornerRadius, 0.0)
+    testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft])
+  }
+
+  private func testRadiusPath(for sides: UIRectCorner) {
     let mask = element.contentView.layer.mask as? CAShapeLayer
-    XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.bounds.size))
+    XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.contentView.bounds.size))
     XCTAssertEqual(mask?.name, "cornerSideLayer")
     let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
-    let corners: UIRectCorner = [.bottomLeft, .bottomRight, .topLeft]
-    let mockPath = UIBezierPath(roundedRect: element.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
+    let corners: UIRectCorner = sides
+    let mockPath = UIBezierPath(roundedRect: element.contentView.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
     XCTAssertEqual(mask?.path, mockPath)
-    XCTAssertTrue(element.contentView.layer.masksToBounds)
   }
 
 }

--- a/Sources/Protocols/Designable/CornerDesignable.swift
+++ b/Sources/Protocols/Designable/CornerDesignable.swift
@@ -26,18 +26,11 @@ public extension CornerDesignable where Self: UICollectionViewCell {
         layer.mask?.removeFromSuperlayer()
       }
       layer.cornerRadius = 0.0
+      contentView.layer.cornerRadius = 0.0
 
-      if cornerSides == .allSides {
-        contentView.layer.cornerRadius = cornerRadius
-      } else {
-        contentView.layer.cornerRadius = 0.0
-
-        // if a layer mask is specified, remove it
-        contentView.layer.mask?.removeFromSuperlayer()
-
-        contentView.layer.mask = cornerSidesLayer()
-      }
-
+      // if a layer mask is specified, remove it
+      contentView.layer.mask?.removeFromSuperlayer()
+      contentView.layer.mask = cornerSidesLayer()
       contentView.layer.masksToBounds = true
     } else {
       contentView.layer.masksToBounds = false
@@ -48,16 +41,11 @@ public extension CornerDesignable where Self: UICollectionViewCell {
 public extension CornerDesignable where Self: UIView {
   public func configureCornerRadius() {
     if !cornerRadius.isNaN && cornerRadius > 0 {
-      if cornerSides == .allSides {
-        layer.cornerRadius = cornerRadius
-      } else {
-        layer.cornerRadius = 0.0
-
-        // if a layer mask is specified, remove it
-        layer.mask?.removeFromSuperlayer()
-
-        layer.mask = cornerSidesLayer()
-      }
+      layer.cornerRadius = 0.0
+      
+      // if a layer mask is specified, remove it
+      layer.mask?.removeFromSuperlayer()
+      layer.mask = cornerSidesLayer()
     }
   }
 

--- a/Sources/Protocols/Designable/CornerDesignable.swift
+++ b/Sources/Protocols/Designable/CornerDesignable.swift
@@ -42,7 +42,7 @@ public extension CornerDesignable where Self: UIView {
   public func configureCornerRadius() {
     if !cornerRadius.isNaN && cornerRadius > 0 {
       layer.cornerRadius = 0.0
-      
+
       // if a layer mask is specified, remove it
       layer.mask?.removeFromSuperlayer()
       layer.mask = cornerSidesLayer()


### PR DESCRIPTION
The border doesn't respect the `allSides` radius when both are set. Using a custom layer for every radius fix this.