### PR TITLE
Fix swift build by adding missing import and updating package.swift #no-public-changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: build
+on: push
+jobs:
+  build:
+    name: build
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Swift build
+        run: |
+          sdk=`xcrun -sdk iphonesimulator -show-sdk-path`
+          sdkVersion=`echo $sdk | sed -E 's/.*iPhoneSimulator(.*)\.sdk/\1/'`
+          swift build  -Xswiftc "-sdk" -Xswiftc "$sdk" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios$sdkVersion-simulator"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ N/A
 
 #### Bugfixes
 
-N/A
+- Fix `swift build` [#623](https://github.com/IBAnimatable/IBAnimatable/pull/623) by [@phimage](https://github.com/phimage)
 
 ### [6.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/6.0.0)
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "IBAnimatable",
-    // platforms: [.iOS("9.0")],
+    platforms: [.iOS(.v9)],
     products: [
         .library(name: "IBAnimatable", targets: ["IBAnimatable"])
     ],

--- a/Sources/Enums/Utils.swift
+++ b/Sources/Enums/Utils.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension Array {
   /// Returns the element at the specified index iff it is within bounds, otherwise nil.
@@ -116,13 +117,6 @@ func iterateEnum<T: Hashable>(from: T.Type) -> AnyIterator<T> {
   }
 }
 #endif
-
-import UIKit
-extension CALayer {
-    var currentMediaTime: CFTimeInterval {
-       return convertTime(CACurrentMediaTime(), from: nil)
-    }
-}
 
 extension String {
 

--- a/Sources/Enums/Utils.swift
+++ b/Sources/Enums/Utils.swift
@@ -117,6 +117,7 @@ func iterateEnum<T: Hashable>(from: T.Type) -> AnyIterator<T> {
 }
 #endif
 
+import UIKit
 extension CALayer {
     var currentMediaTime: CFTimeInterval {
        return convertTime(CACurrentMediaTime(), from: nil)

--- a/Sources/Extensions/CALayerExtension.swift
+++ b/Sources/Extensions/CALayerExtension.swift
@@ -15,3 +15,9 @@ public extension CALayer {
     CATransaction.commit()
   }
 }
+
+extension CALayer {
+    var currentMediaTime: CFTimeInterval {
+       return convertTime(CACurrentMediaTime(), from: nil)
+    }
+}

--- a/Sources/Others/IB.swift
+++ b/Sources/Others/IB.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public final class IB: NSObject, CornerDesignable, FillDesignable, BorderDesignable,
                        RotationDesignable, ShadowDesignable, BlurDesignable,


### PR DESCRIPTION
opening with Xcode the Package.swift file or by using command line
```sh
sdk=`xcrun -sdk iphonesimulator -show-sdk-path`
sdkVersion=`echo $sdk | sed -E 's/.*iPhoneSimulator(.*)\.sdk/\1/'`
swift build  -Xswiftc "-sdk" -Xswiftc "$sdk" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios$sdkVersion-simulator"
```

In fact swift build do not allow missing import

I think new release must be done with that, a 6.0.1 or 6.1.0

--

Also I have added a test with github workflow, but to be activated on IBAnimatable organisation
*  an admin must active it here https://github.com/features/actions