### PR TITLE
Animate TabBarItem image view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ N/A
 - Fix dismissal animation type of AnimatableModalViewController when the type is set in Interface Builder. [#526](https://github.com/IBAnimatable/IBAnimatable/pull/526) by [@kazyk](https://github.com/kazyk)
 - Fix view's borders when using it with corner radius `allSides` [#530](https://github.com/IBAnimatable/IBAnimatable/pull/530) by [@tbaranes](https://github.com/tbaranes)
 - Fix CACurrentMediaTime usage by calling it on the CALayer object with conversion. [#541](https://github.com/IBAnimatable/IBAnimatable/pull/541) by [@lukas2](https://github.com/lukas2)
+- Animate TabBarItem image view when clicking on it. [#539](https://github.com/IBAnimatable/IBAnimatable/pull/539) by [@phimage](https://github.com/phimage)
 
 ### [5.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/5.0.0)
 

--- a/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		48D80DCA20403DAC00D3137B /* AnimatableTabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */; };
 		C4511F371F93F1B2002E0FAF /* UIBezierPathExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4511F361F93F1B2002E0FAF /* UIBezierPathExtension.swift */; };
 		E20DAEB82003662900BE1C88 /* GradientMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DAEB72003662900BE1C88 /* GradientMode.swift */; };
 		E20DAEBA2003682F00BE1C88 /* RadialGradientLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DAEB92003682F00BE1C88 /* RadialGradientLayer.swift */; };
@@ -202,6 +203,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableTabBarItem.swift; sourceTree = "<group>"; };
 		C4511F361F93F1B2002E0FAF /* UIBezierPathExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBezierPathExtension.swift; sourceTree = "<group>"; };
 		E20DAEB72003662900BE1C88 /* GradientMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientMode.swift; sourceTree = "<group>"; };
 		E20DAEB92003682F00BE1C88 /* RadialGradientLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadialGradientLayer.swift; sourceTree = "<group>"; };
@@ -828,6 +830,7 @@
 				E27FD2311ECD7D8A00F74840 /* AnimatableScrollView.swift */,
 				E27FD2321ECD7D8A00F74840 /* AnimatableSlider.swift */,
 				E27FD2331ECD7D8A00F74840 /* AnimatableStackView.swift */,
+				48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */,
 				E27FD2341ECD7D8A00F74840 /* AnimatableTableView.swift */,
 				E27FD2351ECD7D8A00F74840 /* AnimatableTableViewCell.swift */,
 				E27FD2361ECD7D8A00F74840 /* AnimatableTextField.swift */,
@@ -1041,6 +1044,7 @@
 				E27FD2491ECD7D8A00F74840 /* ActivityIndicatorAnimationBallScaleRippleMultiple.swift in Sources */,
 				E27FD28C1ECD7D8A00F74840 /* PresentationModalSize.swift in Sources */,
 				E27FD27A1ECD7D8A00F74840 /* AnimatableTableViewController.swift in Sources */,
+				48D80DCA20403DAC00D3137B /* AnimatableTabBarItem.swift in Sources */,
 				E27FD2A91ECD7D8A00F74840 /* SideImageDesignable.swift in Sources */,
 				E27FD2A31ECD7D8A00F74840 /* PlaceholderDesignable.swift in Sources */,
 				E27FD2681ECD7D8A00F74840 /* DropDownAnimator.swift in Sources */,

--- a/IBAnimatableApp/IBAnimatableApp/Playground/Interactions/Interactions.storyboard
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/Interactions/Interactions.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dfA-Oz-Rzp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dfA-Oz-Rzp">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,7 +14,7 @@
             <objects>
                 <tableViewController clearsSelectionOnViewWillAppear="NO" id="dfA-Oz-Rzp" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="rx3-Wx-7El" customClass="AnimatableTableView" customModule="IBAnimatable">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="separatorColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -28,7 +29,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="ContainerView custom transitions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="RMO-OG-nWz">
