### PR TITLE
Add `conical` gradient type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ N/A
 - Add new activity indicator `rupee`. [#562](https://github.com/IBAnimatable/IBAnimatable/pull/562) by [@phimage](https://github.com/phimage)
 - Make AnimatableCollectionViewCell conforming to RotationDesignable [#565](https://github.com/IBAnimatable/IBAnimatable/pull/565) by [@tbaranes](https://github.com/tbaranes)
 - Add `preferred` presentation modal size. [#566](https://github.com/IBAnimatable/IBAnimatable/pull/566) by [@phimage](https://github.com/phimage)
+- Add `conical` gradient type. [#567](https://github.com/IBAnimatable/IBAnimatable/pull/567) by [@phimage](https://github.com/phimage)
 
 #### Bugfixes
 

--- a/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		3676E7DD2059457A0003B9DF /* AnimatableTextView.swift in Headers */ = {isa = PBXBuildFile; fileRef = E27FD2371ECD7D8A00F74840 /* AnimatableTextView.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		3676E7DE2059457A0003B9DF /* AnimatableView.swift in Headers */ = {isa = PBXBuildFile; fileRef = E27FD2381ECD7D8A00F74840 /* AnimatableView.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		3676E7DF2059457A0003B9DF /* DesignableNavigationBar.swift in Headers */ = {isa = PBXBuildFile; fileRef = E27FD2391ECD7D8A00F74840 /* DesignableNavigationBar.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		48A167122063CD0D00D7BCFB /* ConicalGradientLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A167112063CD0D00D7BCFB /* ConicalGradientLayer.swift */; };
 		48D80DCA20403DAC00D3137B /* AnimatableTabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */; };
 		C414765F209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift in Sources */ = {isa = PBXBuildFile; fileRef = C414765E209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift */; };
 		C41A0E80209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41A0E7F209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift */; };
@@ -226,6 +227,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		48A167112063CD0D00D7BCFB /* ConicalGradientLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConicalGradientLayer.swift; sourceTree = "<group>"; };
 		48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableTabBarItem.swift; sourceTree = "<group>"; };
 		C414765E209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationTripleGear.swift; sourceTree = "<group>"; };
 		C41A0E7F209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationHeartBeat.swift; sourceTree = "<group>"; };
@@ -756,6 +758,7 @@
 			children = (
 				E27FD1F31ECD7D8A00F74840 /* AnimationChainable.swift */,
 				E20DAEB92003682F00BE1C88 /* RadialGradientLayer.swift */,
+				48A167112063CD0D00D7BCFB /* ConicalGradientLayer.swift */,
 				E2AD5F862020AE3800832382 /* IB.swift */,
 			);
 			path = Others;
@@ -1045,6 +1048,7 @@
 				E27FD2931ECD7D8A00F74840 /* UIViewControllerExtension.swift in Sources */,
 				E27FD2C71ECD7D8A00F74840 /* AnimatableCheckBox.swift in Sources */,
 				E27FD29F1ECD7D8A00F74840 /* GradientDesignable.swift in Sources */,
+				48A167122063CD0D00D7BCFB /* ConicalGradientLayer.swift in Sources */,
 				E27FD2B01ECD7D8A00F74840 /* AnimatedTransitioning.swift in Sources */,
 				E27FD2841ECD7D8A00F74840 /* GradientStartPoint.swift in Sources */,
 				E27FD27D1ECD7D8A00F74840 /* ActivityIndicatorType.swift in Sources */,

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientCustomStartPointViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientCustomStartPointViewController.swift
@@ -13,7 +13,7 @@ final class GradientCustomStartPointViewController: UIViewController {
 
   @IBOutlet fileprivate weak var gView: AnimatableView!
 
-  var useRadialGradient = false
+  var gradientMode: GradientMode = .linear
   let gradientValues = ParamType(fromEnum: GradientType.self)
   let coordPointValues = ParamType.number(min: 0, max: 1, interval: 0.1, ascending: true, unit: "")
   lazy var componentValues: [ParamType] = [self.gradientValues,
@@ -24,7 +24,7 @@ final class GradientCustomStartPointViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    gView.gradientMode = useRadialGradient ? .radial : .linear
+    gView.gradientMode = gradientMode
     gView.predefinedGradient = GradientType(rawValue: gradientValues.value(at: 0))
   }
 }

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientCustomStartPointViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientCustomStartPointViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import IBAnimatable
 
-final class GradientCustomStartPointViewController: UIViewController {
+final class GradientCustomStartPointViewController: UIViewController, GradientModePresenter {
 
   @IBOutlet fileprivate weak var gView: AnimatableView!
 

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientViewController.swift
@@ -6,7 +6,7 @@
 import UIKit
 import IBAnimatable
 
-final class GradientViewController: UIViewController {
+final class GradientViewController: UIViewController, GradientModePresenter {
 
   @IBOutlet fileprivate weak var gView: AnimatableView!
 

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/GradientViewController.swift
@@ -14,14 +14,14 @@ final class GradientViewController: UIViewController {
   let startPointValues = ParamType.enumeration(values: ["top", "topLeft", "topRight", "left", "right", "bottom", "bottomRight", "bottomLeft"])
   let colorValues = ParamType(fromEnum: ColorType.self)
   var usePredefinedGradient = true
-  var useRadialGradient = false
+  var gradientMode: GradientMode = .linear
   lazy var componentValues: [ParamType] = {
     self.usePredefinedGradient ? [self.gradientValues, self.startPointValues] : [self.colorValues, self.colorValues, self.startPointValues]
   }()
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    gView.gradientMode = useRadialGradient ? .radial : .linear
+    gView.gradientMode = gradientMode
     if usePredefinedGradient {
       gView.predefinedGradient = GradientType(rawValue: gradientValues.value(at: 0))
       gView.startPoint = GradientStartPoint(string: startPointValues.value(at: 0))

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradients.storyboard
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradients.storyboard
@@ -73,8 +73,33 @@
                                             <segue destination="YvY-Pr-4LY" kind="show" identifier="radialGradient" id="j8M-Fd-sWl"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="t5m-Ei-nOr" style="IBUITableViewCellStyleDefault" id="AkO-ey-85U" userLabel="Predefined gradients" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="nsb-am-nbX" style="IBUITableViewCellStyleDefault" id="Kgn-1m-fAf" userLabel="Conical Gradients" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
                                         <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Kgn-1m-fAf" id="aei-LA-1XG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Conical Gradient" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nsb-am-nbX">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="YvY-Pr-4LY" kind="show" identifier="conicalGradient" id="81r-Ow-RIg"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="t5m-Ei-nOr" style="IBUITableViewCellStyleDefault" id="AkO-ey-85U" userLabel="Predefined gradients" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AkO-ey-85U" id="PXI-Fe-iHY">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -99,7 +124,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="0tk-xl-sR8" style="IBUITableViewCellStyleDefault" id="pmt-bP-l2M" userLabel="Radial Predefined gradients" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="176" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pmt-bP-l2M" id="o4x-OP-ORR">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -119,12 +144,9 @@
                                                 <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <segue destination="YvY-Pr-4LY" kind="show" identifier="radialPredefinedGradient" id="ntD-96-lWN"/>
-                                        </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="YJL-aX-k2r" style="IBUITableViewCellStyleDefault" id="YMn-Qv-PvD" userLabel="Gradients custom start points" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="176" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="220" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YMn-Qv-PvD" id="4Iz-AO-vKu">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -149,13 +171,13 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="hPE-CW-3dG" style="IBUITableViewCellStyleDefault" id="lor-jQ-4e6" userLabel="Radial Gradients custom start points" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="220" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="264" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lor-jQ-4e6" id="Lhx-GN-i0G">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Radial Gradients with custom start points" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hPE-CW-3dG" userLabel="Gradients with custom start points">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Radial Gradients with custom start points" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hPE-CW-3dG">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -173,8 +195,33 @@
                                             <segue destination="Z6c-Ij-gBS" kind="show" identifier="radialGradientCustomStartPoints" id="o0r-Ah-Eo9"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="mT6-Nr-kRl" style="IBUITableViewCellStyleDefault" id="3IN-P9-AfS" userLabel="Conical Gradients custom start points" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
+                                        <rect key="frame" x="0.0" y="308" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3IN-P9-AfS" id="OTe-AN-Oma">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Conical Gradients with custom start points" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mT6-Nr-kRl">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" red="1" green="0.99997437" blue="0.99999129769999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                                                <color key="value" red="0.72941176470000002" green="0.46666666670000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Z6c-Ij-gBS" kind="show" identifier="conicalGradientCustomStartPoints" id="soG-ql-yyY"/>
+                                        </connections>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transitionCell" textLabel="qIM-Mg-POm" style="IBUITableViewCellStyleDefault" id="5tQ-oF-o3a" userLabel="Predefined gradients collection" customClass="AnimatableTableViewCell" customModule="IBAnimatable">
-                                        <rect key="frame" x="0.0" y="264" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="352" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5tQ-oF-o3a" id="h4c-oT-sym">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -509,7 +556,7 @@
         <image name="back" width="21" height="21"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="o0r-Ah-Eo9"/>
-        <segue reference="ntD-96-lWN"/>
+        <segue reference="soG-ql-yyY"/>
+        <segue reference="j8M-Fd-sWl"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradientsTableViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradientsTableViewController.swift
@@ -12,11 +12,25 @@ import UIKit
 final class UserInterfaceGradientsTableViewController: UITableViewController {
 
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let gradientVC = segue.destination as? GradientViewController {
-      gradientVC.usePredefinedGradient = segue.identifier?.lowercased().contains("predefined") ?? false
-      gradientVC.useRadialGradient = segue.identifier?.lowercased().contains("radial") ?? false
-    } else if let gradientVC = segue.destination as? GradientCustomStartPointViewController {
-      gradientVC.useRadialGradient = segue.identifier?.lowercased().contains("radial") ?? false
+    if let identifier = segue.identifier?.lowercased() {
+      if let gradientVC = segue.destination as? GradientViewController {
+        gradientVC.usePredefinedGradient = identifier.contains("predefined")
+        if identifier.contains("radial") {
+          gradientVC.gradientMode = .radial
+        } else if identifier.contains("conical") {
+          gradientVC.gradientMode = .conical
+        } else {
+          gradientVC.gradientMode = .linear
+        }
+      } else if let gradientVC = segue.destination as? GradientCustomStartPointViewController {
+        if identifier.contains("radial") {
+          gradientVC.gradientMode = .radial
+        } else if identifier.contains("conical") {
+          gradientVC.gradientMode = .conical
+        } else {
+          gradientVC.gradientMode = .linear
+        }
+      }
     }
   }
 }

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradientsTableViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Gradients/UserInterfaceGradientsTableViewController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import IBAnimatable
 
 final class UserInterfaceGradientsTableViewController: UITableViewController {
 
@@ -15,14 +16,8 @@ final class UserInterfaceGradientsTableViewController: UITableViewController {
     if let identifier = segue.identifier?.lowercased() {
       if let gradientVC = segue.destination as? GradientViewController {
         gradientVC.usePredefinedGradient = identifier.contains("predefined")
-        if identifier.contains("radial") {
-          gradientVC.gradientMode = .radial
-        } else if identifier.contains("conical") {
-          gradientVC.gradientMode = .conical
-        } else {
-          gradientVC.gradientMode = .linear
-        }
-      } else if let gradientVC = segue.destination as? GradientCustomStartPointViewController {
+      }
+      if var gradientVC = segue.destination as? GradientModePresenter {
         if identifier.contains("radial") {
           gradientVC.gradientMode = .radial
         } else if identifier.contains("conical") {
@@ -33,4 +28,8 @@ final class UserInterfaceGradientsTableViewController: UITableViewController {
       }
     }
   }
+}
+
+protocol GradientModePresenter {
+  var gradientMode: GradientMode { get set }
 }

--- a/Sources/Enums/GradientMode.swift
+++ b/Sources/Enums/GradientMode.swift
@@ -11,4 +11,5 @@ import Foundation
 public enum GradientMode: String, IBEnum {
   case linear
   case radial
+  case conical
 }

--- a/Sources/Enums/GradientStartPoint.swift
+++ b/Sources/Enums/GradientStartPoint.swift
@@ -54,3 +54,60 @@ extension GradientStartPoint {
     }
   }
 }
+
+extension GradientStartPoint {
+
+  var startPoint: CGPoint {
+    switch self {
+    case .top:
+      return CGPoint(x: 0.5, y: 0)
+    case .topRight:
+      return CGPoint(x: 1, y: 0)
+    case .right:
+      return CGPoint(x: 1, y: 0.5)
+    case .bottomRight:
+      return CGPoint(x: 1, y: 1)
+    case .bottom:
+      return CGPoint(x: 0.5, y: 1)
+    case .bottomLeft:
+      return CGPoint(x: 0, y: 1)
+    case .left:
+      return CGPoint(x: 0, y: 0.5)
+    case .topLeft:
+      return CGPoint(x: 0, y: 0)
+    case let .custom(start, _):
+      return start
+    case .none:
+      return .zero
+    }
+  }
+
+  var endPoint: CGPoint {
+    switch self {
+    case .top:
+      return CGPoint(x: 0.5, y: 1)
+    case .topRight:
+      return CGPoint(x: 0, y: 1)
+    case .right:
+      return CGPoint(x: 0, y: 0.5)
+    case .bottomRight:
+      return CGPoint(x: 0, y: 0)
+    case .bottom:
+      return CGPoint(x: 0.5, y: 0)
+    case .bottomLeft:
+      return  CGPoint(x: 1, y: 0)
+    case .left:
+      return CGPoint(x: 1, y: 0.5)
+    case .topLeft:
+      return CGPoint(x: 1, y: 1)
+    case let .custom(_, end):
+      return end
+    case .none:
+      return .zero
+    }
+  }
+
+  var points: (CGPoint, CGPoint) {
+    return (startPoint, endPoint)
+  }
+}

--- a/Sources/Others/ConicalGradientLayer.swift
+++ b/Sources/Others/ConicalGradientLayer.swift
@@ -51,7 +51,7 @@ final class ConicalGradientLayer: CALayer {
                                   y: newValue.y - centerPoint.y)
       var angle = Double(atan2(centeredPoint.y - self.frame.midY, centeredPoint.x - self.frame.midX))
       if angle < 0 {
-        angle = angle + 2 * .pi
+        angle += 2 * .pi
       }
       self.startAngle = angle
     }
@@ -67,7 +67,7 @@ final class ConicalGradientLayer: CALayer {
                                   y: centerPoint.y - newValue.y)
       var angle = Double(atan2(centeredPoint.y - self.frame.midY, centeredPoint.x - self.frame.midX))
       if angle < 0 {
-        angle = angle + 2 * .pi
+        angle += + 2 * .pi
       }
       self.endAngle = angle + 2 * .pi
     }

--- a/Sources/Others/ConicalGradientLayer.swift
+++ b/Sources/Others/ConicalGradientLayer.swift
@@ -1,0 +1,206 @@
+//
+//  ConicalGradientLayer.swift
+//  IBAnimatable
+//
+//  Created by Eric Marchand on 22/03/2018.
+//  Copyright © 2018 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+final class ConicalGradientLayer: CALayer {
+
+  required override init() {
+    super.init()
+    needsDisplayOnBoundsChange = true
+  }
+
+  required init(coder aDecoder: NSCoder) {
+    super.init()
+  }
+
+  open var colors = [CGColor]() {
+    didSet {
+      setNeedsDisplay()
+    }
+  }
+
+  /// Start angle in radians. Defaults to 0.
+  open var startAngle: Double = 0.0 {
+    didSet {
+      setNeedsDisplay()
+    }
+  }
+
+  /// End angle in radians. Defaults to 2 pi.
+  open var endAngle: Double = 2 * .pi {
+    didSet {
+      setNeedsDisplay()
+    }
+  }
+
+  open let centerPoint: CGPoint = CGPoint(x: 0.5, y: 0.5)
+
+  open var startPoint: CGPoint {
+    get {
+      assertionFailure("not implemented")
+      return .zero
+    }
+    set {
+      let centeredPoint = CGPoint(x: newValue.x - centerPoint.x,
+                                  y: newValue.y - centerPoint.y)
+      var angle = Double(atan2(centeredPoint.y - self.frame.midY, centeredPoint.x - self.frame.midX))
+      if angle < 0 {
+        angle = angle + 2 * .pi
+      }
+      self.startAngle = angle
+    }
+  }
+
+  open var endPoint: CGPoint {
+    get {
+      assertionFailure("not implemented")
+      return .zero
+    }
+    set {
+      let centeredPoint = CGPoint(x: centerPoint.x - newValue.x,
+                                  y: centerPoint.y - newValue.y)
+      var angle = Double(atan2(centeredPoint.y - self.frame.midY, centeredPoint.x - self.frame.midX))
+      if angle < 0 {
+        angle = angle + 2 * .pi
+      }
+      self.endAngle = angle + 2 * .pi
+    }
+  }
+
+  /// List of computed color transitions.
+  private var transitions = [UIColor.Transition]()
+
+  open override func draw(in ctx: CGContext) {
+    UIGraphicsPushContext(ctx)
+    draw(in: ctx.boundingBoxOfClipPath)
+    UIGraphicsPopContext()
+  }
+
+  private func draw(in rect: CGRect) {
+    configureTransitions()
+
+    let center = CGPoint(x: rect.width * centerPoint.x,
+                         y: rect.height * centerPoint.y)
+    let longerSide = max(rect.width, rect.height)
+    let radius = Double(longerSide) * 2.squareRoot()
+    let step = (.pi / 2) / radius
+    var angle = startAngle
+
+    while angle <= endAngle {
+      let pointX = radius * cos(angle) + Double(center.x)
+      let pointY = radius * sin(angle) + Double(center.y)
+      let startPoint = CGPoint(x: pointX, y: pointY)
+
+      let line = UIBezierPath()
+      line.move(to: startPoint)
+      line.addLine(to: center)
+      color(forAngle: angle - startAngle, on: (endAngle - startAngle)).setStroke()
+      line.stroke()
+
+      angle += step
+    }
+  }
+
+  private func color(forAngle angle: Double, on arc: Double) -> UIColor {
+    let percent = angle / arc
+    guard let transition = transition(forPercent: percent) else {
+      return UIColor(hue: CGFloat(percent), saturation: 1.0, brightness: 1.0, alpha: 1.0)
+    }
+    return transition.color(forPercent: percent)
+  }
+
+  private func configureTransitions() {
+    transitions.removeAll()
+
+    if colors.count > 1 {
+      let transitionsCount = colors.count - 1
+      let step = 1.0 / Double(transitionsCount)
+
+      for i in 0 ..< transitionsCount {
+        let fromLocation = step * Double(i)
+        let toLocation = step * Double(i + 1)
+
+        let fromColor = UIColor(cgColor: colors[i])
+        let toColor = UIColor(cgColor: colors[i + 1])
+
+        transitions.append(.init(fromLocation: fromLocation,
+                                 toLocation: toLocation,
+                                 fromColor: fromColor,
+                                 toColor: toColor))
+      }
+    }
+  }
+
+  private func transition(forPercent percent: Double) -> UIColor.Transition? {
+    let filtered = transitions.filter { percent >= $0.fromLocation && percent < $0.toLocation }
+    if let first = filtered.first {
+      return first
+    }
+    return percent <= 0.5 ? transitions.first : transitions.last // only to complete
+  }
+
+}
+
+// MARK: UIColor
+
+private extension UIColor {
+
+  struct RGBA {
+    var red: CGFloat = 0.0
+    var green: CGFloat = 0.0
+    var blue: CGFloat = 0.0
+    var alpha: CGFloat = 0.0
+
+    init(color: UIColor) {
+      color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    }
+  }
+
+  var rgba: RGBA {
+    return RGBA(color: self)
+  }
+
+  struct Transition {
+
+    let fromLocation: Double
+    let toLocation: Double
+
+    let fromColor: UIColor
+    let toColor: UIColor
+
+    func color(forPercent percent: Double) -> UIColor {
+      let normalizedPercent = percent.normalize(fromMin: fromLocation, max: toLocation)
+      return UIColor.lerp(from: fromColor.rgba, to: toColor.rgba, percent: CGFloat(normalizedPercent))
+    }
+
+  }
+
+  class func lerp(from: UIColor.RGBA, to: UIColor.RGBA, percent: CGFloat) -> UIColor {
+    let red = from.red + percent * (to.red - from.red)
+    let green = from.green + percent * (to.green - from.green)
+    let blue = from.blue + percent * (to.blue - from.blue)
+    let alpha = from.alpha + percent * (to.alpha - from.alpha)
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+  }
+
+}
+
+// MARK: - Double
+
+private extension Double {
+
+  func normalize(fromMin min: Double, max: Double) -> Double {
+    let range = max - min
+    if range == 0 {
+      return 0
+    }
+    return (self - min) / range
+  }
+
+}

--- a/Sources/Others/ConicalGradientLayer.swift
+++ b/Sources/Others/ConicalGradientLayer.swift
@@ -67,7 +67,7 @@ final class ConicalGradientLayer: CALayer {
                                   y: centerPoint.y - newValue.y)
       var angle = Double(atan2(centeredPoint.y - self.frame.midY, centeredPoint.x - self.frame.midX))
       if angle < 0 {
-        angle += + 2 * .pi
+        angle += 2 * .pi
       }
       self.endAngle = angle + 2 * .pi
     }

--- a/Sources/Others/RadialGradientLayer.swift
+++ b/Sources/Others/RadialGradientLayer.swift
@@ -25,8 +25,9 @@ final class RadialGradientLayer: CALayer {
   override func draw(in ctx: CGContext) {
     ctx.saveGState()
     let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: [0, 1])!
-
+    guard !colors.isEmpty, let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: [0, 1])  else {
+      return
+    }
     let startCenter = CGPoint(x: bounds.width * startPoint.x,
                               y: bounds.height * startPoint.y)
     let endCenter = CGPoint(x: bounds.width * endPoint.x,

--- a/Sources/Protocols/Designable/GradientDesignable.swift
+++ b/Sources/Protocols/Designable/GradientDesignable.swift
@@ -82,6 +82,8 @@ extension GradientDesignable {
       return makeLinearLayer(colors: colors)
     case .radial:
       return makeRadialLayer(colors: colors)
+    case .conical:
+      return makeConicalLayer(colors: colors)
     }
   }
 
@@ -98,9 +100,8 @@ extension GradientDesignable {
     let layer = CAGradientLayer()
     layer.colors = colors
 
-    let points = gradientPoints()
-    layer.startPoint = points.0
-    layer.endPoint = points.1
+    layer.startPoint = startPoint.startPoint
+    layer.endPoint = startPoint.endPoint
     return layer
   }
 
@@ -108,35 +109,18 @@ extension GradientDesignable {
     let layer = RadialGradientLayer()
     layer.colors = colors
 
-    let points = gradientPoints()
-    layer.startPoint = points.0
-    layer.endPoint = points.1
+    layer.startPoint = startPoint.startPoint
+    layer.endPoint = startPoint.endPoint
     return layer
   }
 
-  private func gradientPoints() -> (CGPoint, CGPoint) {
-    switch startPoint {
-    case .top:
-      return (CGPoint(x: 0.5, y: 0), CGPoint(x: 0.5, y: 1))
-    case .topRight:
-      return (CGPoint(x: 1, y: 0), CGPoint(x: 0, y: 1))
-    case .right:
-      return (CGPoint(x: 1, y: 0.5), CGPoint(x: 0, y: 0.5))
-    case .bottomRight:
-      return (CGPoint(x: 1, y: 1), CGPoint(x: 0, y: 0))
-    case .bottom:
-      return (CGPoint(x: 0.5, y: 1), CGPoint(x: 0.5, y: 0))
-    case .bottomLeft:
-      return (CGPoint(x: 0, y: 1), CGPoint(x: 1, y: 0))
-    case .left:
-      return (CGPoint(x: 0, y: 0.5), CGPoint(x: 1, y: 0.5))
-    case .topLeft:
-      return (CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 1))
-    case let .custom(start, end):
-      return (CGPoint(x: start.x, y: start.y), CGPoint(x: end.x, y: end.y))
-    case .none:
-      return (.zero, .zero)
-    }
+  private func makeConicalLayer(colors: [CGColor]) -> ConicalGradientLayer {
+    let layer = ConicalGradientLayer()
+    layer.colors = colors
+
+    layer.startPoint = startPoint.startPoint
+    layer.endPoint = startPoint.endPoint
+    return layer
   }
 
 }


### PR DESCRIPTION
sometimes called angular, sweep(on android)

![screen shot 2018-05-20 at 17 26 03](https://user-images.githubusercontent.com/8875768/40280408-1630e710-5c53-11e8-997f-b6b398ff1149.png)

The current code draw lines starting at the center point, and change the color for each lines.

An optimisation could be to create an image with that, to not redraw it each time

---

Then I can also make a more smooth conical grandient by repeating the colors
instead of `layer.colors = colors`(with two colors) 
I put that `layer.colors = [colors[0], colors[1], colors[0]]`
to get that
![screen shot 2018-05-20 at 17 25 05](https://user-images.githubusercontent.com/8875768/40280434-7d354c30-5c53-11e8-9cd5-be9ae8c1f888.png)

Do not know how to include that in library. Maybe with the repeating gradient issue, if we could create odd number colors when repeating

if not with only even number of colors :
![screen shot 2018-05-20 at 17 34 43](https://user-images.githubusercontent.com/8875768/40280467-4531513e-5c54-11e8-90ef-760836f3c12f.png)

