### PR TITLE
Reinstate CornerDesignable .allSides case with no mask applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ N/A
 - Add suppport for radial gradient. Currently not working with `startPoint`. [#527](https://github.com/IBAnimatable/IBAnimatable/pull/527) by [@tbaranes](https://github.com/tbaranes)
 
 #### Bugfixes
-
+- Fix CornerDesignable refactor 24d308d5ca that caused changed rendering behaviour (always applied mask, even when case .allSides)
 - Fix presented modal view (over context) frame when device orientation changed. [#516](https://github.com/IBAnimatable/IBAnimatable/pull/516) by [@phimage](https://github.com/phimage)
 - Fix dismissal animation type of AnimatableModalViewController when the type is set in Interface Builder. [#526](https://github.com/IBAnimatable/IBAnimatable/pull/526) by [@kazyk](https://github.com/kazyk)
 - Fix view's borders when using it with corner radius `allSides` [#530](https://github.com/IBAnimatable/IBAnimatable/pull/530) by [@tbaranes](https://github.com/tbaranes)

--- a/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
+++ b/IBAnimatable/IBAnimatableTests/TestProtocols/CornerDesignableTests.swift
@@ -50,19 +50,23 @@ extension CornerDesignableTests where Element: UIView, Element: CornerDesignable
   func _testCornerRadius() {
     element.cornerRadius = 3
     element.cornerSides = .allSides
-    testRadiusPath(for: [.topLeft, .topRight, .bottomLeft, .bottomRight])
+    testRadiusPath(for: .allCorners)
     element.cornerSides = [.bottomLeft, .bottomRight, .topLeft]
     testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft])
   }
 
   private func testRadiusPath(for sides: UIRectCorner) {
     let mask = element.layer.mask as? CAShapeLayer
-    XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.bounds.size))
-    XCTAssertEqual(mask?.name, "cornerSideLayer")
-    let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
-    let corners: UIRectCorner = sides
-    let mockPath = UIBezierPath(roundedRect: element.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
-    XCTAssertEqual(mask?.path, mockPath)
+    if sides == .allCorners {
+      XCTAssertNil(mask)
+    } else {
+      XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.bounds.size))
+      XCTAssertEqual(mask?.name, "cornerSideLayer")
+      let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
+      let corners: UIRectCorner = sides
+      let mockPath = UIBezierPath(roundedRect: element.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
+      XCTAssertEqual(mask?.path, mockPath)
+    }
   }
 
 }
@@ -79,19 +83,23 @@ extension CornerDesignableTests where Element: UICollectionViewCell, Element: Co
     XCTAssertEqual(element.layer.cornerRadius, 0.0)
 
     element.cornerSides = .allSides
-    testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft, .topRight])
+    testRadiusPath(for: .allCorners)
     element.cornerSides = [.bottomLeft, .bottomRight, .topLeft]
     testRadiusPath(for: [.bottomLeft, .bottomRight, .topLeft])
   }
 
   private func testRadiusPath(for sides: UIRectCorner) {
     let mask = element.contentView.layer.mask as? CAShapeLayer
-    XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.contentView.bounds.size))
-    XCTAssertEqual(mask?.name, "cornerSideLayer")
-    let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
-    let corners: UIRectCorner = sides
-    let mockPath = UIBezierPath(roundedRect: element.contentView.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
-    XCTAssertEqual(mask?.path, mockPath)
+    if sides == .allCorners {
+      XCTAssertNil(mask)
+    } else {
+      XCTAssertEqual(mask?.frame, CGRect(origin: .zero, size: element.contentView.bounds.size))
+      XCTAssertEqual(mask?.name, "cornerSideLayer")
+      let cornerRadii = CGSize(width: element.cornerRadius, height: element.cornerRadius)
+      let corners: UIRectCorner = sides
+      let mockPath = UIBezierPath(roundedRect: element.contentView.bounds, byRoundingCorners: corners, cornerRadii: cornerRadii).cgPath
+      XCTAssertEqual(mask?.path, mockPath)
+    }
   }
 
 }

--- a/Sources/Protocols/Designable/CornerDesignable.swift
+++ b/Sources/Protocols/Designable/CornerDesignable.swift
@@ -61,10 +61,14 @@ extension CornerDesignable {
   }
 
   private func applyCorner(in view: UIView) {
-    view.layer.cornerRadius = 0.0
-    // if a layer mask is specified, remove it
-    view.layer.mask?.removeFromSuperlayer()
-    view.layer.mask = cornerSidesLayer(inRect: view.bounds)
+    if cornerSides == .allSides {
+      view.layer.cornerRadius = cornerRadius
+    } else {
+      view.layer.cornerRadius = 0.0
+      // if a layer mask is specified, remove it
+      view.layer.mask?.removeFromSuperlayer()
+      view.layer.mask = cornerSidesLayer(inRect: view.bounds)
+    }
   }
 
   private func cornerSidesLayer(inRect bounds: CGRect) -> CAShapeLayer {


### PR DESCRIPTION
This supports situations when `clipsToBounds == false` and no mask is required.

I have an `AnimatableButton` subclass that uses `clipsToBounds == false` and has a badge subview . This could no longer be seen using master with reverting the refactor.