### PR TITLE
[WIP] For iOS13 do not use `automatic` modal presentation style for segue

### DIFF
--- a/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
+++ b/IBAnimatable/IBAnimatable.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		3676E7DF2059457A0003B9DF /* DesignableNavigationBar.swift in Headers */ = {isa = PBXBuildFile; fileRef = E27FD2391ECD7D8A00F74840 /* DesignableNavigationBar.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		48A167122063CD0D00D7BCFB /* ConicalGradientLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A167112063CD0D00D7BCFB /* ConicalGradientLayer.swift */; };
 		48D80DCA20403DAC00D3137B /* AnimatableTabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */; };
+		7E8A8028230FD8F100771F99 /* UIStoryboardSegueExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8A8027230FD8F100771F99 /* UIStoryboardSegueExtension.swift */; };
 		C40AE6A220E6210100B24A44 /* ActivityIndicatorAnimationNewtonCradle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40AE6A120E6210100B24A44 /* ActivityIndicatorAnimationNewtonCradle.swift */; };
 		C414765F209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift in Sources */ = {isa = PBXBuildFile; fileRef = C414765E209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift */; };
 		C41A0E80209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41A0E7F209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift */; };
@@ -231,6 +232,7 @@
 /* Begin PBXFileReference section */
 		48A167112063CD0D00D7BCFB /* ConicalGradientLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConicalGradientLayer.swift; sourceTree = "<group>"; };
 		48D80DC920403DAC00D3137B /* AnimatableTabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableTabBarItem.swift; sourceTree = "<group>"; };
+		7E8A8027230FD8F100771F99 /* UIStoryboardSegueExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStoryboardSegueExtension.swift; sourceTree = "<group>"; };
 		C40AE6A120E6210100B24A44 /* ActivityIndicatorAnimationNewtonCradle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationNewtonCradle.swift; sourceTree = "<group>"; };
 		C414765E209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationTripleGear.swift; sourceTree = "<group>"; };
 		C41A0E7F209A39660069555A /* ActivityIndicatorAnimationHeartBeat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorAnimationHeartBeat.swift; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 				E27FD1F01ECD7D8A00F74840 /* UIColorExtension.swift */,
 				E27FD1F11ECD7D8A00F74840 /* UIViewControllerExtension.swift */,
 				C4511F361F93F1B2002E0FAF /* UIBezierPathExtension.swift */,
+				7E8A8027230FD8F100771F99 /* UIStoryboardSegueExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -993,6 +996,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1173,6 +1177,7 @@
 				E27FD2A51ECD7D8A00F74840 /* RefreshControlerDesignable.swift in Sources */,
 				E27FD2971ECD7D8A00F74840 /* Animatable.swift in Sources */,
 				E27FD29B1ECD7D8A00F74840 /* BorderDesignable.swift in Sources */,
+				7E8A8028230FD8F100771F99 /* UIStoryboardSegueExtension.swift in Sources */,
 				E27FD27F1ECD7D8A00F74840 /* BlurEffectStyle.swift in Sources */,
 				E27FD24E1ECD7D8A00F74840 /* ActivityIndicatorAnimationCubeTransition.swift in Sources */,
 				C414765F209C1BD700945C8B /* ActivityIndicatorAnimationTripleGear.swift in Sources */,

--- a/Sources/Extensions/UIStoryboardSegueExtension.swift
+++ b/Sources/Extensions/UIStoryboardSegueExtension.swift
@@ -1,0 +1,17 @@
+//
+//  Created by phimage on 23/08/2019.
+//  Copyright © 2019 IBAnimatable. All rights reserved.
+//
+
+import UIKit
+
+extension UIStoryboardSegue {
+  func present(animated flag: Bool = true) {
+    if #available(iOS 13.0, *) {
+      if destination.transitioningDelegate != nil {
+        destination.modalPresentationStyle = .fullScreen // .automatic do not work well with our transitioningDelegate
+      }
+    }
+    source.present(destination, animated: flag, completion: nil)
+  }
+}

--- a/Sources/Extensions/UIStoryboardSegueExtension.swift
+++ b/Sources/Extensions/UIStoryboardSegueExtension.swift
@@ -7,11 +7,16 @@ import UIKit
 
 extension UIStoryboardSegue {
   func present(animated flag: Bool = true) {
+    #if swift(>=5.1)
     if #available(iOS 13.0, *) {
       if destination.transitioningDelegate != nil {
-        destination.modalPresentationStyle = .fullScreen // .automatic do not work well with our transitioningDelegate
+        let presentationStyle = destination.modalPresentationStyle
+        if presentationStyle == .automatic || presentationStyle == .pageSheet {
+          destination.modalPresentationStyle = .fullScreen // .automatic & .pageSheet do not work well with our transitioningDelegate
+        }
       }
     }
+    #endif
     source.present(destination, animated: flag, completion: nil)
   }
 }

