### PR TITLE
Fix activity indicator with delayed animations on some shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ N/A
 #### Enhancements
 
 - Allow to create new `compound` animation by code using operator `+`, or `Array` . [#559](https://github.com/IBAnimatable/IBAnimatable/pull/559) by [@phimage](https://github.com/phimage)
-- Allow new activity indicators `circleStrokeSpin`, `circleDashStrokeSpin`, `gear`, `tripleGear`,  `heartBeat`  and  `triforce`  . [#561](https://github.com/IBAnimatable/IBAnimatable/pull/561) by [@phimage](https://github.com/phimage)
+- Add new activity indicators `circleStrokeSpin`, `circleDashStrokeSpin`, `gear`, `tripleGear`,  `heartBeat`  and  `triforce`  . [#561](https://github.com/IBAnimatable/IBAnimatable/pull/561) by [@phimage](https://github.com/phimage)
+- Add new activity indicator `rupee`. [#562](https://github.com/IBAnimatable/IBAnimatable/pull/562) by [@phimage](https://github.com/phimage)
 
 #### Bugfixes
-N/A
+
+- Fix some activity indicator animations . [#562](https://github.com/IBAnimatable/IBAnimatable/pull/562) by [@phimage](https://github.com/phimage)
 
 ### [5.1.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/5.1.0)
 

--- a/Documentation/ActivityIndicators.md
+++ b/Documentation/ActivityIndicators.md
@@ -60,6 +60,7 @@ You can see an example of each animation in the demo app. Launch the app, then t
 35. [TripleGear](#triplegear)
 36. [HeartBeat](#heartbeat)
 37. [Triforce](#triforce)
+37. [Rupe](#rupe)
 
 ### AudioEqualizer
 
@@ -208,3 +209,7 @@ You can see an example of each animation in the demo app. Launch the app, then t
 ### Triforce
 
 ![ActivityIndicator - Triforce](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorTriforce.gif)
+
+### Rupe
+
+![ActivityIndicator - Rupe](https://raw.githubusercontent.com/IBAnimatable/IBAnimatable-Misc/master/IBAnimatable/ActivityIndicatorRupe.gif)

--- a/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		C456071F209BAACB002B1DF4 /* ActivityIndicatorAnimationCircleDashStrokeSpin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C456071E209BAACB002B1DF4 /* ActivityIndicatorAnimationCircleDashStrokeSpin.swift */; };
 		C46DC3E12099863A00501E63 /* ActivityIndicatorAnimationCircleStrokeSpin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46DC3E02099863A00501E63 /* ActivityIndicatorAnimationCircleStrokeSpin.swift */; };
 		C46DC3E32099895E00501E63 /* ActivityIndicatorAnimationGear.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46DC3E22099895E00501E63 /* ActivityIndicatorAnimationGear.swift */; };
+		C49C08DD20A05072002FCAFD /* ActivityIndicatorAnimationRupee.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49C08DC20A05072002FCAFD /* ActivityIndicatorAnimationRupee.swift */; };
 		E20DAEB82003662900BE1C88 /* GradientMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DAEB72003662900BE1C88 /* GradientMode.swift */; };
 		E20DAEBA2003682F00BE1C88 /* RadialGradientLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DAEB92003682F00BE1C88 /* RadialGradientLayer.swift */; };
 		E2561F5F1ECD7DD900A6D853 /* IBAnimatable.h in Headers */ = {isa = PBXBuildFile; fileRef = E2561F5D1ECD7DD900A6D853 /* IBAnimatable.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -233,6 +234,7 @@
 		C456071E209BAACB002B1DF4 /* ActivityIndicatorAnimationCircleDashStrokeSpin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationCircleDashStrokeSpin.swift; sourceTree = "<group>"; };
 		C46DC3E02099863A00501E63 /* ActivityIndicatorAnimationCircleStrokeSpin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationCircleStrokeSpin.swift; sourceTree = "<group>"; };
 		C46DC3E22099895E00501E63 /* ActivityIndicatorAnimationGear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationGear.swift; sourceTree = "<group>"; };
+		C49C08DC20A05072002FCAFD /* ActivityIndicatorAnimationRupee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationRupee.swift; sourceTree = "<group>"; };
 		E20DAEB72003662900BE1C88 /* GradientMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientMode.swift; sourceTree = "<group>"; };
 		E20DAEB92003682F00BE1C88 /* RadialGradientLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadialGradientLayer.swift; sourceTree = "<group>"; };
 		E2561F5D1ECD7DD900A6D853 /* IBAnimatable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IBAnimatable.h; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 				C41A0E7F209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift */,
 				C41A0E81209A3C1B0069555A /* ActivityIndicatorAnimationTriforce.swift */,
 				C456071E209BAACB002B1DF4 /* ActivityIndicatorAnimationCircleDashStrokeSpin.swift */,
+				C49C08DC20A05072002FCAFD /* ActivityIndicatorAnimationRupee.swift */,
 			);
 			path = Animations;
 			sourceTree = "<group>";
@@ -1175,6 +1178,7 @@
 				E27FD2771ECD7D8A00F74840 /* AnimatableNavigationController.swift in Sources */,
 				E27FD2431ECD7D8A00F74840 /* ActivityIndicatorAnimationBallPulseSync.swift in Sources */,
 				E27FD2591ECD7D8A00F74840 /* ActivityIndicatorFactory.swift in Sources */,
+				C49C08DD20A05072002FCAFD /* ActivityIndicatorAnimationRupee.swift in Sources */,
 				E27FD25C1ECD7D8A00F74840 /* ContainerTransition.swift in Sources */,
 				E27FD2451ECD7D8A00F74840 /* ActivityIndicatorAnimationBallRotateChase.swift in Sources */,
 				E27FD25D1ECD7D8A00F74840 /* InteractiveAnimatorFactory.swift in Sources */,

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallGridPulse.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallGridPulse.swift
@@ -21,6 +21,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
     let durations: [CFTimeInterval] = [0.72, 1.02, 1.28, 1.42, 1.45, 1.18, 0.87, 1.45, 1.06]
     let beginTime = layer.currentMediaTime
     let beginTimes: [CFTimeInterval] = [-0.06, 0.25, -0.17, 0.48, 0.31, 0.03, 0.46, 0.78, 0.45]
+    let animation = defaultAnimation
 
     // Draw circles
     for i in 0 ..< 3 {
@@ -45,7 +46,7 @@ public class ActivityIndicatorAnimationBallGridPulse: ActivityIndicatorAnimating
 
 private extension ActivityIndicatorAnimationBallGridPulse {
 
-  var animation: CAAnimationGroup {
+  var defaultAnimation: CAAnimationGroup {
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, opacityAnimation]
     animation.repeatCount = .infinity

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallScaleMultiple.swift
@@ -17,6 +17,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
     let beginTime = layer.currentMediaTime
     let beginTimes = [0, 0.2, 0.4]
 
+    let animation = defaultAnimation
     for i in 0 ..< 3 {
       let circle = ActivityIndicatorShape.circle.makeLayer(size: size, color: color)
       let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
@@ -37,7 +38,7 @@ public class ActivityIndicatorAnimationBallScaleMultiple: ActivityIndicatorAnima
 
 private extension ActivityIndicatorAnimationBallScaleMultiple {
 
-  var animation: CAAnimationGroup {
+  var defaultAnimation: CAAnimationGroup {
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, opacityAnimation]
     animation.timingFunctionType = .linear

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -18,6 +18,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
     let beginTime = layer.currentMediaTime
     let beginTimes = [0.0, 0.2, 0.4]
 
+    let animation = defaultAnimation
     for i in 0 ..< 3 {
       let circle = ActivityIndicatorShape.ring.makeLayer(size: size, color: color)
       let frame = CGRect(x: (layer.bounds.size.width - size.width) / 2,
@@ -37,7 +38,7 @@ public class ActivityIndicatorAnimationBallScaleRippleMultiple: ActivityIndicato
 
 private extension ActivityIndicatorAnimationBallScaleRippleMultiple {
 
-  var animation: CAAnimationGroup {
+  var defaultAnimation: CAAnimationGroup {
     let animation = CAAnimationGroup()
     animation.animations = [scaleAnimation, opacityAnimation]
     animation.duration = duration

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationRupee.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationRupee.swift
@@ -23,17 +23,17 @@ public class ActivityIndicatorAnimationRupee: ActivityIndicatorAnimating {
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTime = layer.currentMediaTime
-    let beginTimes: [CFTimeInterval] = [0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5]
+    let beginTimes: [CFTimeInterval] = [0.0, 0.5, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0]
     let animation = defaultAnimation
 
     // Draw shapes
     for i in 0 ..< 8 {
       if i % 4 != 0 { // remove left and right
         let shapeLayer = makeLayer(angle: .pi / 4 * CGFloat(i),
-                                     size: maskSize,
-                                     origin: CGPoint(x: x, y: y),
-                                     containerSize: size,
-                                     color: color)
+                                   size: maskSize,
+                                   origin: CGPoint(x: x, y: y),
+                                   containerSize: size,
+                                   color: color)
         animation.beginTime = beginTime + beginTimes[i]
         shapeLayer.add(animation, forKey: "animation")
         layer.addSublayer(shapeLayer)
@@ -49,9 +49,7 @@ public class ActivityIndicatorAnimationRupee: ActivityIndicatorAnimating {
       y: origin.y + radius * (sin(angle) + 1),
       width: size,
       height: size)
-    
     layer.frame = frame
-    
     return layer
   }
 
@@ -59,7 +57,7 @@ public class ActivityIndicatorAnimationRupee: ActivityIndicatorAnimating {
 
 // MARK: - Setup
 
-private extension ActivityIndicatorAnimationRupe {
+private extension ActivityIndicatorAnimationRupee {
 
   var defaultAnimation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationRupee.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationRupee.swift
@@ -1,60 +1,65 @@
 //
-//  Created by Tom Baranes on 23/08/16.
-//  Copyright (c) 2016 IBAnimatable. All rights reserved.
+//  ActivityIndicatorAnimationRupee.swift
+//  IBAnimatable
+//
+//  Created by phimage on 07/05/2018.
+//  Copyright © 2018 IBAnimatable. All rights reserved.
 //
 
 import UIKit
 
-public class ActivityIndicatorAnimationBallSpinFadeLoader: ActivityIndicatorAnimating {
+public class ActivityIndicatorAnimationRupee: ActivityIndicatorAnimating {
 
   // MARK: Properties
 
   fileprivate let duration: CFTimeInterval = 1
+  fileprivate let maskType: MaskType = .polygon(sides: 6)
 
   // MARK: ActivityIndicatorAnimating
 
   public func configureAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
-
-    let circleSpacing: CGFloat = -2
-    let circleSize = (size.width - 4 * circleSpacing) / 5
+    let maskSpacing: CGFloat = -2
+    let maskSize = (size.width - 4 * maskSpacing) / 5
     let x = (layer.bounds.size.width - size.width) / 2
     let y = (layer.bounds.size.height - size.height) / 2
     let beginTime = layer.currentMediaTime
-    let beginTimes: [CFTimeInterval] = [0, 0.12, 0.24, 0.36, 0.48, 0.6, 0.72, 0.84]
-
-    // Draw circles
+    let beginTimes: [CFTimeInterval] = [0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5]
     let animation = defaultAnimation
-    for i in 0 ..< 8 {
-      let circle = makeCircleLayer(angle: CGFloat.pi / 4 * CGFloat(i),
-                                   size: circleSize,
-                                   origin: CGPoint(x: x, y: y),
-                                   containerSize: size,
-                                   color: color)
 
-      animation.beginTime = beginTime + beginTimes[i]
-      circle.add(animation, forKey: "animation")
-      layer.addSublayer(circle)
+    // Draw shapes
+    for i in 0 ..< 8 {
+      if i % 4 != 0 { // remove left and right
+        let shapeLayer = makeLayer(angle: .pi / 4 * CGFloat(i),
+                                     size: maskSize,
+                                     origin: CGPoint(x: x, y: y),
+                                     containerSize: size,
+                                     color: color)
+        animation.beginTime = beginTime + beginTimes[i]
+        shapeLayer.add(animation, forKey: "animation")
+        layer.addSublayer(shapeLayer)
+      }
     }
   }
 
-  func makeCircleLayer(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
+  func makeLayer(angle: CGFloat, size: CGFloat, origin: CGPoint, containerSize: CGSize, color: UIColor) -> CALayer {
     let radius = containerSize.width / 2 - size / 2
-    let circle = ActivityIndicatorShape.circle.makeLayer(size: CGSize(width: size, height: size), color: color)
+    let layer = ActivityIndicatorShape.mask(type: maskType).makeLayer(size: CGSize(width: size, height: size), color: color)
     let frame = CGRect(
       x: origin.x + radius * (cos(angle) + 1),
       y: origin.y + radius * (sin(angle) + 1),
       width: size,
       height: size)
-
-    circle.frame = frame
-
-    return circle
+    
+    layer.frame = frame
+    
+    return layer
   }
+
 }
 
 // MARK: - Setup
 
-private extension ActivityIndicatorAnimationBallSpinFadeLoader {
+private extension ActivityIndicatorAnimationRupe {
 
   var defaultAnimation: CAAnimationGroup {
     let animation = CAAnimationGroup()

--- a/Sources/ActivityIndicators/Common/ActivityIndicatorFactory.swift
+++ b/Sources/ActivityIndicators/Common/ActivityIndicatorFactory.swift
@@ -84,6 +84,8 @@ public struct ActivityIndicatorFactory {
       return ActivityIndicatorAnimationHeartBeat()
     case .triforce:
       return ActivityIndicatorAnimationTriforce()
+    case .rupee:
+      return ActivityIndicatorAnimationRupee()
     }
   }
 }

--- a/Sources/Enums/ActivityIndicatorType.swift
+++ b/Sources/Enums/ActivityIndicatorType.swift
@@ -45,4 +45,5 @@ public enum ActivityIndicatorType: String, IBEnum {
   case tripleGear
   case heartBeat
   case triforce
+  case rupee
 }


### PR DESCRIPTION
Trying to add a new activity indicator named `rupee` 

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8875768/39699450-84f131fa-51f9-11e8-930d-6ea4eee5565d.gif)

and comparing the animation gif in doc and the current one in demo app, I see an issue :
some animation which use `beginTime` doesn't working

I see for working animation that the animation group is created only one time, not for each additional layer. So I edit the bugged ones.
