### PR TITLE
🪁 Add `kite` mask type and fix swiftlint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ N/A
 - Allow imbricated `AnimationType` options, `Array` and operator `+` to create `compound` animation by string. [#611](https://github.com/IBAnimatable/IBAnimatable/pull/611) by [@phimage](https://github.com/phimage)
 - Implement `Hashable` with `Hasher`. [#616](https://github.com/IBAnimatable/IBAnimatable/pull/616) by [@phimage](https://github.com/phimage)
 - Add `roundedPolygon`, a polygon `MaskType` with corner radius. [#619](https://github.com/IBAnimatable/IBAnimatable/pull/619) by [@phimage](https://github.com/phimage)
+- Add new mask type `kite`. [#619](https://github.com/IBAnimatable/IBAnimatable/pull/626) by [@phimage](https://github.com/phimage)
 
 #### Bugfixes
 

--- a/Documentation/APIs.md
+++ b/Documentation/APIs.md
@@ -107,6 +107,7 @@ To use `IBAnimatable`, we can drag and drop a UIKit element and connect it with 
 * `insetBy`: Must use the parameters to defined the inset for the inner rectangle e.g. use `insetBy(10, 12)`.
 * `rounded`: Choose the radius to define the corner radius, eg. use `rounded(10)`. Can also specify the `CornerSides` to choose rouned the corner, eg. use `rounded(10, topLeft)`.
 * `roundedPolygon`: Could specify the number of sides of the polygon and the radius to define the corner radius, eg. use `roundedPolygon(6, 10)`. 
+* `kite`: Can use parameters to customize the `kite`. `kite(60)` means the top angle of the kite with its median will have an angle of 60 degrees. The default value is `kite(74)`. if angle == 90 it will be a triangle Mask. if angle > 90 the kite will be a "dart" or "arrowhead".
 * `custom`: Allows you to use your own bezier path as mask. Only usable from code (not from IB). You have to pass in parameter a closure that takes a `CGSize` (the current's view Size) and returns the `UIBezierPath`
 
 

--- a/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Mask/MaskViewController.swift
+++ b/IBAnimatableApp/IBAnimatableApp/Playground/UserInterfaces/Mask/MaskViewController.swift
@@ -15,7 +15,7 @@ final class MaskViewController: UIViewController {
   lazy var entries: [PickerEntry] = {
     let pointsParam = ParamType.number(min: 3, max: 10, interval: 1, ascending: true, unit: "points") // default 5
     let sidesParam = ParamType.number(min: 3, max: 10, interval: 1, ascending: true, unit: "sides") // default 6
-    let angleParam = ParamType.number(min: 60, max: 180, interval: 2, ascending: true, unit: "°") // default 6
+    let angleParam = ParamType.number(min: 20, max: 180, interval: 2, ascending: true, unit: "°") // default 6
     let waveParam = ParamType(fromEnum: MaskType.WaveDirection.self)
     let widthParam = ParamType.number(min: 15, max: 90, interval: 2, ascending: true, unit: "px")
     let radiusParam = ParamType.number(min: 10, max: 40, interval: 10, ascending: true, unit: "px")
@@ -40,6 +40,7 @@ final class MaskViewController: UIViewController {
             PickerEntry(params: [angleParam], name: "moon"),
             PickerEntry(params: [widthParam, widthParam], name: "insetby"),
             PickerEntry(params: [radiusParam, cornerParam], name: "rounded"),
+            PickerEntry(params: [angleParam], name: "kite"),
             PickerEntry(params: [], name: "none"),
             PickerEntry(params: [], name: "CUSTOM Bubble")
     ]

--- a/Scripts/FlatColorsTypeScript.swift
+++ b/Scripts/FlatColorsTypeScript.swift
@@ -24,11 +24,9 @@ func parseJSON(JSONData: Data) -> [String: String]? {
   }
 }
 
-// swiftlint:disable variable_name_min_length
 func colorLiteral(r: Int, g: Int, b: Int, a: Double) -> String {
   return "#colorLiteral(red: \(CGFloat(r) / 255), green: \(CGFloat(g) / 255), blue: \(CGFloat(b) / 255), alpha: \(a))"
 }
-// swiftlint:enable variable_name_min_length
 
 // Generator constants
 let enumCase = "\tcase %@\n"

--- a/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallRotateChase.swift
+++ b/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallRotateChase.swift
@@ -33,7 +33,6 @@ public class ActivityIndicatorAnimationBallRotateChase: ActivityIndicatorAnimati
 }
 
 // MARK: - Setup
-// swiftlint:disable variable_name_min_length
 private extension ActivityIndicatorAnimationBallRotateChase {
   func rotateAnimation(rate: Float, x: CGFloat, y: CGFloat, size: CGSize) -> CAAnimationGroup {
     let fromScale = 1 - rate
@@ -63,4 +62,3 @@ private extension ActivityIndicatorAnimationBallRotateChase {
     return animation
   }
 }
-// swiftlint:enable variable_name_min_length

--- a/Sources/Enums/MaskType.swift
+++ b/Sources/Enums/MaskType.swift
@@ -46,6 +46,8 @@ public enum MaskType: IBEnum {
   case rounded(radii: (Double, Double), cornerSides: CornerSides)
   /// For rounded polygon shape with `n` sides. (min: 3, the default: 6).
   case roundedPolygon(sides: Int, cornerRadius: Double)
+  /// For kite shape.
+  case kite(angle: Double)
 
   /// Custom shape
   case custom(pathProvider: CustomMaskProvider)
@@ -123,6 +125,8 @@ public extension MaskType {
         cornerSides = .allSides
       }
       self = .rounded(radii: (radius, radii[safe: 1] ?? radius), cornerSides: cornerSides)
+    case "kite":
+      self = .kite(angle: params.toDouble(0) ?? 74)
     default:
       self = .none
     }
@@ -169,6 +173,8 @@ extension MaskType {
       return UIBezierPath(roundedRect: rect, byRoundingCorners: cornerSides.rectCorner, cornerRadii: CGSize(width: radii.0, height: radii.1))
     case .roundedPolygon(let sides, let cornerRadius):
       return UIBezierPath(roundedPolygonInRect: rect, with: sides, cornerRadius: CGFloat(cornerRadius))
+    case .kite(let angle):
+      return UIBezierPath(kiteInRect: rect, with: CGFloat(angle))
     case let .custom(pathProvider):
       return pathProvider(rect.size)
     case .none:

--- a/Sources/Enums/PresentationAnimationType.swift
+++ b/Sources/Enums/PresentationAnimationType.swift
@@ -59,7 +59,7 @@ extension PresentationAnimationType: Hashable {
     hasher.combine(stringValue)
   }
   #else
-  public var hashValue: Int {
+  public var hashValue: Int { //swiftlint:disable:this legacy_hashing
     return stringValue.hashValue
   }
   #endif

--- a/Sources/Enums/TimingFunctionType.swift
+++ b/Sources/Enums/TimingFunctionType.swift
@@ -141,7 +141,7 @@ extension TimingFunctionType: Hashable {
     hasher.combine(caType)
   }
   #else
-  public var hashValue: Int {
+  public var hashValue: Int { // swiftlint:disable:this legacy_hashing
     return caType.hashValue
   }
   #endif

--- a/Sources/Enums/TransitionAnimationType.swift
+++ b/Sources/Enums/TransitionAnimationType.swift
@@ -380,7 +380,7 @@ extension TransitionAnimationType: Hashable {
     hasher.combine(stringValue)
   }
   #else
-  public var hashValue: Int {
+  public var hashValue: Int { // swiftlint:disable:this legacy_hashing
     return stringValue.hashValue
   }
   #endif

--- a/Sources/Extensions/UIBezierPathExtension.swift
+++ b/Sources/Extensions/UIBezierPathExtension.swift
@@ -422,6 +422,32 @@ extension UIBezierPath {
     close()
     self.translate(to: bounds.center)
   }
+  
+  /**
+   Create a Bezier path for a kite shape.
+   
+   - Parameter bounds: The bounds of shape.
+   - Parameter angle: The angle.
+   */
+  convenience init(kiteInRect bounds: CGRect, with angle: CGFloat) {
+    self.init()
+    let topAngleRad = angle * .pi / 180
+    
+    let offset = abs(CGFloat(sin(topAngleRad - .pi / 2))) * bounds.height
+
+    if angle <= 90 {
+      move(to: CGPoint(x: bounds.width / 2, y: 0))
+      addLine(to: CGPoint(x: bounds.width, y: offset))
+      addLine(to: CGPoint(x: bounds.width / 2, y: bounds.height))
+      addLine(to: CGPoint(x: 0, y: offset))
+    } else { // dart shape
+      move(to: CGPoint(x: bounds.width / 2, y: offset))
+      addLine(to: CGPoint(x: bounds.width, y: 0))
+      addLine(to: CGPoint(x: bounds.width / 2, y: bounds.height))
+      addLine(to: CGPoint(x: 0, y: 0))
+    }
+    close()
+  }
 }
 
 private extension UIBezierPath {

--- a/Sources/Extensions/UIBezierPathExtension.swift
+++ b/Sources/Extensions/UIBezierPathExtension.swift
@@ -422,7 +422,7 @@ extension UIBezierPath {
     close()
     self.translate(to: bounds.center)
   }
-  
+
   /**
    Create a Bezier path for a kite shape.
    
@@ -432,7 +432,7 @@ extension UIBezierPath {
   convenience init(kiteInRect bounds: CGRect, with angle: CGFloat) {
     self.init()
     let topAngleRad = angle * .pi / 180
-    
+
     let offset = abs(CGFloat(sin(topAngleRad - .pi / 2))) * bounds.height
 
     if angle <= 90 {
@@ -556,3 +556,4 @@ fileprivate extension CGPoint {
   }
 
 }
+// swiftlint:disable:this file_length

--- a/Sources/Protocols/Animatable/Animatable.swift
+++ b/Sources/Protocols/Animatable/Animatable.swift
@@ -504,7 +504,6 @@ fileprivate extension UIView {
     }, completion: completion)
   }
 
-  // swiftlint:disable variable_name_min_length
   func moveBy(x: Double, y: Double, configuration: AnimationConfiguration, completion: AnimatableCompletion? = nil) {
     if x.isNaN && y.isNaN {
       return
@@ -592,7 +591,6 @@ fileprivate extension UIView {
     }, completion: completion)
   }
 
-  // swiftlint:enable variable_name_min_length
   func computeValues(way: AnimationType.Way,
                      direction: AnimationType.Direction,
                      configuration: AnimationConfiguration,
@@ -692,7 +690,6 @@ fileprivate extension UIView {
     )
   }
 
-  // swiftlint:disable:next variable_name_min_length
   func animateBy(x: CGFloat, y: CGFloat, configuration: AnimationConfiguration, completion: AnimatableCompletion? = nil) {
     let translate = CGAffineTransform(translationX: x, y: y)
     UIView.animate(with: configuration, animations: {
@@ -750,7 +747,6 @@ fileprivate extension UIView {
     return window?.screen.bounds.size ?? .zero
   }
 }
-// swiftlint:enable variable_name_min_length
 
 // Animations for `UIBarItem`
 public extension Animatable where Self: UIBarItem {
@@ -791,9 +787,7 @@ public extension AnimationType {
     case .fade(way: .inOut), .fade(way: .outIn):
       return false
     case .compound(let animations, _):
-      return animations.reduce(false) { result, animation in
-        result || animation.isSpring
-      }
+      return animations.contains { $0.isSpring }
     case .none:
       return false
     }
@@ -813,9 +807,7 @@ public extension AnimationType {
     case .fade(way: .in), .fade(way: .out):
       return false
     case .compound(let animations, _):
-      return animations.reduce(false) { result, animation in
-        result || animation.isCubic
-      }
+      return animations.contains { $0.isCubic }
     case .none:
       return false
     }


### PR DESCRIPTION
Definition https://en.wikipedia.org/wiki/Kite_(geometry)

* with an angle between 0 and 89
![Screenshot 2019-11-11 at 05 49 02](https://user-images.githubusercontent.com/8875768/68562248-1df5e780-0449-11ea-873e-fe68f5a09dba.png)
* 90 is a triangle

* with an angle between 91 and 180 we have a `dart`
![Screenshot 2019-11-11 at 05 49 12](https://user-images.githubusercontent.com/8875768/68562251-1fbfab00-0449-11ea-8ea9-701e952e9bfd.png)