--- a/Sources/Segues/PresentCardsSegue.swift
+++ b/Sources/Segues/PresentCardsSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentCardsSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .cards(direction: .forward))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentExplodeSegue.swift
+++ b/Sources/Segues/PresentExplodeSegue.swift
@@ -9,6 +9,6 @@ open class PresentExplodeSegue: UIStoryboardSegue {
   open override func perform() {
     let transitionType: TransitionAnimationType = .explode(xFactor: nil, minAngle: nil, maxAngle: nil)
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: transitionType)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFadeSegue.swift
+++ b/Sources/Segues/PresentFadeSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentFadeSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .fade(direction: .cross))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFadeWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentFadeWithDismissInteractionSegue.swift
@@ -10,6 +10,6 @@ open class PresentFadeWithDismissInteractionSegue: UIStoryboardSegue {
     let transitionPresenterManager = TransitionPresenterManager.shared
     destination.transitioningDelegate = transitionPresenterManager.retrievePresenter(transitionAnimationType: .fade(direction: .cross),
                                                                                      interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFlipSegue.swift
+++ b/Sources/Segues/PresentFlipSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentFlipSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .flip(from: .left))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFlipWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentFlipWithDismissInteractionSegue.swift
@@ -9,6 +9,6 @@ open class PresentFlipWithDismissInteractionSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .flip(from: .left),
                                                                                             interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFoldSegue.swift
+++ b/Sources/Segues/PresentFoldSegue.swift
@@ -9,6 +9,6 @@ open class PresentFoldSegue: UIStoryboardSegue {
   open override func perform() {
 
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .fold(from: .left, folds: nil))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentFoldWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentFoldWithDismissInteractionSegue.swift
@@ -9,6 +9,6 @@ open class PresentFoldWithDismissInteractionSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .fold(from: .left, folds: nil),
                                                                                             interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentNatGeoSegue.swift
+++ b/Sources/Segues/PresentNatGeoSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentNatGeoSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .natGeo(to: .left))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentOverCurrentContextSegue.swift
+++ b/Sources/Segues/PresentOverCurrentContextSegue.swift
@@ -17,6 +17,6 @@ open class PresentOverCurrentContextSegue: UIStoryboardSegue {
         return CGRect(origin: correctedOrigin, size: source.view.bounds.size)
       }
     }
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentPortalSegue.swift
+++ b/Sources/Segues/PresentPortalSegue.swift
@@ -9,6 +9,6 @@ open class PresentPortalSegue: UIStoryboardSegue {
   open override func perform() {
     let transitionAnimationType: TransitionAnimationType = .portal(direction: .forward, zoomScale: nil)
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: transitionAnimationType)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentPortalWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentPortalWithDismissInteractionSegue.swift
@@ -10,6 +10,6 @@ open class PresentPortalWithDismissInteractionSegue: UIStoryboardSegue {
     let transitionAnimationType: TransitionAnimationType = .portal(direction: .forward, zoomScale: nil)
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: transitionAnimationType,
                                                                                             interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentSlideSegue.swift
+++ b/Sources/Segues/PresentSlideSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentSlideSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .slide(to: .left, isFade: false))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentSlideWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentSlideWithDismissInteractionSegue.swift
@@ -9,6 +9,6 @@ open class PresentSlideWithDismissInteractionSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .slide(to: .left, isFade: false),
                                                                                             interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentTurnSegue.swift
+++ b/Sources/Segues/PresentTurnSegue.swift
@@ -8,6 +8,6 @@ import UIKit
 open class PresentTurnSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .turn(from: .left))
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }

--- a/Sources/Segues/PresentTurnWithDismissInteractionSegue.swift
+++ b/Sources/Segues/PresentTurnWithDismissInteractionSegue.swift
@@ -9,6 +9,6 @@ open class PresentTurnWithDismissInteractionSegue: UIStoryboardSegue {
   open override func perform() {
     destination.transitioningDelegate = TransitionPresenterManager.shared.retrievePresenter(transitionAnimationType: .turn(from: .left),
                                                                                             interactiveGestureType: .default)
-    source.present(destination, animated: true, completion: nil)
+    present()
   }
 }


### PR DESCRIPTION
Segues set using storyboards, such as `PresentSlideSegue`, seem to failed to present

I see that iOS 13 add new navigation stack and `automatic` modal presentation style
Before `fullscreen`(=0) was the default one (If I debug)

I am wondering If IBAnimatable must force to fullscreen the modal presentation style like I do in my PR when the segue is used (to make it work)

or document and say you must select Presentation: Full Screen  (or current context if previous was also full screen etc...) 
![Screenshot 2019-08-23 at 10 32 14](https://user-images.githubusercontent.com/8875768/63579747-a58f3100-c593-11e9-92dd-ab1525d53975.png)
(xcode 11 screenshot, must not be available in xcode 10)