-                                                    <rect key="frame" x="16" y="0.0" width="344" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -53,7 +54,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="TabBar custom transitions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="b5Y-Ve-VLp">
-                                                    <rect key="frame" x="16" y="0.0" width="344" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -109,11 +110,15 @@
                         <viewControllerLayoutGuide type="bottom" id="oMF-dG-t6v"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gyx-JV-sSQ">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.26168105850000001" green="1" blue="0.17631615510000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <tabBarItem key="tabBarItem" systemItem="recents" id="O3c-iP-ZXd"/>
+                    <tabBarItem key="tabBarItem" systemItem="recents" id="O3c-iP-ZXd" customClass="AnimatableTabBarItem" customModule="IBAnimatable">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="rotate"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HKj-c9-aFa" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -128,11 +133,15 @@
                         <viewControllerLayoutGuide type="bottom" id="fBZ-EX-AER"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Yaf-io-dbm">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
-                    <tabBarItem key="tabBarItem" systemItem="bookmarks" id="BW0-Bw-ABa"/>
+                    <tabBarItem key="tabBarItem" systemItem="bookmarks" id="BW0-Bw-ABa" customClass="AnimatableTabBarItem" customModule="IBAnimatable">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="pop"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vLn-gs-sWQ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -147,11 +156,15 @@
                         <viewControllerLayoutGuide type="bottom" id="PKQ-2M-SJa"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="oEM-fl-ZZV">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <tabBarItem key="tabBarItem" systemItem="favorites" id="o9V-tw-wHB"/>
+                    <tabBarItem key="tabBarItem" systemItem="favorites" id="o9V-tw-wHB" customClass="AnimatableTabBarItem" customModule="IBAnimatable">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="_animationType" value="shake"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="p6O-89-jTc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -189,9 +202,12 @@
                         <viewControllerLayoutGuide type="bottom" id="X8g-nh-bqF"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="L8f-q3-2fq">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iy1-Oz-HwZ">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
+                            </containerView>
                             <tabBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tfq-47-rbv">
                                 <rect key="frame" x="0.0" y="554" width="375" height="49"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -205,9 +221,6 @@
                                     <outlet property="delegate" destination="wik-5c-GI1" id="5Mf-s5-eg2"/>
                                 </connections>
                             </tabBar>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iy1-Oz-HwZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
-                            </containerView>
                         </subviews>
                         <color key="backgroundColor" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>

--- a/Sources/Controllers/AnimatableTabBarController.swift
+++ b/Sources/Controllers/AnimatableTabBarController.swift
@@ -79,14 +79,12 @@ open class AnimatableTabBarController: UITabBarController, TransitionAnimatable 
   }
 }
 
-fileprivate extension UITabBar {
+private extension UITabBar {
 
     func view(for item: UITabBarItem) -> UIControl? {
       // return item.value(forKeyPath: "view") as? UIControl // apple could not allow that
-      guard let items = self.items else {
-        return nil
-      }
-      guard let index = items.index(of: item) else {
+      guard let items = self.items,
+        let index = items.index(of: item) else {
         return nil
       }
       // get all buttons

--- a/Sources/Controllers/AnimatableTabBarController.swift
+++ b/Sources/Controllers/AnimatableTabBarController.swift
@@ -46,9 +46,8 @@ open class AnimatableTabBarController: UITabBarController, TransitionAnimatable 
         return
     }
     // Animate the children image view
-    let subviews = tabBarButton.subviews.filter { $0 is UIImageView }
-    if let view = subviews.first {
-      animatable.animate(view: view)
+    if let imageView = tabBarButton.subviews.first(where: { $0 is UIImageView }) {
+      animatable.animate(view: imageView)
     }
   }
 

--- a/Sources/Controllers/AnimatableTabBarController.swift
+++ b/Sources/Controllers/AnimatableTabBarController.swift
@@ -39,6 +39,19 @@ open class AnimatableTabBarController: UITabBarController, TransitionAnimatable 
     }
   }
 
+  // MARK: - UITabBarDelegate
+  open override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+    guard let animatable = item as? (UITabBarItem & Animatable),
+      let tabBarButton = tabBar.view(for: item) else {
+        return
+    }
+    // Animate the children image view
+    let subviews = tabBarButton.subviews.filter { $0 is UIImageView }
+    if let view = subviews.first {
+      animatable.animate(view: view)
+    }
+  }
+
   // MARK: - Private
   // Must have a property to keep the reference alive because `UITabBarController.delegate` is `weak`
   fileprivate var navigator: Navigator?
