### PR TITLE
Fix navigationBar gradient height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ N/A
 #### Bugfixes
 
 - Fix `swift build` [#623](https://github.com/IBAnimatable/IBAnimatable/pull/623) by [@phimage](https://github.com/phimage)
+- Fix grandient heigth on navigation bar [#625](https://github.com/IBAnimatable/IBAnimatable/pull/625) by [@phimage](https://github.com/phimage)
 
 ### [6.0.0](https://github.com/IBAnimatable/IBAnimatable/releases/tag/6.0.0)
 

--- a/Sources/Protocols/Designable/GradientDesignable.swift
+++ b/Sources/Protocols/Designable/GradientDesignable.swift
@@ -28,12 +28,22 @@ extension GradientDesignable where Self: UIView {
 extension GradientDesignable where Self: UINavigationBar {
 
   public func configureGradient() {
-    let navBarFrame = CGRect(x: 0, y: 0, width: bounds.width, height: UIApplication.shared.statusBarFrame.height)
-    let gradientLayer = makeGradientLayer()
-    gradientLayer?.frame = navBarFrame
-    gradientLayer?.cornerRadius = layer.cornerRadius
+    guard let gradientLayer = makeGradientLayer() else {
+      setBackgroundImage(nil, for: .default)
+      return
+    }
+    let statusBarHeight: CGFloat
+    if #available(iOS 13, *) {
+      statusBarHeight = 0 /*self.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0 */ 
+    } else {
+      statusBarHeight = UIApplication.shared.statusBarFrame.height
+    }
+    let height = bounds.height + statusBarHeight
+    let navBarFrame = CGRect(x: 0, y: 0, width: bounds.width, height: height)
+    gradientLayer.frame = navBarFrame
+    gradientLayer.cornerRadius = layer.cornerRadius
 
-    let image = gradientLayer?.makeImage()
+    let image = gradientLayer.makeImage()
     setBackgroundImage(image, for: .default)
   }
 


### PR DESCRIPTION
When looking at warning on `UIApplication.shared.statusBarFrame.height` call I see that gradient on navigation bar is not correct

Before the height was 64 with a comment about `UIApplication.shared.statusBarFrame.height`
I think 64 was 44 for nav bar and 20 for status bar
That has been replaced by `UIApplication.shared.statusBarFrame.height`, so without original navigation bar height and so the gradient is misplaced and repeated

Now on iOS13 I set the status bar height to 0 because with the default card presentation, it is not recommanded to colorise status bar with navigation bar. We must use the window scene status bar manager. It work pretty well with the demo app with page/card presentation (the default one)

I do an optimisation also, do not execute some code if there is no gradient colors defined