### PR TITLE
Fix warning on `UIColor(hexString:` about scanner #no-public-changes

### DIFF
--- a/IBAnimatable/IBAnimatableTests/InternalTests/ColorTypeTests.swift
+++ b/IBAnimatable/IBAnimatableTests/InternalTests/ColorTypeTests.swift
@@ -34,4 +34,28 @@ final class ColorTypeTests: XCTestCase {
     XCTAssertEqual(#colorLiteral(red: 0.827450980392157, green: 0.329411764705882, blue: 0.0, alpha: 1.0), ColorType.flatPumpkin.color)
   }
 
+  func testHexStringToColor() {
+    // without alpha
+    XCTAssertEqual(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), UIColor(hexString: "FFFFFF"))
+    XCTAssertEqual(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1), UIColor(hexString: "000000"))
+    XCTAssertEqual(#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1), UIColor(hexString: "FF0000"))
+    XCTAssertEqual(#colorLiteral(red: 0, green: 1, blue: 0, alpha: 1), UIColor(hexString: "00FF00"))
+    XCTAssertEqual(#colorLiteral(red: 0, green: 0, blue: 1, alpha: 1), UIColor(hexString: "0000FF"))
+    XCTAssertEqual(#colorLiteral(red: 1, green: 0, blue: 1, alpha: 1), UIColor(hexString: "FF00FF"))
+    XCTAssertEqual(#colorLiteral(red: 0, green: 1, blue: 1, alpha: 1), UIColor(hexString: "00FFFF"))
+    XCTAssertEqual(#colorLiteral(red: 1, green: 1, blue: 0, alpha: 1), UIColor(hexString: "FFFF00"))
+
+    // with alpha
+    XCTAssertEqual(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 0), UIColor(hexString: "00FFFFFF"))
+    XCTAssertEqual(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 0), UIColor(hexString: "00000000"))
+    XCTAssertEqual(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), UIColor(hexString: "FFFFFFFF"))
+
+    // could not test with standards uicolor equals.
+    // XCTAssertEqual(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5), UIColor(hexString: "80FFFFFF"))
+    // XCTAssertEqual(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.8), UIColor(hexString: "CC000000"))
+    // XCTAssertEqual(#colorLiteral(red: 0.9019607843, green: 0.4941176471, blue: 0.1333333333, alpha: 1), UIColor(hexString: "E67E22"))
+    // XCTAssertEqual(#colorLiteral(red: 0.9058823529, green: 0.2980392157, blue: 0.2352941176, alpha: 1), UIColor(hexString: "E74C3C"))
+
+  }
+
 }

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,11 @@ let package = Package(
         .target(
             name: "IBAnimatable",
             path: "Sources"
+        ),
+        .testTarget(
+            name: "IBAnimatableTests",
+            dependencies: ["IBAnimatable"],
+            path: "IBAnimatable/IBAnimatableTests"
         )
     ]
 )

--- a/Scripts/GradientsTypeScript.swift
+++ b/Scripts/GradientsTypeScript.swift
@@ -6,9 +6,9 @@ import UIKit
 
 func colorLiteral(hexString: String) -> String {
   let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-  var int = UInt32()
-  Scanner(string: hex).scanHexInt32(&int)
-  let a, r, g, b: UInt32
+  var int = UInt64()
+  Scanner(string: hex).scanHexInt64(&int)
+  let a, r, g, b: UInt64
   switch hex.characters.count {
   case 3:
     (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)

--- a/Sources/Extensions/UIColorExtension.swift
+++ b/Sources/Extensions/UIColorExtension.swift
@@ -9,9 +9,9 @@ public extension UIColor {
 
   convenience init(hexString: String) {
     let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-    var int = UInt32()
-    Scanner(string: hex).scanHexInt32(&int)
-    let a, r, g, b: UInt32
+    var int = UInt64()
+    Scanner(string: hex).scanHexInt64(&int)
+    let a, r, g, b: UInt64
     switch hex.count {
     case 3:
       (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)


### PR DESCRIPTION
by using not deprecated function `scanHexInt64` instead of `scanHexInt32` 

Also add unit test on `UIColor(hexString:` and target for test in `Package.swift` to check that there is no regression

---

On `Scanner` there is new functions which return the data
like `scanUInt64(representation: .hexadecimal) -> Int64?`

so the code could be 
```swift
    var int: UInt64
    if #available(iOS 13.0, *) {
        int = Scanner(string: hex).scanUInt64(representation: .hexadecimal) ?? 0
    } else {
        int = UInt64()
        Scanner(string: hex).scanHexInt64(&int)
    }
```
but `scanHexInt64` is not yet deprecated so...