@@ -64,4 +77,29 @@ open class AnimatableTabBarController: UITabBarController, TransitionAnimatable 
     }
     delegate = navigator
   }
+}
+
+fileprivate extension UITabBar {
+
+    func view(for item: UITabBarItem) -> UIControl? {
+      // return item.value(forKeyPath: "view") as? UIControl // apple could not allow that
+      guard let items = self.items else {
+        return nil
+      }
+      guard let index = items.index(of: item) else {
+        return nil
+      }
+      // get all buttons
+      // 1/ filter on control, not safe if apple add a new control in bar
+      let controls = self.subviews.filter { $0 is UIControl }
+      // 2/ filter on name, not safe if button class change
+      // let controls = self.subviews.filter { String(describing: type(of: $0 )) == "UITabBarButton" }
+
+      guard index < controls.count else {
+        // item could be not in tab bar (see "More")
+        return nil
+      }
+      return controls[index] as? UIControl
+    }
+
 }

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -154,7 +154,8 @@ fileprivate extension UIView {
   }
 
   // MARK: - Animation methods
-  func slide(_ way: AnimationType.Way, direction: AnimationType.Direction,
+  func slide(_ way: AnimationType.Way,
+             direction: AnimationType.Direction,
              configuration: AnimationConfiguration,
              completion: AnimatableCompletion? = nil) {
     let values = computeValues(way: way, direction: direction, configuration: configuration, shouldScale: false)
@@ -167,7 +168,8 @@ fileprivate extension UIView {
     }
   }
 
-  func squeeze(_ way: AnimationType.Way, direction: AnimationType.Direction,
+  func squeeze(_ way: AnimationType.Way,
+               direction: AnimationType.Direction,
                configuration: AnimationConfiguration,
                completion: AnimatableCompletion? = nil) {
     let values = computeValues(way: way, direction: direction, configuration: configuration, shouldScale: true)
@@ -179,7 +181,8 @@ fileprivate extension UIView {
     }
   }
 
-  func rotate(direction: AnimationType.RotationDirection, repeatCount: Int,
+  func rotate(direction: AnimationType.RotationDirection,
+              repeatCount: Int,
               configuration: AnimationConfiguration,
               completion: AnimatableCompletion? = nil) {
     CALayer.animate({
@@ -240,7 +243,8 @@ fileprivate extension UIView {
     }
   }
 
-  func slideFade(_ way: AnimationType.Way, direction: AnimationType.Direction,
+  func slideFade(_ way: AnimationType.Way,
+                 direction: AnimationType.Direction,
                  configuration: AnimationConfiguration,
                  completion: AnimatableCompletion? = nil) {
     let values = computeValues(way: way, direction: direction, configuration: configuration, shouldScale: false)
@@ -268,9 +272,10 @@ fileprivate extension UIView {
     }
   }
 
-  func squeezeFade(_ way: AnimationType.Way, direction: AnimationType.Direction,
-                     configuration: AnimationConfiguration,
-                     completion: AnimatableCompletion? = nil) {
+  func squeezeFade(_ way: AnimationType.Way,
+                   direction: AnimationType.Direction,
+                   configuration: AnimationConfiguration,
+                   completion: AnimatableCompletion? = nil) {
     let values = computeValues(way: way, direction: direction, configuration: configuration, shouldScale: true)
     switch way {
     case .in:
@@ -516,8 +521,12 @@ fileprivate extension UIView {
     }
   }
 
-  private func springScale(fromX: Double, fromY: Double, toX: Double, toY: Double,
-                           configuration: AnimationConfiguration, completion: AnimatableCompletion? = nil) {
+  private func springScale(fromX: Double,
+                           fromY: Double,
+                           toX: Double,
+                           toY: Double,
+                           configuration: AnimationConfiguration,
+                           completion: AnimatableCompletion? = nil) {
     transform = CGAffineTransform(scaleX: CGFloat(fromX), y: CGFloat(fromY))
     UIView.animate(
       withDuration: configuration.duration,
@@ -536,8 +545,12 @@ fileprivate extension UIView {
     )
   }
 
-  private func layerScale(fromX: Double, fromY: Double, toX: Double, toY: Double,
-                          configuration: AnimationConfiguration, completion: AnimatableCompletion? = nil) {
+  private func layerScale(fromX: Double,
+                          fromY: Double,
+                          toX: Double,
+                          toY: Double,
+                          configuration: AnimationConfiguration,
+                          completion: AnimatableCompletion? = nil) {
     CALayer.animate({
       let scaleX = CAKeyframeAnimation(keyPath: "transform.scale.x")
       scaleX.values = [fromX, toX]
@@ -558,7 +571,8 @@ fileprivate extension UIView {
   }
 
 // swiftlint:enable variable_name_min_length
-  func computeValues(way: AnimationType.Way, direction: AnimationType.Direction,
+  func computeValues(way: AnimationType.Way,
+                     direction: AnimationType.Direction,
                      configuration: AnimationConfiguration,
                      shouldScale: Bool) -> AnimationValues {
     let scale = 3 * configuration.force
@@ -636,7 +650,7 @@ fileprivate extension UIView {
                    usingSpringWithDamping: configuration.damping,
                    initialSpringVelocity: configuration.velocity,
                    options: [],
-      animations: {
+                   animations: {
         self.transform = translate
       },
       completion: { completed in
@@ -669,7 +683,7 @@ fileprivate extension UIView {
                    usingSpringWithDamping: configuration.damping,
                    initialSpringVelocity: configuration.velocity,
                    options: [],
-      animations: {
+                   animations: {
         self.transform = CGAffineTransform.identity
         self.alpha = alpha
       },
@@ -690,7 +704,7 @@ fileprivate extension UIView {
                    usingSpringWithDamping: configuration.damping,
                    initialSpringVelocity: configuration.velocity,
                    options: [],
-      animations: {
+                   animations: {
         self.transform = translateAndScale
         self.alpha = alpha
       },

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -92,7 +92,24 @@ public extension Animatable where Self: UIView {
     let completion = {
       promise.animationCompleted()
     }
-    switch animation ?? animationType {
+    doAnimation(animation ?? self.animationType, configuration: configuration, completion: completion)
+  }
+
+  /**
+   `autoRunAnimation` method, should be called in layoutSubviews() method
+   */
+  func autoRunAnimation() {
+    if autoRun {
+      autoRun = false
+      animate(animationType)
+    }
+  }
+}
+
+fileprivate extension UIView {
+
+  func doAnimation(_ animationType: AnimationType, configuration: AnimationConfiguration, completion: @escaping () -> Void) {
+    switch animationType {
     case let .slide(way, direction):
       slide(way, direction: direction, configuration: configuration, completion: completion)
     case let .squeeze(way, direction):
@@ -135,19 +152,6 @@ public extension Animatable where Self: UIView {
       break
     }
   }
-
-  /**
-   `autoRunAnimation` method, should be called in layoutSubviews() method
-   */
-  func autoRunAnimation() {
-    if autoRun {
-      autoRun = false
-      animate(animationType)
-    }
-  }
-}
-
-fileprivate extension Animatable where Self: UIView {
 
   // MARK: - Animation methods
   func slide(_ way: AnimationType.Way, direction: AnimationType.Direction,
@@ -264,7 +268,7 @@ fileprivate extension Animatable where Self: UIView {
     }
   }
 
-    func squeezeFade(_ way: AnimationType.Way, direction: AnimationType.Direction,
+  func squeezeFade(_ way: AnimationType.Way, direction: AnimationType.Direction,
                      configuration: AnimationConfiguration,
                      completion: AnimatableCompletion? = nil) {
     let values = computeValues(way: way, direction: direction, configuration: configuration, shouldScale: true)
@@ -704,9 +708,26 @@ fileprivate extension Animatable where Self: UIView {
 }
 // swiftlint:enable variable_name_min_length
 
+// Animations for `UIBarItem`
 public extension Animatable where Self: UIBarItem {
-  // TODO: animations for `UIBarItem`
-  public func animate(completion: AnimatableCompletion? = nil) {
+
+  public func animate(_ animation: AnimationType? = nil,
+                      duration: TimeInterval? = nil,
+                      damping: CGFloat? = nil,
+                      velocity: CGFloat? = nil,
+                      force: CGFloat? = nil,
+                      view: UIView,
+                      completion: AnimatableCompletion? = nil) {
+
+    let configuration = AnimationConfiguration(damping: damping ?? self.damping,
+                                               velocity: velocity ?? self.velocity,
+                                               duration: duration ?? self.duration,
+                                               delay: 0,
+                                               force: force ?? self.force,
+                                               timingFunction: timingFunction ?? self.timingFunction)
+    view.doAnimation(animation ?? self.animationType, configuration: configuration) {
+      completion?()
+    }
   }
 }
 

--- a/Sources/Views/AnimatableTabBarItem.swift
+++ b/Sources/Views/AnimatableTabBarItem.swift
@@ -1,0 +1,47 @@
+//
+//  Created by Eric Marchand on 23/02/2018.
+//  Copyright © 2018 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+open class AnimatableTabBarItem: UITabBarItem, Animatable {
+
+  // MARK: - Animatable
+  open var animationType: AnimationType = .none
+  @IBInspectable var _animationType: String? {
+    didSet {
+      animationType = AnimationType(string: _animationType)
+    }
+  }
+  @IBInspectable open var autoRun: Bool = true
+  @IBInspectable open var duration: Double = Double.nan
+  @IBInspectable open var delay: Double = Double.nan
+  @IBInspectable open var damping: CGFloat = CGFloat.nan
+  @IBInspectable open var velocity: CGFloat = CGFloat.nan
+  @IBInspectable open var force: CGFloat = CGFloat.nan
+  @IBInspectable var _timingFunction: String = "" {
+    didSet {
+      timingFunction = TimingFunctionType(string: _timingFunction)
+    }
+  }
+  open var timingFunction: TimingFunctionType = .none
+
+  // MARK: - Lifecycle
+  open override func prepareForInterfaceBuilder() {
+    super.prepareForInterfaceBuilder()
+    configureInspectableProperties()
+  }
+
+  open override func awakeFromNib() {
+    super.awakeFromNib()
+    configureInspectableProperties()
+  }
+
+  // MARK: - Private
+  fileprivate func configureInspectableProperties() {
+    configureAnimatableProperties()
+  }
+
+}


### PR DESCRIPTION
See the re-opened issue #452 (I closed it thinking of a possible duplicate)

I make UIBarItem animatable by passing a view in `animate` function

There is many way to get a view to animate it, and no solution is perfect
I do not want to force the way to get the view

but for `AnimatableTabBarController` I make an example to get the internal `UIImageView`
The demo is updated to use `AnimatableTabBarItem`

---

Then in Animatable I move some function from `extension Animatable where Self: UIView {`to `extension UIView {` to be able to animate any view

---

I think there is some lags because I animate after tab bar item selection
`func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem)`
there is no
`func tabBar(_ tabBar: UITabBar, willSelect item: UITabBarItem)`