### PR TITLE
Fix the build for Xcode 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - IOS_FRAMEWORK_SCHEME="IBAnimatable"
     - IOS_APP_SCHEME="IBAnimatableApp"
   matrix:
-    - DESTINATION="OS=10.3.1,name=iPad Pro (12.9-Inch)" SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
+    - DESTINATION="OS=10.3.1,name=iPad Pro (12.9 Inch)" SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
     - DESTINATION="OS=9.3,name=iPhone 6s Plus"        SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
     - DESTINATION="OS=11.1,name=iPhone 7 Plus"        SCHEME=${IOS_FRAMEWORK_SCHEME}    APP_SCHEME=${IOS_APP_SCHEME}
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode10
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ N/A
 - Add new activity indicators `newtonCradle` and `circlePendulum`. [#573](https://github.com/IBAnimatable/IBAnimatable/pull/573) by [@phimage](https://github.com/phimage)
 - Add new mask `rounded` to  make a rounded rectangle. [#575](https://github.com/IBAnimatable/IBAnimatable/pull/575) by [@phimage](https://github.com/phimage)
 - Support for Swift 4.2. [#576](https://github.com/IBAnimatable/IBAnimatable/pull/576) by [@djbe](https://github.com/djbe)
+- Upgrade for Xcode 10 [#588](https://github.com/IBAnimatable/IBAnimatable/pull/588) by [@JakeLin](https://github.com/JakeLin)
 
 #### Bugfixes
 

--- a/Sources/Enums/CornerSide.swift
+++ b/Sources/Enums/CornerSide.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum CornerSide: String {
+public enum CornerSide: String, CaseIterable {
   case topLeft = "topleft"
   case topRight = "topright"
   case bottomLeft = "bottomleft"

--- a/Sources/Enums/CornerSide.swift
+++ b/Sources/Enums/CornerSide.swift
@@ -8,12 +8,16 @@
 
 import Foundation
 
-public enum CornerSide: String, CaseIterable {
+public enum CornerSide: String {
   case topLeft = "topleft"
   case topRight = "topright"
   case bottomLeft = "bottomleft"
   case bottomRight = "bottomright"
 }
+
+#if swift(>=4.2)
+extension CornerSide: CaseIterable {}
+#endif
 
 public struct CornerSides: OptionSet {
   public let rawValue: Int


### PR DESCRIPTION
Fix #587

We need to make the `enum CornerSide` to be `CaseIterable`. And then we can `iterateEnum`. Compiled in Xcode Version 10.0 (10A254a)